### PR TITLE
Remove extra README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# datachain
-Wrangle unstructured AI data at scale


### PR DESCRIPTION
Unfortunately, I did not realize the default README is [README.md](https://github.com/iterative/datachain/blob/main/README.md) and the transferred README is [README.rst](https://github.com/iterative/datachain/blob/main/README.rst) so the initial, mostly empty README was not overwritten. This removes the default mostly empty [README.md](https://github.com/iterative/datachain/blob/main/README.md), so the main [README.rst](https://github.com/iterative/datachain/blob/main/README.rst) is shown / used instead.