### PR TITLE
Added fixture to clean session before each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,14 @@ def monkeypatch_session() -> Generator[MonkeyPatch, None, None]:
     mpatch.undo()
 
 
+@pytest.fixture(autouse=True)
+def clean_session() -> None:
+    """
+    Make sure we clean leftover session before each test case
+    """
+    Session.cleanup_for_tests()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def clean_environment(
     monkeypatch_session: MonkeyPatch,

--- a/tests/unit/lib/test_datachain_bootstrap.py
+++ b/tests/unit/lib/test_datachain_bootstrap.py
@@ -24,7 +24,7 @@ class MyMapper(Mapper):
         self.value = MyMapper.TEARDOWN_VALUE
 
 
-def test_udf(catalog):
+def test_udf():
     vals = ["a", "b", "c", "d", "e", "f"]
     chain = DataChain.from_features(key=vals)
 
@@ -36,7 +36,7 @@ def test_udf(catalog):
 
 
 @pytest.mark.skip(reason="Skip until tests module will be importer for unit-tests")
-def test_udf_parallel(catalog):
+def test_udf_parallel():
     vals = ["a", "b", "c", "d", "e", "f"]
     chain = DataChain.from_features(key=vals)
 
@@ -45,7 +45,7 @@ def test_udf_parallel(catalog):
     assert res == [MyMapper.BOOTSTRAP_VALUE] * len(vals)
 
 
-def test_no_bootstrap_for_callable(catalog):
+def test_no_bootstrap_for_callable():
     class MyMapper:
         def __init__(self):
             self._had_bootstrap = False


### PR DESCRIPTION
Missing catalog fixture was causing tests to fail on CH because old catalog object would stay in session which wasn't cleaned and we are removing tables from DB after each test case  which left that old catalog in session without metastore tables like `dqlapp_datasets` which was causing errors like `TableMissingError`.

This adds fixture to always clean session which means every test case will start with session without catalog object and will create new catalog with new empty tables etc.
We also remove `catalog` fixture that was added in some tests to avoid the issue and which was not actually needed / used.