### PR TITLE
remove image top level import by default

### DIFF
--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -2,8 +2,6 @@ from datachain.lib.dc import C, DataChain
 from datachain.lib.feature import Feature
 from datachain.lib.feature_utils import pydantic_to_feature
 from datachain.lib.file import File, FileError, FileFeature, IndexedFile, TarVFile
-from datachain.lib.image import ImageFile, convert_images
-from datachain.lib.text import convert_text
 from datachain.lib.udf import Aggregator, Generator, Mapper
 from datachain.lib.utils import AbstractUDF, DataChainError
 from datachain.query.dataset import UDF as BaseUDF  # noqa: N811
@@ -23,12 +21,9 @@ __all__ = [
     "FileError",
     "FileFeature",
     "Generator",
-    "ImageFile",
     "IndexedFile",
     "Mapper",
     "Session",
     "TarVFile",
-    "convert_images",
-    "convert_text",
     "pydantic_to_feature",
 ]

--- a/src/datachain/image/__init__.py
+++ b/src/datachain/image/__init__.py
@@ -1,0 +1,3 @@
+from datachain.lib.image import ImageFile, convert_images
+
+__all__ = ["ImageFile", "convert_images"]

--- a/src/datachain/text/__init__.py
+++ b/src/datachain/text/__init__.py
@@ -1,0 +1,3 @@
+from datachain.lib.text import convert_text
+
+__all__ = ["convert_text"]

--- a/tests/unit/test_module_exports.py
+++ b/tests/unit/test_module_exports.py
@@ -18,14 +18,13 @@ def test_module_exports():
             FileError,
             FileFeature,
             Generator,
-            ImageFile,
             IndexedFile,
             Mapper,
             Session,
             TarVFile,
-            convert_images,
-            convert_text,
             pydantic_to_feature,
         )
+        from datachain.image import ImageFile, convert_images
+        from datachain.text import convert_text
     except Exception as e:  # noqa: BLE001
         pytest.fail(f"Importing raised an exception: {e}")


### PR DESCRIPTION
Followup https://github.com/iterative/datachain/pull/23 . I think it breaks tests in Studio since `import datachain` now raises exception if torch is not installed.

~Need more research if this is a proper fix. This is more for awareness.~