### PR TITLE
run SAAS tests against datachain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Lint code
         run: nox -s lint
 
-  tests:
+  test-open-source:
     timeout-minutes: 25
     runs-on: ${{ matrix.os }}
     strategy:
@@ -125,3 +125,72 @@ jobs:
 
       - name: Build docs
         run: nox -s docs
+
+
+  test-studio:
+    runs-on: ubuntu-latest-16-cores
+    strategy:
+      matrix:
+        pyv: ['3.12']
+        group: [1, 2, 3, 4, 5, 6]
+    services:
+      postgres:
+        image: postgres:16.3
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: test
+          POSTGRES_DB: database
+          POSTGRES_HOST_AUTH_METHOD: trust
+      clickhouse:
+        image: clickhouse/clickhouse-server:24
+        ports:
+          - 8123:8123
+          - 9010:9000
+        env:
+          CLICKHOUSE_DB: studio_local_db
+          CLICKHOUSE_USER: studio_local
+          CLICKHOUSE_PASSWORD: ch123456789!
+          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+      redis:
+        image: redis:7.2.5
+        ports:
+          - 6379:6379
+    steps:
+
+      - name: Check out Studio
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: iterative/studio
+          ref: develop
+          token: ${{ secrets.ITERATIVE_STUDIO_READ_ACCESS_TOKEN }}
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          path: './backend/datachain'
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.pyv }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.pyv }}
+          cache: 'pip'
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade uv
+          uv --version
+
+      - name: Install dependencies
+        run: uv pip install --system ./backend/datachain_server[tests] ./backend/datachain[tests]
+
+      - name: Run tests
+        # Generate `.test_durations` file with `pytest --store-durations --durations-path ../.github/.test_durations ...`
+        run: >
+          pytest
+          --config-file=pyproject.toml -rsx
+          --splits=6 --group=${{ matrix.group }} --durations-path=../../.github/.test_durations
+          tests ../datachain/tests
+        working-directory: backend/datachain_server


### PR DESCRIPTION
This PR introduces the Studio / datachain-server tests into this repo against pull requests and main.

We have wasted a significant amount of time fixing tests to be able to upgrade datachain in Studio and we have been blocked on several occasions. Most recently for ~1 week.

This approach is imperfect, but I cannot think of a better way to stem the flow of broken tests.

Please LMK if you have any better ideas.

Thanks