### PR TITLE
avoid circular imports

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -2,7 +2,7 @@ import json
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
 from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
@@ -236,49 +236,6 @@ class File(FileFeature):
 
     def get_fs(self):
         return self._catalog.get_client(self.source).fs
-
-
-class TextFile(File):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._stream = None
-
-    def _set_stream(self, catalog: "Catalog", caching_enabled: bool = False) -> None:
-        super()._set_stream(catalog, caching_enabled)
-        self._stream.set_mode("r")
-
-
-def get_file(type: Literal["binary", "text", "image"] = "binary"):
-    file = File
-    if type == "text":
-        file = TextFile
-    elif type == "image":
-        from datachain.lib.image import ImageFile
-
-        file = ImageFile  # type: ignore[assignment]
-
-    def get_file_type(
-        source: str,
-        parent: str,
-        name: str,
-        version: str,
-        etag: str,
-        size: int,
-        vtype: str,
-        location: Optional[Union[dict, list[dict]]],
-    ) -> file:  # type: ignore[valid-type]
-        return file(
-            source=source,
-            parent=parent,
-            name=name,
-            version=version,
-            etag=etag,
-            size=size,
-            vtype=vtype,
-            location=location,
-        )
-
-    return get_file_type
 
 
 class IndexedFile(Feature):

--- a/src/datachain/lib/text.py
+++ b/src/datachain/lib/text.py
@@ -1,7 +1,11 @@
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
+from datachain.lib.file import File
+
 if TYPE_CHECKING:
     import torch
+
+    from datachain.catalog import Catalog
 
 
 def convert_text(
@@ -47,3 +51,13 @@ def convert_text(
         "Missing dependency 'torch' needed to encode text."
 
     return encoder(torch.tensor(tokens))
+
+
+class TextFile(File):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._stream = None
+
+    def _set_stream(self, catalog: "Catalog", caching_enabled: bool = False) -> None:
+        super()._set_stream(catalog, caching_enabled)
+        self._stream.set_mode("r")

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -5,7 +5,8 @@ from fsspec.implementations.local import LocalFileSystem
 
 from datachain.cache import UniqueId
 from datachain.catalog import Catalog
-from datachain.lib.file import File, TextFile
+from datachain.lib.file import File
+from datachain.lib.text import TextFile
 
 
 def test_uid_missing_location():

--- a/tests/unit/lib/test_text.py
+++ b/tests/unit/lib/test_text.py
@@ -1,8 +1,7 @@
 import torch
 from transformers import CLIPModel, CLIPProcessor
 
-from datachain.lib.file import TextFile
-from datachain.lib.text import convert_text
+from datachain.lib.text import TextFile, convert_text
 
 
 def test_convert_text(fake_clip_model):


### PR DESCRIPTION
I started looking into #52 and realised there were some circular imports in and around `datachain.lib.file`. I moved things around to avoid them.