### PR TITLE
add missing torch dependencies test

### DIFF
--- a/tests/unit/test_module_exports.py
+++ b/tests/unit/test_module_exports.py
@@ -1,5 +1,8 @@
 # flake8: noqa: F401
 
+import builtins
+import sys
+
 import pytest
 
 
@@ -35,3 +38,56 @@ def test_module_exports():
         )
     except Exception as e:  # noqa: BLE001
         pytest.fail(f"Importing raised an exception: {e}")
+
+
+@pytest.mark.parametrize("dep", ["torch", "torchvision", "transformers"])
+def test_no_torch_deps(monkeypatch, dep):
+    real_import = builtins.__import__
+
+    def monkey_import_importerror(
+        name, globals=None, locals=None, fromlist=(), level=0
+    ):
+        if name.startswith(dep):
+            raise ImportError(f"Mocked import error {name}")
+        return real_import(
+            name, globals=globals, locals=locals, fromlist=fromlist, level=level
+        )
+
+    for module in list(sys.modules):
+        if module.startswith((dep, "datachain")):
+            monkeypatch.delitem(sys.modules, module)
+    monkeypatch.setattr(builtins, "__import__", monkey_import_importerror)
+
+    try:
+        from datachain import (
+            AbstractUDF,
+            Aggregator,
+            BaseUDF,
+            C,
+            Column,
+            DataChain,
+            DataChainError,
+            DataModel,
+            File,
+            FileBasic,
+            FileError,
+            Generator,
+            ImageFile,
+            IndexedFile,
+            Mapper,
+            Session,
+            TarVFile,
+            TextFile,
+        )
+    except Exception as e:  # noqa: BLE001
+        pytest.fail(f"Importing raised an exception: {e}")
+
+    with pytest.raises(ImportError):
+        from datachain.torch import (
+            PytorchDataset,
+            clip_similarity_scores,
+            convert_image,
+            convert_images,
+            convert_text,
+            label_to_int,
+        )


### PR DESCRIPTION
Closes #52. This PR adds a test which confirms that the optional `[torch]` dependencies are not needed to `import datachain` (and that they are required in order to `import datachain.torch`)