### PR TITLE
Fix for `order_by` with sub signals

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1,6 +1,7 @@
 import copy
 import re
 from collections.abc import Iterable, Iterator, Sequence
+from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -16,6 +17,7 @@ from typing import (
 import pandas as pd
 import sqlalchemy
 from pydantic import BaseModel, create_model
+from sqlalchemy.sql.functions import GenericFunction
 
 from datachain import DataModel
 from datachain.lib.convert.values_to_tuples import values_to_tuples
@@ -46,11 +48,40 @@ from datachain.query.schema import Column, DatasetRow
 from datachain.utils import inside_notebook
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing_extensions import Concatenate, ParamSpec, Self
+
+    P = ParamSpec("P")
 
 C = Column
 
 _T = TypeVar("_T")
+D = TypeVar("D", bound="DataChain")
+
+
+def resolve_columns(
+    method: "Callable[Concatenate[D, P], D]",
+) -> "Callable[Concatenate[D, P], D]":
+    """Decorator that resolvs input column names to their actual DB names. This is
+    specially important for nested columns as user works with them by using dot
+    notation e.g (file.name) but are actually defined with default delimiter
+    in DB, e.g file__name.
+    If there are any sql functions in arguments, they will just be transferred as is
+    to a method.
+    """
+
+    @wraps(method)
+    def _inner(self: D, *args: "P.args", **kwargs: "P.kwargs") -> D:
+        resolved_args = self.signals_schema.resolve(
+            *[arg for arg in args if not isinstance(arg, GenericFunction)]
+        ).db_signals()
+
+        for idx, arg in enumerate(args):
+            if isinstance(arg, GenericFunction):
+                resolved_args.insert(idx, arg)
+
+        return method(self, *resolved_args, **kwargs)
+
+    return _inner
 
 
 class DatasetPrepareError(DataChainParamsError):  # noqa: D101
@@ -603,9 +634,10 @@ class DataChain(DatasetQuery):
         return res
 
     @detach
-    def order_by(self, *args: str) -> "Self":
+    @resolve_columns
+    def order_by(self, *args: Union[str, GenericFunction]) -> "Self":
         """Orders by specified set of signals."""
-        return super().order_by(*self.signals_schema.resolve(*args).db_signals())
+        return super().order_by(*args)
 
     @detach
     def distinct(self, arg: str, *args: str) -> "Self":  # type: ignore[override]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -939,3 +939,15 @@ def test_order_by_with_nested_columns():
         .order_by("file.name")
         .collect_one("file.name")
     ) == ["a.txt", "a.txt", "b.txt", "c.txt", "d.txt"]
+
+
+def test_order_by_with_func():
+    names = ["a.txt", "c.txt", "d.txt", "a.txt", "b.txt"]
+
+    from datachain.sql.functions import rand
+
+    assert (
+        DataChain.from_values(file=[File(name=name) for name in names])
+        .order_by("file.name", rand())
+        .collect_one("file.name")
+    ) == ["a.txt", "a.txt", "b.txt", "c.txt", "d.txt"]


### PR DESCRIPTION
This adds `order_by` method to `DataChain` to make it work with sub signals, e.g `order_by("file.name")`.

Fixes: https://github.com/iterative/dvcx/issues/1724