### PR TITLE
update pytest-servers to 0.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ tests = [
   "pytest-sugar>=0.9.6",
   "pytest-cov>=4.1.0",
   "pytest-mock>=3.12.0",
-  "pytest-servers[all]>=0.5.4",
+  "pytest-servers[all]>=0.5.5",
   "pytest-benchmark[histogram]",
   "pytest-asyncio>=0.23.2",
   "pytest-xdist>=3.3.1",


### PR DESCRIPTION
Should fix the errors shown in the CI for these runs:

- https://github.com/iterative/datachain/actions/runs/10000951516
- https://github.com/iterative/datachain/actions/runs/10000871298