### PR TITLE
Fix repository reference in Notebook

### DIFF
--- a/examples/computer_vision/fashion_product_images/4-inference.ipynb
+++ b/examples/computer_vision/fashion_product_images/4-inference.ipynb
@@ -3021,7 +3021,7 @@
     "## Get Involved\n",
     "\n",
     "We'd love to have you join our growing community of DataChain users and contributors! Here's how you can get involved:\n",
-    "- ⭐ Give us a star on [GitHub](https://github.com/iterative/dvcx) to show your support\n",
+    "- ⭐ Give us a star on [GitHub](https://github.com/iterative/datachain) to show your support\n",
     "- 🌐 Visit the [datachain.ai website](https://datachain.ai/) to learn more about our products and services\n",
     "- 📞 Contact us to discuss how DataChain can help streamline your company's ML workflows\n",
     "- 🙌 Follow us on social media for the latest updates and insights\n",


### PR DESCRIPTION
Just a quick fix to rename the repository reference from `dvcx` to `datachain` in this notebook. 