### PR TITLE
storage: index as a dir if no glob

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1,4 +1,5 @@
 import ast
+import glob
 import io
 import json
 import logging
@@ -709,7 +710,12 @@ class Catalog:
 
         client_config = client_config or self.client_config
         client, path = self.parse_url(source, **client_config)
-        prefix = posixpath.dirname(path)
+        stem = os.path.basename(os.path.normpath(path))
+        prefix = (
+            posixpath.dirname(path)
+            if glob.has_magic(stem) or client.fs.isfile(source)
+            else path
+        )
         storage_dataset_name = Storage.dataset_name(
             client.uri, posixpath.join(prefix, "")
         )

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -1068,6 +1068,45 @@ def test_storage_stats(cloud_test_catalog):
     assert stats.size == 15
 
 
+@pytest.mark.parametrize("cloud_type", ["s3", "azure", "gs"], indirect=True)
+def test_enlist_source_handles_slash(cloud_test_catalog):
+    catalog = cloud_test_catalog.catalog
+    src_uri = cloud_test_catalog.src_uri
+
+    catalog.enlist_source(f"{src_uri}/dogs", ttl=1234)
+    stats = catalog.storage_stats(src_uri)
+    assert stats.num_objects == len(DEFAULT_TREE["dogs"])
+    assert stats.size == 15
+
+    catalog.enlist_source(f"{src_uri}/dogs/", ttl=1234, force_update=True)
+    stats = catalog.storage_stats(src_uri)
+    assert stats.num_objects == len(DEFAULT_TREE["dogs"])
+    assert stats.size == 15
+
+
+@pytest.mark.parametrize("cloud_type", ["s3", "azure", "gs"], indirect=True)
+def test_enlist_source_handles_glob(cloud_test_catalog):
+    catalog = cloud_test_catalog.catalog
+    src_uri = cloud_test_catalog.src_uri
+
+    catalog.enlist_source(f"{src_uri}/dogs/*.jpg", ttl=1234)
+    stats = catalog.storage_stats(src_uri)
+
+    assert stats.num_objects == len(DEFAULT_TREE["dogs"])
+    assert stats.size == 15
+
+
+@pytest.mark.parametrize("cloud_type", ["s3", "azure", "gs"], indirect=True)
+def test_enlist_source_handles_file(cloud_test_catalog):
+    catalog = cloud_test_catalog.catalog
+    src_uri = cloud_test_catalog.src_uri
+
+    catalog.enlist_source(f"{src_uri}/dogs/dog1", ttl=1234)
+    stats = catalog.storage_stats(src_uri)
+    assert stats.num_objects == len(DEFAULT_TREE["dogs"])
+    assert stats.size == 15
+
+
 @pytest.mark.parametrize("from_cli", [False, True])
 def test_garbage_collect(cloud_test_catalog, from_cli, capsys):
     catalog = cloud_test_catalog.catalog

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -660,7 +660,7 @@ def test_parse_tabular_partitions(tmp_dir, catalog):
 
 def test_parse_tabular_empty(tmp_dir, catalog):
     path = tmp_dir / "test.parquet"
-    with pytest.raises(DataChainParamsError):
+    with pytest.raises(FileNotFoundError):
         DataChain.from_storage(path.as_uri()).parse_tabular()
 
 


### PR DESCRIPTION
Related to:

https://github.com/iterative/dvcx/issues/1488#issuecomment-2139318338
https://github.com/iterative/dvcx/pull/1485#issuecomment-2133400527

(see links and discussion in those threads as well).

Trying to make things like:

```
datachain ls neurips
```

and 

```
datachain ls neurips/
```

behave the same way and avoid indexing the parent directory. I think is the most expected thing from the user perspective. Otherwise a query like `datachain ls neurips` now can index an unpredictable amount of all sorts of files in the parent directory, while still producing the exact same result at the end as `datachain ls neurips/`.

Same goes for `DataChain.from_storage("gs://datachain-demo/50k-laion-files/")` should be the same as `gs://datachain-demo/50k-laion-files` (no slash at the end).

## TODO:

- [x] Check tests
- [x] Add more tests
- [ ] Even with this fix a query like `from_storage("path-to-a-file")` leads to indexing the parent dir. It affects `from_parquet`, etc. Not optimal. Can be fixed in a followup.
- [ ] Review `cp` command semantics, `no_glob` etc
- [ ] Create followup to remove glob support from from_storage. Keep it in `cp`, etc