### PR TITLE
merge/join: exclude sys signals

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -958,12 +958,15 @@ class SQLJoin(Step):
 
         q1_columns = list(q1.c)
         q1_column_names = {c.name for c in q1_columns}
-        q2_columns = [
-            c
-            if c.name not in q1_column_names and c.name != "sys__id"
-            else c.label(self.rname.format(name=c.name))
-            for c in q2.c
-        ]
+
+        q2_columns = []
+        for c in q2.c:
+            if c.name.startswith("sys__"):
+                continue
+
+            if c.name in q1_column_names:
+                c = c.label(self.rname.format(name=c.name))
+            q2_columns.append(c)
 
         res_columns = q1_columns + q2_columns
         predicates = (

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -1486,7 +1486,9 @@ def test_join_left_one_column_predicate(
     # check core duplicated columns
     for r in joined_records:
         dog_r = next(dr for dr in dogs_cats_records if dr["name"] == r["name"])
-        assert all([r[f"{k}_right"] == dog_r[k]] for k in dog_r)
+        assert all(
+            [r[f"{k}_right"] == dog_r[k]] for k in dog_r if not k.startswith("sys__")
+        )
 
 
 @pytest.mark.parametrize(
@@ -1545,7 +1547,9 @@ def test_join_left_multiple_column_pedicates(
     # check core duplicated columns
     for r in joined_records:
         dog_r = next(dr for dr in dogs_cats_records if dr["name"] == r["name"])
-        assert all([r[f"{k}_right"] == dog_r[k]] for k in dog_r)
+        assert all(
+            [r[f"{k}_right"] == dog_r[k]] for k in dog_r if not k.startswith("sys__")
+        )
 
 
 @pytest.mark.parametrize(
@@ -1790,7 +1794,9 @@ def test_join_inner(
     assert all(r["sig1"] == 1 and r["sig2"] == 2 for r in joined_records)
     for r in joined_records:
         dog_r = next(dr for dr in dogs_records if dr["name"] == r["name"])
-        assert all([r[f"{k}_right"] == dog_r[k]] for k in dog_r)
+        assert all(
+            [r[f"{k}_right"] == dog_r[k]] for k in dog_r if not k.startswith("sys__")
+        )
 
     # joining on multiple fields
     joined_records = dogs_cats.join(
@@ -1803,7 +1809,9 @@ def test_join_inner(
     # check core duplicated columns
     for r in joined_records:
         dog_r = next(dr for dr in dogs_records if dr["name"] == r["name"])
-        assert all([r[f"{k}_right"] == dog_r[k]] for k in dog_r)
+        assert all(
+            [r[f"{k}_right"] == dog_r[k]] for k in dog_r if not k.startswith("sys__")
+        )
 
 
 @pytest.mark.parametrize(
@@ -1834,7 +1842,9 @@ def test_join_with_self(cloud_test_catalog, dogs_dataset):
     # check core duplicated columns
     for r in joined_records:
         dog_r = next(dr for dr in dogs_records if dr["name"] == r["name"])
-        assert all([r[f"{k}_right"] == dog_r[k]] for k in dog_r)
+        assert all(
+            [r[f"{k}_right"] == dog_r[k]] for k in dog_r if not k.startswith("sys__")
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -92,7 +92,7 @@ def test_merge_similar_objects(catalog):
     rname = "qq"
     ch = ch1.merge(ch2, "emp.person.name", rname=rname)
 
-    assert list(ch.signals_schema.values.keys()) == ["emp", rname + "emp"]
+    assert list(ch.signals_schema.values.keys()) == ["sys", "emp", rname + "emp"]
 
     empl = list(ch.iterate())
     assert len(empl) == 4
@@ -116,7 +116,13 @@ def test_merge_values(catalog):
 
     ch = ch1.merge(ch2, "id")
 
-    assert list(ch.signals_schema.values.keys()) == ["id", "descr", "right_id", "time"]
+    assert list(ch.signals_schema.values.keys()) == [
+        "sys",
+        "id",
+        "descr",
+        "right_id",
+        "time",
+    ]
 
     i = 0
     j = 0


### PR DESCRIPTION
Fixes #114.

For now, I am going to ignore `sys` signals even if `settings(sys=True)` is passed.