### PR TITLE
remove docstring from DataModel.__pydantic__init_subclass__

### DIFF
--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -27,7 +27,7 @@ class DataModel(BaseModel):
 
     @classmethod
     def __pydantic_init_subclass__(cls):
-        """It automatically registers every declared DataModel child class."""
+        # automatically registers every declared DataModel child class.
         ModelStore.add(cls)
 
     @staticmethod


### PR DESCRIPTION
Otherwise, this shows up on [docs](https://datachain.dvc.ai/references/datatype/#datachain.lib.data_model.DataModel.__pydantic_init_subclass__).