### PR TITLE
Adding tests for exporting image files and `File.write()`

### DIFF
--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -7,6 +7,7 @@ from PIL import Image
 
 from datachain.lib.dc import DataChain
 from datachain.lib.file import File, ImageFile
+from tests.utils import images_equal
 
 
 @pytest.mark.parametrize("anon", [True, False])
@@ -115,9 +116,6 @@ def test_export_files(
 
 @pytest.mark.parametrize("use_cache", [True, False])
 def test_export_images_files(tmp_dir, tmp_path, use_cache):
-    def are_equal(img1: Image, img2: Image) -> bool:
-        return list(img1.getdata()) == list(img2.getdata())
-
     images = [
         {"name": "img1.jpg", "data": Image.new(mode="RGB", size=(64, 64))},
         {"name": "img2.jpg", "data": Image.new(mode="RGB", size=(128, 128))},
@@ -134,7 +132,7 @@ def test_export_images_files(tmp_dir, tmp_path, use_cache):
 
     for img in images:
         exported_img = Image.open(tmp_dir / "output" / img["name"])
-        assert are_equal(img["data"], exported_img) is True
+        assert images_equal(img["data"], exported_img)
 
 
 def test_export_files_filename_placement_not_unique_files(tmp_dir, catalog):

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -3,9 +3,10 @@ import re
 
 import pandas as pd
 import pytest
+from PIL import Image
 
 from datachain.lib.dc import DataChain
-from datachain.lib.file import File
+from datachain.lib.file import File, ImageFile
 
 
 @pytest.mark.parametrize("anon", [True, False])
@@ -110,6 +111,30 @@ def test_export_files(
             file_path = file.get_full_name()
         with open(tmp_dir / "output" / file_path) as f:
             assert f.read() == expected[file.name]
+
+
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_export_images_files(tmp_dir, tmp_path, use_cache):
+    def are_equal(img1: Image, img2: Image) -> bool:
+        return list(img1.getdata()) == list(img2.getdata())
+
+    images = [
+        {"name": "img1.jpg", "data": Image.new(mode="RGB", size=(64, 64))},
+        {"name": "img2.jpg", "data": Image.new(mode="RGB", size=(128, 128))},
+    ]
+
+    for img in images:
+        img["data"].save(tmp_path / img["name"])
+
+    DataChain.from_values(
+        file=[
+            ImageFile(name=img["name"], source=f"file://{tmp_path}") for img in images
+        ],
+    ).export_files(tmp_dir / "output", placement="filename", use_cache=use_cache)
+
+    for img in images:
+        exported_img = Image.open(tmp_dir / "output" / img["name"])
+        assert are_equal(img["data"], exported_img) is True
 
 
 def test_export_files_filename_placement_not_unique_files(tmp_dir, catalog):

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -2,10 +2,11 @@ import json
 
 import pytest
 from fsspec.implementations.local import LocalFileSystem
+from PIL import Image
 
 from datachain.cache import UniqueId
 from datachain.catalog import Catalog
-from datachain.lib.file import File, TextFile
+from datachain.lib.file import File, ImageFile, TextFile
 
 
 def create_file(source: str):
@@ -167,6 +168,61 @@ def test_read_text_data(tmp_path, catalog: Catalog):
     file = TextFile(name=file_name, source=f"file://{tmp_path}")
     file._set_stream(catalog, True)
     assert file.read() == data
+
+
+def test_write_binary_data(tmp_path, catalog: Catalog):
+    file1_name = "myfile1"
+    file2_name = "myfile2"
+    data = b"some\x00data\x00is\x48\x65\x6c\x57\x6f\x72\x6c\x64\xff\xffheRe"
+
+    with open(tmp_path / file1_name, "wb") as fd:
+        fd.write(data)
+
+    file1 = File(name=file1_name, source=f"file://{tmp_path}")
+    file1._set_stream(catalog, False)
+
+    file1.write(tmp_path / file2_name)
+
+    file2 = File(name=file2_name, source=f"file://{tmp_path}")
+    file2._set_stream(catalog, False)
+    assert file2.read() == data
+
+
+def test_write_text_data(tmp_path, catalog: Catalog):
+    file1_name = "myfile1.txt"
+    file2_name = "myfile2.txt"
+    data = "some text"
+
+    with open(tmp_path / file1_name, "w") as fd:
+        fd.write(data)
+
+    file1 = TextFile(name=file1_name, source=f"file://{tmp_path}")
+    file1._set_stream(catalog, False)
+
+    file1.write(tmp_path / file2_name)
+
+    file2 = TextFile(name=file2_name, source=f"file://{tmp_path}")
+    file2._set_stream(catalog, False)
+    assert file2.read() == data
+
+
+def test_write_image_data(tmp_path, catalog: Catalog):
+    from tests.utils import images_equal
+
+    file1_name = "myfile1.jpg"
+    file2_name = "myfile2.jpg"
+
+    image = Image.new(mode="RGB", size=(64, 64))
+    image.save(tmp_path / file1_name)
+
+    file1 = ImageFile(name=file1_name, source=f"file://{tmp_path}")
+    file1._set_stream(catalog, False)
+
+    file1.write(tmp_path / file2_name)
+
+    file2 = ImageFile(name=file2_name, source=f"file://{tmp_path}")
+    file2._set_stream(catalog, False)
+    assert images_equal(image, file2.read())
 
 
 def test_cache_get_path_without_cache():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -272,4 +272,5 @@ def assert_row_names(
 
 
 def images_equal(img1: Image, img2: Image):
+    """Checks if two image objects have exactly the same data"""
     return list(img1.getdata()) == list(img2.getdata())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -271,6 +271,6 @@ def assert_row_names(
     )
 
 
-def images_equal(img1: Image, img2: Image):
+def images_equal(img1: Image.Image, img2: Image.Image):
     """Checks if two image objects have exactly the same data"""
     return list(img1.getdata()) == list(img2.getdata())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ from time import sleep, time
 from typing import Any, Callable, Optional
 
 import pytest
+from PIL import Image
 
 from datachain.catalog.catalog import Catalog
 from datachain.dataset import DatasetDependency, DatasetRecord
@@ -268,3 +269,7 @@ def assert_row_names(
         == {r.get("name") for r in preview}
         == expected_names
     )
+
+
+def images_equal(img1: Image, img2: Image):
+    return list(img1.getdata()) == list(img2.getdata())


### PR DESCRIPTION
Adding missing tests from https://github.com/iterative/datachain/pull/135 :

- Exporting images
- `File.write()` 
- `TextFile.write()`
- `ImageFile.write()`