### PR TITLE
Error handling for type errors in `.mutate()` and tests

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 C = Column
+cast = sqlalchemy.cast
 
 _T = TypeVar("_T")
 D = TypeVar("D", bound="DataChain")

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -33,6 +33,7 @@ from sqlalchemy.sql.elements import ColumnClause, ColumnElement
 from sqlalchemy.sql.expression import label
 from sqlalchemy.sql.schema import TableClause
 from sqlalchemy.sql.selectable import Select
+from sqlalchemy.sql.sqltypes import NullType
 
 from datachain.asyn import ASYNC_WORKERS, AsyncMapper, OrderedMapper
 from datachain.catalog import (
@@ -1390,6 +1391,13 @@ class DatasetQuery:
             >>> ds.mutate(size10x=C.size * 10).order_by(C.size10x).results()
         """
         query_args = [v.label(k) for k, v in dict(args, **kwargs).items()]
+        for arg in query_args:
+            if isinstance(arg.type, NullType):
+                raise TypeError(
+                    f"Cannot infere type for {arg.name}, use cast(..) function"
+                    " to explicitly set correct type"
+                )
+
         query = self.clone()
         query.steps.append(SQLMutate((*query_args,)))
         return query

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -544,12 +544,11 @@ def test_mutate_with_type_cast(cloud_test_catalog):
         DatasetQuery(path=path, catalog=catalog)
         .mutate(size_subtract=cast(C.size - 10, Int))
         .save(ds_name)
-        .save(ds_name)
     )
 
     assert (
         DatasetQuery(name=ds_name, catalog=catalog)
-        .order_by(C.size_subtract.desc(), C.name)
+        .order_by(C.size_subtract.desc())
         .select(C.size, C.size_subtract)
         .db_results(row_factory=lambda c, v: dict(zip(c, v)))
     ) == [


### PR DESCRIPTION
When we create new column using `.mutate()` that column type is inferred from the expression itself. The problem is that with some expression, like subtraction or division, this cannot be inferred automatically so `NullType` is set for that column which causes errors along the way (when saving dataset etc.).  

Example:
```python
from sqlalchemy import column
print((column("x") + 5).type)   # Integer()
print((column("x") * 5).type)   # Integer()
print((column("x") - 5).type)   # NullType()
print((column("x") / 5).type)   # NullType()
```

To overcome this, user must cast the type explicitly with `cast(...)` function. 
Example:
```python
from datachain.lib.dc import C, DataChain, cast                                 
from datachain.sql.types import Int

(
    DataChain.from_storage("s3://ldb-public/remote/data-lakes/dogs-and-cats/", anon=True)
    .mutate(size_diff = cast(C("file__size") - 2, Int))
    .save("example")
)
```

This PR added:

- `cast` function to `DataChain` which is just `sqlalchemy.cast`
- better error handling when type failed to infer im `.mutate()`
- test cases with mutate and types