### PR TITLE
Update DataChain.subtract() to work without legacy file signals

### DIFF
--- a/examples/computer_vision/fashion_product_images/4-inference.ipynb
+++ b/examples/computer_vision/fashion_product_images/4-inference.ipynb
@@ -258,7 +258,7 @@
     ")\n",
     "print(new.to_pandas().shape)\n",
     "\n",
-    "update = new.subtract(old, on=\"file.name\")\n",
+    "update = new.subtract(old)\n",
     "print(update.to_pandas().shape)\n"
    ]
   },
@@ -746,7 +746,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/examples/computer_vision/fashion_product_images/4-inference.ipynb
+++ b/examples/computer_vision/fashion_product_images/4-inference.ipynb
@@ -258,7 +258,7 @@
     ")\n",
     "print(new.to_pandas().shape)\n",
     "\n",
-    "update = new.subtract(old)\n",
+    "update = new.subtract(old, on=\"file.name\")\n",
     "print(update.to_pandas().shape)\n"
    ]
   },
@@ -746,7 +746,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -912,29 +912,6 @@ class AbstractWarehouse(ABC, Serializable):
         for name in names:
             self.db.drop_table(Table(name, self.db.metadata), if_exists=True)
 
-    def subtract_query(
-        self,
-        source_query: sa.sql.selectable.Select,
-        target_query: sa.sql.selectable.Select,
-    ) -> sa.sql.selectable.Select:
-        sq = source_query.alias("source_query")
-        tq = target_query.alias("target_query")
-
-        source_target_join = sa.join(
-            sq,
-            tq,
-            (sq.c.source == tq.c.source)
-            & (sq.c.parent == tq.c.parent)
-            & (sq.c.name == tq.c.name),
-            isouter=True,
-        )
-
-        return (
-            select(*sq.c)
-            .select_from(source_target_join)
-            .where((tq.c.name == None) | (tq.c.name == ""))  # noqa: E711
-        )
-
     def changed_query(
         self,
         source_query: sa.sql.selectable.Select,

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -951,6 +951,41 @@ class DataChain(DatasetQuery):
 
         return ds
 
+    def subtract(  # type: ignore[override]
+        self,
+        other: "DataChain",
+        on: Optional[Union[str, Sequence[str]]] = None,
+    ) -> "Self":
+        """Remove rows that appear in another chain.
+
+        Parameters:
+            other: chain whose rows will be removed from `self`
+            on: columns to consider for determining row equality. If unspecified,
+                defaults to all common columns between `self` and `other`.
+        """
+        if isinstance(on, str):
+            on = [on]
+        if on is None:
+            other_columns = set(other._effective_signals_schema.db_signals())
+            signals = [
+                c
+                for c in self._effective_signals_schema.db_signals()
+                if c in other_columns
+            ]
+            if not signals:
+                raise DataChainParamsError("subtract(): no common columns")
+        elif not isinstance(on, Sequence):
+            raise TypeError(
+                f"'on' must be 'str' or 'Sequence' object but got type '{type(on)}'",
+            )
+        elif not on:
+            raise DataChainParamsError(
+                "'on' cannot be empty",
+            )
+        else:
+            signals = self.signals_schema.resolve(*on).db_signals()
+        return super()._subtract(other, signals)
+
     @classmethod
     def from_values(
         cls,

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -292,23 +292,21 @@ class DatasetDiffOperation(Step):
 
 @frozen
 class Subtract(DatasetDiffOperation):
-    """
-    Calculates rows that are in a source query but are not in target query (diff)
-    This can be used to do delta updates (calculate UDF only on newly added rows)
-    Example:
-        >>> ds = DatasetQuery(name="dogs_cats") # some older dataset with embeddings
-        >>> ds_updated = (
-                DatasetQuery("gs://dvcx-datalakes/dogs-and-cats")
-                .filter(C.size > 1000) # we can also filter out source query
-                .subtract(ds)
-                .add_signals(calc_embeddings) # calculae embeddings only on new rows
-                .union(ds) # union with old dataset that's missing new rows
-                .save("dogs_cats_updated")
-            )
-    """
+    on: Sequence[str]
 
     def query(self, source_query: Select, target_query: Select) -> Select:
-        return self.catalog.warehouse.subtract_query(source_query, target_query)
+        sq = source_query.alias("source_query")
+        tq = target_query.alias("target_query")
+        on_clause = sqlalchemy.and_(
+            getattr(sq.c, col_name) == getattr(tq.c, col_name) for col_name in self.on
+        )  # type: ignore[arg-type]
+        outer_join = sqlalchemy.join(sq, tq, on_clause, isouter=True)
+
+        where_clause = sqlalchemy.and_(
+            getattr(tq.c, col_name) == None  # noqa: E711
+            for col_name in self.on
+        )  # type: ignore[arg-type]
+        return sqlalchemy.select(*sq.c).select_from(outer_join).where(where_clause)
 
 
 @frozen
@@ -1556,8 +1554,12 @@ class DatasetQuery:
 
     @detach
     def subtract(self, dq: "DatasetQuery") -> "Self":
+        return self._subtract(dq, on=["source", "parent", "name"])
+
+    @detach
+    def _subtract(self, dq: "DatasetQuery", on: Sequence[str]) -> "Self":
         query = self.clone()
-        query.steps.append(Subtract(dq, self.catalog))
+        query.steps.append(Subtract(dq, self.catalog, on=on))
         return query
 
     @detach

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -999,3 +999,38 @@ def test_order_by_descending(with_function):
         "a.txt",
         "a.txt",
     ]
+
+
+def test_union(catalog):
+    chain1 = DataChain.from_values(value=[1, 2])
+    chain2 = DataChain.from_values(value=[3, 4])
+    chain3 = chain1 | chain2
+    assert chain3.count() == 4
+    assert sorted(chain3.collect("value")) == [1, 2, 3, 4]
+
+
+def test_subtract(catalog):
+    chain1 = DataChain.from_values(a=[1, 1, 2], b=["x", "y", "z"])
+    chain2 = DataChain.from_values(a=[1, 2], b=["x", "y"])
+    assert set(chain1.subtract(chain2, on=["a", "b"]).collect()) == {(1, "y"), (2, "z")}
+    assert set(chain1.subtract(chain2, on=["b"]).collect()) == {(2, "z")}
+    assert set(chain1.subtract(chain2, on=["a"]).collect()) == set()
+    assert set(chain1.subtract(chain2).collect()) == {(1, "y"), (2, "z")}
+    assert chain1.subtract(chain1).count() == 0
+
+    chain3 = DataChain.from_values(a=[1, 3], c=["foo", "bar"])
+    assert set(chain1.subtract(chain3, on="a").collect()) == {(2, "z")}
+    assert set(chain1.subtract(chain3).collect()) == {(2, "z")}
+
+
+def test_subtract_error(catalog):
+    chain1 = DataChain.from_values(a=[1, 1, 2], b=["x", "y", "z"])
+    chain2 = DataChain.from_values(a=[1, 2], b=["x", "y"])
+    with pytest.raises(DataChainParamsError):
+        chain1.subtract(chain2, on=[])
+    with pytest.raises(TypeError):
+        chain1.subtract(chain2, on=42)
+
+    chain3 = DataChain.from_values(c=["foo", "bar"])
+    with pytest.raises(DataChainParamsError):
+        chain1.subtract(chain3)


### PR DESCRIPTION
Partial fix for #103. Also includes a unit test for `DataChain.union()` which was mentioned there but appears to work.

Note that `chain1.subtract(chain2)` doesn't actually work for real datasets, even though the unit tests pass. The workaround in to use `on` as in `new.subtract(old, on=["file.name"])`.