### PR TITLE
Fixing test warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,11 @@ markers = [
 ]
 asyncio_mode = "auto"
 filterwarnings = [
+  "error::pandas.errors.PerformanceWarning",
+  "error::pydantic.warnings.PydanticDeprecatedSince20",
+  "error::pytest_mock.PytestMockWarning",
+  "error::pytest.PytestCollectionWarning",
+  "error::sqlalchemy.exc.SADeprecationWarning",
   "ignore:Field name .* shadows an attribute in parent:UserWarning"  # datachain.lib.feature
 ]
 

--- a/src/datachain/data_storage/schema.py
+++ b/src/datachain/data_storage/schema.py
@@ -19,8 +19,12 @@ from datachain.sql.types import Int, SQLType, UInt64
 if TYPE_CHECKING:
     from sqlalchemy import Engine
     from sqlalchemy.engine.interfaces import Dialect
-    from sqlalchemy.sql.base import Executable, ReadOnlyColumnCollection
-    from sqlalchemy.sql.elements import KeyedColumnElement
+    from sqlalchemy.sql.base import (
+        ColumnCollection,
+        Executable,
+        ReadOnlyColumnCollection,
+    )
+    from sqlalchemy.sql.elements import ColumnElement
 
 
 def dedup_columns(columns: Iterable[sa.Column]) -> list[sa.Column]:
@@ -43,7 +47,7 @@ def dedup_columns(columns: Iterable[sa.Column]) -> list[sa.Column]:
 
 
 def convert_rows_custom_column_types(
-    columns: "ReadOnlyColumnCollection[str, KeyedColumnElement[Any]]",
+    columns: "ColumnCollection[str, ColumnElement[Any]]",
     rows: Iterator[tuple[Any, ...]],
     dialect: "Dialect",
 ):

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -594,7 +594,7 @@ class SQLiteWarehouse(AbstractWarehouse):
     ):
         rows = self.db.execute(select_query, **kwargs)
         yield from convert_rows_custom_column_types(
-            select_query.columns, rows, sqlite_dialect
+            select_query.selected_columns, rows, sqlite_dialect
         )
 
     def get_dataset_sources(

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -494,7 +494,7 @@ class AbstractWarehouse(ABC, Serializable):
         This gets nodes based on the provided query, and should be used sparingly,
         as it will be slow on any OLAP database systems.
         """
-        columns = [c.name for c in query.columns]
+        columns = [c.name for c in query.selected_columns]
         for row in self.db.execute(query):
             d = dict(zip(columns, row))
             yield Node(**d)

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1027,11 +1027,7 @@ class DataChain(DatasetQuery):
 
         transposed_result = list(map(list, zip(*self.results())))
         data = {tuple(n): val for n, val in zip(headers, transposed_result)}
-        df = pd.DataFrame(data)
-        # Sort the dataframe to avoid a PerformanceWarning about unsorted indexing.
-        df.sort_index(axis=0, inplace=True, sort_remaining=True)
-        df.sort_index(axis=1, inplace=True, sort_remaining=True)
-        return df
+        return pd.DataFrame(data)
 
     def show(
         self,

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1027,7 +1027,11 @@ class DataChain(DatasetQuery):
 
         transposed_result = list(map(list, zip(*self.results())))
         data = {tuple(n): val for n, val in zip(headers, transposed_result)}
-        return pd.DataFrame(data)
+        df = pd.DataFrame(data)
+        # Sort the dataframe to avoid a PerformanceWarning about unsorted indexing.
+        df.sort_index(axis=0, inplace=True, sort_remaining=True)
+        df.sort_index(axis=1, inplace=True, sort_remaining=True)
+        return df
 
     def show(
         self,

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -268,7 +268,7 @@ class DatasetDiffOperation(Step):
 
         columns = [
             c if isinstance(c, Column) else Column(c.name, c.type)
-            for c in source_query.columns
+            for c in source_query.selected_columns
         ]
         temp_table = self.catalog.warehouse.create_dataset_rows_table(
             temp_table_name,
@@ -1252,7 +1252,7 @@ class DatasetQuery:
     def as_iterable(self, **kwargs) -> Iterator[ResultIter]:
         try:
             query = self.apply_steps().select()
-            selected_columns = [c.name for c in query.columns]
+            selected_columns = [c.name for c in query.selected_columns]
             yield ResultIter(
                 self.catalog.warehouse.dataset_rows_select(query, **kwargs),
                 selected_columns,
@@ -1676,7 +1676,7 @@ class DatasetQuery:
                     f.row_number().over(order_by=q._order_by_clauses).label("sys__id")
                 )
 
-            cols = tuple(c.name for c in q.columns)
+            cols = tuple(c.name for c in q.selected_columns)
             insert_q = sqlalchemy.insert(dr.get_table()).from_select(cols, q)
             self.catalog.warehouse.db.execute(insert_q, **kwargs)
             self.catalog.metastore.update_dataset_status(

--- a/tests/examples/test_wds_e2e.py
+++ b/tests/examples/test_wds_e2e.py
@@ -90,7 +90,7 @@ def test_wds(catalog, webdataset_tars):
         assert laion_wds.file.parent
         assert laion_wds.file.name == f"{idx}.jpg"
         assert laion_wds.file.location
-        assert laion_wds.json.dict() == Laion(**data).dict()
+        assert laion_wds.json.model_dump() == Laion(**data).model_dump()
 
     assert num_rows == len(WDS_TAR_SHARDS)
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -210,15 +210,16 @@ def test_create_dataset_from_sources_failed(listed_bucket, cloud_test_catalog, m
     dataset_name = uuid.uuid4().hex
     src_uri = cloud_test_catalog.src_uri
     catalog = cloud_test_catalog.catalog
-    with mocker.patch.object(
+    # Mocks are automatically undone at the end of a test.
+    mocker.patch.object(
         catalog.warehouse.__class__,
         "create_dataset_rows_table",
         side_effect=RuntimeError("Error"),
-    ) as _:
-        with pytest.raises(RuntimeError):
-            catalog.create_dataset_from_sources(
-                dataset_name, [f"{src_uri}/dogs/*"], recursive=True
-            )
+    )
+    with pytest.raises(RuntimeError):
+        catalog.create_dataset_from_sources(
+            dataset_name, [f"{src_uri}/dogs/*"], recursive=True
+        )
 
     dataset = catalog.get_dataset(dataset_name)
     dataset_version = dataset.get_version(dataset.latest_version)

--- a/tests/func/test_feature_pickling.py
+++ b/tests/func/test_feature_pickling.py
@@ -60,6 +60,13 @@ def common_df_asserts(df):
     assert df["message"]["input_file_info"]["byte_size"].tolist() == [4, 4]
 
 
+def sort_df_for_tests(df):
+    # Sort the dataframe to avoid a PerformanceWarning about unsorted indexing.
+    df.sort_index(axis=0, inplace=True, sort_remaining=True)
+    df.sort_index(axis=1, inplace=True, sort_remaining=True)
+    return df.sort_values(("file", "name")).reset_index(drop=True)
+
+
 @pytest.mark.parametrize(
     "cloud_type,version_aware",
     [("s3", True)],
@@ -87,7 +94,7 @@ def test_feature_udf_parallel(cloud_test_catalog_tmpfile):
 
     df = chain.to_pandas()
 
-    df = df.sort_values(("file", "name")).reset_index(drop=True)
+    df = sort_df_for_tests(df)
 
     common_df_asserts(df)
     assert df["message"]["model"].tolist() == ["Test AI Model", "Test AI Model"]
@@ -141,7 +148,7 @@ def test_feature_udf_parallel_local(cloud_test_catalog_tmpfile):
 
     df = chain.to_pandas()
 
-    df = df.sort_values(("file", "name")).reset_index(drop=True)
+    df = sort_df_for_tests(df)
 
     common_df_asserts(df)
     assert df["message"]["model"].tolist() == [
@@ -200,7 +207,7 @@ def test_feature_udf_parallel_local_pydantic(cloud_test_catalog_tmpfile):
 
     df = chain.to_pandas()
 
-    df = df.sort_values(("file", "name")).reset_index(drop=True)
+    df = sort_df_for_tests(df)
 
     common_df_asserts(df)
     assert df["message"]["model"].tolist() == [

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -9,22 +9,22 @@ from datachain.lib.signal_schema import SignalResolvingError
 from datachain.sql.types import Float, String
 
 
-class TestUser(BaseModel):
+class ExampleUser(BaseModel):
     name: Optional[str] = None
     age: Optional[int] = None
 
 
-class TestPlayer(TestUser):
+class ExamplePlayer(ExampleUser):
     weight: Optional[float] = None
     height: Optional[int] = None
 
 
-class TestEmployee(BaseModel):
+class ExampleEmployee(BaseModel):
     id: Optional[int] = None
-    person: TestUser
+    person: ExampleUser
 
 
-class TestTeamMember(BaseModel):
+class ExampleTeamMember(BaseModel):
     player: Optional[str] = None
     sport: Optional[str] = None
     weight: Optional[float] = None
@@ -32,15 +32,15 @@ class TestTeamMember(BaseModel):
 
 
 employees = [
-    TestEmployee(id=151, person=TestUser(name="Alice", age=31)),
-    TestEmployee(id=152, person=TestUser(name="Bob", age=27)),
-    TestEmployee(id=153, person=TestUser(name="Charlie", age=54)),
-    TestEmployee(id=154, person=TestUser(name="David", age=29)),
+    ExampleEmployee(id=151, person=ExampleUser(name="Alice", age=31)),
+    ExampleEmployee(id=152, person=ExampleUser(name="Bob", age=27)),
+    ExampleEmployee(id=153, person=ExampleUser(name="Charlie", age=54)),
+    ExampleEmployee(id=154, person=ExampleUser(name="David", age=29)),
 ]
 team = [
-    TestTeamMember(player="Alice", sport="volleyball", weight=120.3, height=5.5),
-    TestTeamMember(player="Charlie", sport="football", weight=200.0, height=6.0),
-    TestTeamMember(player="David", sport="football", weight=158.7, height=5.7),
+    ExampleTeamMember(player="Alice", sport="volleyball", weight=120.3, height=5.5),
+    ExampleTeamMember(player="Charlie", sport="football", weight=200.0, height=6.0),
+    ExampleTeamMember(player="David", sport="football", weight=158.7, height=5.7),
 ]
 
 
@@ -58,11 +58,11 @@ def test_merge_objects(catalog):
         assert len(items) == 2
 
         empl, player = items
-        assert isinstance(empl, TestEmployee)
+        assert isinstance(empl, ExampleEmployee)
         assert empl == employees[i]
         i += 1
 
-        assert isinstance(player, TestTeamMember)
+        assert isinstance(player, ExampleTeamMember)
         if empl.person.name != "Bob":
             assert player.player == team[j].player
             assert player.sport == team[j].sport
@@ -81,9 +81,9 @@ def test_merge_objects(catalog):
 
 def test_merge_similar_objects(catalog):
     new_employees = [
-        TestEmployee(id=152, person=TestUser(name="Bob", age=27)),
-        TestEmployee(id=201, person=TestUser(name="Karl", age=18)),
-        TestEmployee(id=154, person=TestUser(name="David", age=29)),
+        ExampleEmployee(id=152, person=ExampleUser(name="Bob", age=27)),
+        ExampleEmployee(id=201, person=ExampleUser(name="Karl", age=18)),
+        ExampleEmployee(id=154, person=ExampleUser(name="David", age=29)),
     ]
 
     ch1 = DataChain.from_values(emp=employees)
@@ -196,8 +196,8 @@ def test_merge_with_itself(catalog):
 
     count = 0
     for left, right in merged.collect():
-        assert isinstance(left, TestEmployee)
-        assert isinstance(right, TestEmployee)
+        assert isinstance(left, ExampleEmployee)
+        assert isinstance(right, ExampleEmployee)
         assert left == right == employees[count]
         count += 1
 

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -9,22 +9,22 @@ from datachain.lib.signal_schema import SignalResolvingError
 from datachain.sql.types import Float, String
 
 
-class ExampleUser(BaseModel):
+class User(BaseModel):
     name: Optional[str] = None
     age: Optional[int] = None
 
 
-class ExamplePlayer(ExampleUser):
+class Player(User):
     weight: Optional[float] = None
     height: Optional[int] = None
 
 
-class ExampleEmployee(BaseModel):
+class Employee(BaseModel):
     id: Optional[int] = None
-    person: ExampleUser
+    person: User
 
 
-class ExampleTeamMember(BaseModel):
+class TeamMember(BaseModel):
     player: Optional[str] = None
     sport: Optional[str] = None
     weight: Optional[float] = None
@@ -32,15 +32,15 @@ class ExampleTeamMember(BaseModel):
 
 
 employees = [
-    ExampleEmployee(id=151, person=ExampleUser(name="Alice", age=31)),
-    ExampleEmployee(id=152, person=ExampleUser(name="Bob", age=27)),
-    ExampleEmployee(id=153, person=ExampleUser(name="Charlie", age=54)),
-    ExampleEmployee(id=154, person=ExampleUser(name="David", age=29)),
+    Employee(id=151, person=User(name="Alice", age=31)),
+    Employee(id=152, person=User(name="Bob", age=27)),
+    Employee(id=153, person=User(name="Charlie", age=54)),
+    Employee(id=154, person=User(name="David", age=29)),
 ]
 team = [
-    ExampleTeamMember(player="Alice", sport="volleyball", weight=120.3, height=5.5),
-    ExampleTeamMember(player="Charlie", sport="football", weight=200.0, height=6.0),
-    ExampleTeamMember(player="David", sport="football", weight=158.7, height=5.7),
+    TeamMember(player="Alice", sport="volleyball", weight=120.3, height=5.5),
+    TeamMember(player="Charlie", sport="football", weight=200.0, height=6.0),
+    TeamMember(player="David", sport="football", weight=158.7, height=5.7),
 ]
 
 
@@ -58,11 +58,11 @@ def test_merge_objects(catalog):
         assert len(items) == 2
 
         empl, player = items
-        assert isinstance(empl, ExampleEmployee)
+        assert isinstance(empl, Employee)
         assert empl == employees[i]
         i += 1
 
-        assert isinstance(player, ExampleTeamMember)
+        assert isinstance(player, TeamMember)
         if empl.person.name != "Bob":
             assert player.player == team[j].player
             assert player.sport == team[j].sport
@@ -81,9 +81,9 @@ def test_merge_objects(catalog):
 
 def test_merge_similar_objects(catalog):
     new_employees = [
-        ExampleEmployee(id=152, person=ExampleUser(name="Bob", age=27)),
-        ExampleEmployee(id=201, person=ExampleUser(name="Karl", age=18)),
-        ExampleEmployee(id=154, person=ExampleUser(name="David", age=29)),
+        Employee(id=152, person=User(name="Bob", age=27)),
+        Employee(id=201, person=User(name="Karl", age=18)),
+        Employee(id=154, person=User(name="David", age=29)),
     ]
 
     ch1 = DataChain.from_values(emp=employees)
@@ -196,8 +196,8 @@ def test_merge_with_itself(catalog):
 
     count = 0
     for left, right in merged.collect():
-        assert isinstance(left, ExampleEmployee)
-        assert isinstance(right, ExampleEmployee)
+        assert isinstance(left, Employee)
+        assert isinstance(right, Employee)
         assert left == right == employees[count]
         count += 1
 

--- a/tests/unit/lib/test_feature.py
+++ b/tests/unit/lib/test_feature.py
@@ -17,12 +17,12 @@ class FileBasic(DataModel):
     size: int = Field(default=0)
 
 
-class ExampleFileInfo(FileBasic):
+class FileInfo(FileBasic):
     location: dict = Field(default={})
 
 
 class FileInfoEx(DataModel):
-    f_info: ExampleFileInfo
+    f_info: FileInfo
     type_id: int
 
 
@@ -42,13 +42,13 @@ def test_flatten_basic():
 
 
 def test_flatten_with_json():
-    t1 = ExampleFileInfo(parent="prt4", name="test1", size=42, location={"ee": "rr"})
+    t1 = FileInfo(parent="prt4", name="test1", size=42, location={"ee": "rr"})
     assert flatten(t1) == ("prt4", "test1", 42, {"ee": "rr"})
 
 
 def test_flatten_with_empty_json():
     with pytest.raises(ValidationError):
-        ExampleFileInfo(parent="prt4", name="test1", size=42, location=None)
+        FileInfo(parent="prt4", name="test1", size=42, location=None)
 
 
 def test_flatten_with_accepted_empty_json():
@@ -59,15 +59,15 @@ def test_flatten_with_accepted_empty_json():
 
 
 def test_flatten_nested():
-    t0 = ExampleFileInfo(parent="sfo", name="sf", size=567, location={"42": 999})
+    t0 = FileInfo(parent="sfo", name="sf", size=567, location={"42": 999})
     t1 = FileInfoEx(f_info=t0, type_id=1849)
 
     assert flatten(t1) == ("sfo", "sf", 567, {"42": 999}, 1849)
 
 
 def test_flatten_list():
-    t1 = ExampleFileInfo(parent="p1", name="n4", size=3, location={"a": "b"})
-    t2 = ExampleFileInfo(parent="p2", name="n5", size=2, location={"c": "d"})
+    t1 = FileInfo(parent="p1", name="n4", size=3, location={"a": "b"})
+    t2 = FileInfo(parent="p2", name="n5", size=2, location={"c": "d"})
 
     vals = flatten_list([t1, t2])
     assert vals == ("p1", "n4", 3, {"a": "b"}, "p2", "n5", 2, {"c": "d"})

--- a/tests/unit/lib/test_feature.py
+++ b/tests/unit/lib/test_feature.py
@@ -17,12 +17,12 @@ class FileBasic(DataModel):
     size: int = Field(default=0)
 
 
-class TestFileInfo(FileBasic):
+class ExampleFileInfo(FileBasic):
     location: dict = Field(default={})
 
 
 class FileInfoEx(DataModel):
-    f_info: TestFileInfo
+    f_info: ExampleFileInfo
     type_id: int
 
 
@@ -42,13 +42,13 @@ def test_flatten_basic():
 
 
 def test_flatten_with_json():
-    t1 = TestFileInfo(parent="prt4", name="test1", size=42, location={"ee": "rr"})
+    t1 = ExampleFileInfo(parent="prt4", name="test1", size=42, location={"ee": "rr"})
     assert flatten(t1) == ("prt4", "test1", 42, {"ee": "rr"})
 
 
 def test_flatten_with_empty_json():
     with pytest.raises(ValidationError):
-        TestFileInfo(parent="prt4", name="test1", size=42, location=None)
+        ExampleFileInfo(parent="prt4", name="test1", size=42, location=None)
 
 
 def test_flatten_with_accepted_empty_json():
@@ -59,15 +59,15 @@ def test_flatten_with_accepted_empty_json():
 
 
 def test_flatten_nested():
-    t0 = TestFileInfo(parent="sfo", name="sf", size=567, location={"42": 999})
+    t0 = ExampleFileInfo(parent="sfo", name="sf", size=567, location={"42": 999})
     t1 = FileInfoEx(f_info=t0, type_id=1849)
 
     assert flatten(t1) == ("sfo", "sf", 567, {"42": 999}, 1849)
 
 
 def test_flatten_list():
-    t1 = TestFileInfo(parent="p1", name="n4", size=3, location={"a": "b"})
-    t2 = TestFileInfo(parent="p2", name="n5", size=2, location={"c": "d"})
+    t1 = ExampleFileInfo(parent="p1", name="n4", size=3, location={"a": "b"})
+    t2 = ExampleFileInfo(parent="p2", name="n5", size=2, location={"c": "d"})
 
     vals = flatten_list([t1, t2])
     assert vals == ("p1", "n4", 3, {"a": "b"}, "p2", "n5", 2, {"c": "d"})

--- a/tests/unit/test_module_exports.py
+++ b/tests/unit/test_module_exports.py
@@ -2,8 +2,10 @@
 
 import builtins
 import sys
+import warnings
 
 import pytest
+from sqlalchemy.exc import SAWarning
 
 
 def test_module_exports():
@@ -57,24 +59,29 @@ def test_no_torch_deps(monkeypatch, dep):
     monkeypatch.setattr(builtins, "__import__", monkey_import_importerror)
 
     try:
-        from datachain import (
-            AbstractUDF,
-            Aggregator,
-            C,
-            Column,
-            DataChain,
-            DataChainError,
-            DataModel,
-            File,
-            FileError,
-            Generator,
-            ImageFile,
-            IndexedFile,
-            Mapper,
-            Session,
-            TarVFile,
-            TextFile,
-        )
+        with warnings.catch_warnings():
+            # Ignore SQLAlchemy warnings about redeclaring functions due to multiple
+            # imports of the same code in this test, after deleting them from
+            # sys.modules, which would not happen in normal user code.
+            warnings.filterwarnings("ignore", category=SAWarning)
+            from datachain import (
+                AbstractUDF,
+                Aggregator,
+                C,
+                Column,
+                DataChain,
+                DataChainError,
+                DataModel,
+                File,
+                FileError,
+                Generator,
+                ImageFile,
+                IndexedFile,
+                Mapper,
+                Session,
+                TarVFile,
+                TextFile,
+            )
     except Exception as e:  # noqa: BLE001
         pytest.fail(f"Importing raised an exception: {e}")
 


### PR DESCRIPTION
This fixes a variety of warnings that show up when running tests:

- Uses `selected_columns` instead of `columns` in select statements to avoid this SQLAlchemy warning: `  /home/runner/work/datachain/datachain/.nox/tests-3-9/lib/python3.9/site-packages/datachain/query/dataset.py:1255: SADeprecationWarning: The SelectBase.c and SelectBase.columns attributes are deprecated and will be removed in a future release; these attributes implicitly create a subquery that should be explicit.  Please call SelectBase.subquery() first in order to create a subquery, which then contains this attribute.  To access the columns that this SELECT object SELECTs from, use the SelectBase.selected_columns attribute. (deprecated since: 1.4)`
- Renames Test... classes to no longer start with Test as this causes pytest to attempt to collect them as tests, and show warnings like: `/home/runner/work/datachain/datachain/tests/unit/lib/test_datachain_merge.py:12: PytestCollectionWarning: cannot collect test class 'TestUser' because it has a __init__ constructor (from: tests/unit/lib/test_datachain_merge.py)`
- Uses `model_dump` instead of `dict` for Pydantic models, because of this warning: `/home/runner/work/datachain/datachain/.nox/tests-3-9/lib/python3.9/site-packages/pydantic/main.py:1087: PydanticDeprecatedSince20: The "dict" method is deprecated; use "model_dump" instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.8/migration/`
- Sort the returned dataframe from `to_pandas` to avoid this warning from pandas: `/home/runner/work/datachain/datachain/tests/func/test_feature_pickling.py:90: PerformanceWarning: indexing past lexsort depth may impact performance.`
- Pytest mocks don't need to be used as a context manager, as indicated by this warning: `/home/runner/work/datachain/datachain/tests/func/test_datasets.py:213: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager`