### PR TITLE
fix test for ch wrt datetime precision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
   "datachain[docs,tests]",
   "mypy==1.10.1",
   "types-python-dateutil",
+  "types-pytz",
   "types-PyYAML",
   "types-requests",
   "types-ujson"


### PR DESCRIPTION
DateTime in clickhouse is based on Unix time, and has no sub-second precision.

So I am flooring the mtime. Also had to change the timezone to use `pytz.UTC` for some reason (still not sure why that is the case), but wanted to unblock the CI.