### PR TITLE
Fix for using new column from `.mutate()` in `.order_by()`

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -820,8 +820,16 @@ class SQLMutate(SQLClause):
     args: tuple[ColumnElement, ...]
 
     def apply_sql_clause(self, query: Select) -> Select:
-        subquery = query.subquery()
-        return sqlalchemy.select(*subquery.c, *self.args).select_from(subquery)
+        original_subquery = query.subquery()
+        # double subquery is needed so that new column can be used in clauses
+        # like ORDER BY, otherwise new column is not recognized
+        subquery = (
+            sqlalchemy.select(*original_subquery.c, *self.args)
+            .select_from(original_subquery)
+            .subquery()
+        )
+
+        return sqlalchemy.select(*subquery.c).select_from(subquery)
 
 
 @frozen

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -821,7 +821,7 @@ class SQLMutate(SQLClause):
 
     def apply_sql_clause(self, query: Select) -> Select:
         original_subquery = query.subquery()
-        # double subquery is needed so that new column can be used in clauses
+        # this is needed for new column to be used in clauses
         # like ORDER BY, otherwise new column is not recognized
         subquery = (
             sqlalchemy.select(*original_subquery.c, *self.args)

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -518,6 +518,35 @@ def test_mutate(cloud_test_catalog, save):
     [("s3", True)],
     indirect=True,
 )
+def test_order_by_after_mutate(cloud_test_catalog, save):
+    catalog = cloud_test_catalog.catalog
+    ds = DatasetQuery(path=cloud_test_catalog.src_uri, catalog=catalog)
+    q = (
+        ds.mutate(size10x=C.size * 10)
+        .filter((C.size10x < 40) | (C.size10x > 100) | C.name.glob("cat*"))
+        .order_by(C.size10x.desc())
+    )
+
+    if save:
+        ds_name = "animals_cats"
+        q.save(ds_name)
+        result = (
+            DatasetQuery(name=ds_name, catalog=catalog)
+            .order_by(C.size10x.desc(), C.name)
+            .db_results(row_factory=lambda c, v: dict(zip(c, v)))
+        )
+    else:
+        result = q.db_results(row_factory=lambda c, v: dict(zip(c, v)))
+
+    assert [r["size10x"] for r in result] == [130, 40, 40, 30]
+
+
+@pytest.mark.parametrize("save", [True, False])
+@pytest.mark.parametrize(
+    "cloud_type,version_aware",
+    [("s3", True)],
+    indirect=True,
+)
 def test_order_by_limit(cloud_test_catalog, save):
     catalog = cloud_test_catalog.catalog
     path = cloud_test_catalog.src_uri


### PR DESCRIPTION
This adds small fix for using new column added in `.mutate()` in `.order_by(). 

Example:
```python
from datachain.lib.dc import C, DataChain

(
    DataChain.from_storage("s3://ldb-public/remote/data-lakes/dogs-and-cats/", anon=True)
    .mutate(size_10x = C("file__size") * 10)
    .order_by("size_10x")
    .save("example")
)
```