### PR TITLE
Renaming `File.write()` to `File.save()`

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -216,7 +216,7 @@ class File(DataModel):
         with self.open(mode="r") as stream:
             return stream.read()
 
-    def write(self, destination: str):
+    def save(self, destination: str):
         """Writes it's content to destination"""
         with open(destination, mode="wb") as f:
             f.write(self.read())
@@ -234,7 +234,7 @@ class File(DataModel):
         dst_dir = os.path.dirname(dst)
         os.makedirs(dst_dir, exist_ok=True)
 
-        self.write(dst)
+        self.save(dst)
 
     def _set_stream(
         self,
@@ -332,7 +332,7 @@ class TextFile(File):
         with self.open() as stream:
             return stream.read()
 
-    def write(self, destination: str):
+    def save(self, destination: str):
         """Writes it's content to destination"""
         with open(destination, mode="w") as f:
             f.write(self.read_text())
@@ -346,7 +346,7 @@ class ImageFile(File):
         fobj = super().read()
         return Image.open(BytesIO(fobj))
 
-    def write(self, destination: str):
+    def save(self, destination: str):
         """Writes it's content to destination"""
         self.read().save(destination)
 

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -170,7 +170,7 @@ def test_read_text_data(tmp_path, catalog: Catalog):
     assert file.read() == data
 
 
-def test_write_binary_data(tmp_path, catalog: Catalog):
+def test_save_binary_data(tmp_path, catalog: Catalog):
     file1_name = "myfile1"
     file2_name = "myfile2"
     data = b"some\x00data\x00is\x48\x65\x6c\x57\x6f\x72\x6c\x64\xff\xffheRe"
@@ -181,14 +181,14 @@ def test_write_binary_data(tmp_path, catalog: Catalog):
     file1 = File(name=file1_name, source=f"file://{tmp_path}")
     file1._set_stream(catalog, False)
 
-    file1.write(tmp_path / file2_name)
+    file1.save(tmp_path / file2_name)
 
     file2 = File(name=file2_name, source=f"file://{tmp_path}")
     file2._set_stream(catalog, False)
     assert file2.read() == data
 
 
-def test_write_text_data(tmp_path, catalog: Catalog):
+def test_save_text_data(tmp_path, catalog: Catalog):
     file1_name = "myfile1.txt"
     file2_name = "myfile2.txt"
     data = "some text"
@@ -199,14 +199,14 @@ def test_write_text_data(tmp_path, catalog: Catalog):
     file1 = TextFile(name=file1_name, source=f"file://{tmp_path}")
     file1._set_stream(catalog, False)
 
-    file1.write(tmp_path / file2_name)
+    file1.save(tmp_path / file2_name)
 
     file2 = TextFile(name=file2_name, source=f"file://{tmp_path}")
     file2._set_stream(catalog, False)
     assert file2.read() == data
 
 
-def test_write_image_data(tmp_path, catalog: Catalog):
+def test_save_image_data(tmp_path, catalog: Catalog):
     from tests.utils import images_equal
 
     file1_name = "myfile1.jpg"
@@ -218,7 +218,7 @@ def test_write_image_data(tmp_path, catalog: Catalog):
     file1 = ImageFile(name=file1_name, source=f"file://{tmp_path}")
     file1._set_stream(catalog, False)
 
-    file1.write(tmp_path / file2_name)
+    file1.save(tmp_path / file2_name)
 
     file2 = ImageFile(name=file2_name, source=f"file://{tmp_path}")
     file2._set_stream(catalog, False)


### PR DESCRIPTION
Simple rename of `.write()` to `.save()` to not break built-in `io.FileIO` interface which our `File` should follow.