### PR TITLE
ci: disable azure and gs remote tests on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,26 +69,6 @@ jobs:
             pyv: '3.12'
 
     steps:
-
-      # https://github.com/iterative/pytest-servers/pull/122
-      # https://github.com/abiosoft/colima/issues/468
-      # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
-      # colima v0.5.6 seems to run more stable than the latest - that has occasional network failures (ports are not open)
-      # see: https://github.com/abiosoft/colima/issues/962
-      - name: Use colima as default docker host on MacOS
-        if: runner.os == 'macOS'
-        run: |
-          brew install docker lima || true # avoid non-zero exit code if brew link fails
-          sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64
-          sudo chmod +x /usr/local/bin/colima
-          colima start
-          sudo ln -vsf "${HOME}"/.colima/default/docker.sock /var/run/docker.sock
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: true
-          HOMEBREW_NO_INSTALL_CLEANUP: true
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
-          HOMEBREW_NO_INSTALL_UPGRADE: true
-
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
@@ -106,12 +86,17 @@ jobs:
           nox --version
           uv --version
 
-      - name: Skip flaky azure, gs remotes if unavailable on macos
+      - name: Skip flaky azure, gs remotes on macOS
         if: runner.os == 'macOS'
-        run: echo 'DATACHAIN_TEST_SKIP_MISSING_REMOTES=azure,gs' >> "$GITHUB_ENV"
+        run: echo 'DISABLE_REMOTES_ARG=--disable-remotes=azure,gs' >> "$GITHUB_ENV"
+
+      - name: Skip all remotes on Windows
+        if: runner.os == 'Windows'
+        run: echo 'DISABLE_REMOTES_ARG=--disable-remotes=all' >> $env:GITHUB_ENV
 
       - name: Run tests
-        run: nox -s tests-${{ matrix.pyv }}
+        run: nox -s tests-${{ matrix.pyv }} -- $DISABLE_REMOTES_ARG
+        shell: bash
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,13 @@ from pathlib import PosixPath
 
 import attrs
 import pytest
-import pytest_servers.exceptions
 import sqlalchemy
 from pytest import MonkeyPatch, TempPathFactory
 from upath.implementations.cloud import CloudPath
 
 from datachain.catalog import Catalog
 from datachain.catalog.loader import get_id_generator, get_metastore, get_warehouse
+from datachain.cli_utils import CommaSeparatedArgs
 from datachain.client.local import FileClient
 from datachain.data_storage.sqlite import (
     SQLiteDatabaseEngine,
@@ -22,7 +22,7 @@ from datachain.data_storage.sqlite import (
 )
 from datachain.dataset import DatasetRecord
 from datachain.query.session import Session
-from datachain.utils import DataChainDir, get_env_list
+from datachain.utils import DataChainDir
 
 from .utils import DEFAULT_TREE, get_simple_ds_query, instantiate_tree
 
@@ -239,6 +239,13 @@ def tmp_dir(tmp_path_factory, monkeypatch):
 
 def pytest_addoption(parser):
     parser.addoption(
+        "--disable-remotes",
+        action=CommaSeparatedArgs,
+        default=[],
+        help="Comma separated list of remotes to disable",
+    )
+
+    parser.addoption(
         "--datachain-bin",
         type=str,
         default=DEFAULT_DATACHAIN_BIN,
@@ -369,32 +376,38 @@ def version_aware(request):
     return request.param
 
 
+def pytest_collection_modifyitems(config, items):
+    disabled_remotes = config.getoption("--disable-remotes")
+    if not disabled_remotes:
+        return
+
+    for item in items:
+        if "cloud_server" in item.fixturenames:
+            cloud_type = item.callspec.params.get("cloud_type")
+            if cloud_type == "file":
+                continue
+            if "all" in disabled_remotes:
+                reason = "Skipping all tests requiring cloud"
+                item.add_marker(pytest.mark.skip(reason=reason))
+            if cloud_type in disabled_remotes:
+                reason = f"Skipping all tests for {cloud_type=}"
+                item.add_marker(pytest.mark.skip(reason=reason))
+
+
 @pytest.fixture(scope="session")
 def cloud_server(request, tmp_upath_factory, cloud_type, version_aware, tree):
-    # DATACHAIN_TEST_SKIP_MISSING_REMOTES can be set to a comma-separated list
-    # of remotes to skip tests for if unavailable or "all" to skip all
-    # unavailable remotes:
-    #  DATACHAIN_TEST_SKIP_MISSING_REMOTES=azure,gs
-    #  DATACHAIN_TEST_SKIP_MISSING_REMOTES=all
-    skip_missing_remotes = set(get_env_list("DATACHAIN_TEST_SKIP_MISSING_REMOTES", []))
-    try:
-        if cloud_type == "azure" and version_aware:
-            if conn_str := request.config.getoption("--azure-connection-string"):
-                src_path = tmp_upath_factory.azure(conn_str)
-            else:
-                pytest.skip("Can't test versioning with Azure")
-        elif cloud_type == "file":
-            if version_aware:
-                pytest.skip("Local storage can't be versioned")
-            else:
-                src_path = tmp_upath_factory.mktemp("local")
+    if cloud_type == "azure" and version_aware:
+        if conn_str := request.config.getoption("--azure-connection-string"):
+            src_path = tmp_upath_factory.azure(conn_str)
         else:
-            src_path = tmp_upath_factory.mktemp(cloud_type, version_aware=version_aware)
-    except pytest_servers.exceptions.RemoteUnavailable as exc:
-        if "all" in skip_missing_remotes or cloud_type in skip_missing_remotes:
-            pytest.skip(str(exc))
-        raise
-
+            pytest.skip("Can't test versioning with Azure")
+    elif cloud_type == "file":
+        if version_aware:
+            pytest.skip("Local storage can't be versioned")
+        else:
+            src_path = tmp_upath_factory.mktemp("local")
+    else:
+        src_path = tmp_upath_factory.mktemp(cloud_type, version_aware=version_aware)
     return make_cloud_server(src_path, cloud_type, tree)
 
 


### PR DESCRIPTION
The CI is flaky because of colima/docker usage, which does not seem to be stable on macOS. Also, we already run those tests on Linux, so we don't really need to run it on macOS.

Closes #51.