### PR TITLE
avoid instantiating filesystem for path operations

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -12,7 +12,6 @@ from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
-from fsspec.implementations.local import LocalFileSystem
 from PIL import Image
 from pydantic import Field, field_validator
 

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -283,9 +283,8 @@ class File(DataModel):
     def get_path(self) -> str:
         """Returns file path."""
         path = unquote(self.get_uri())
-        fs = self.get_fs()
-        if isinstance(fs, LocalFileSystem):
-            # Drop file:// protocol
+        source = urlparse(self.source)
+        if source.scheme == "file":
             path = urlparse(path).path
             path = url2pathname(path)
         return path
@@ -300,13 +299,10 @@ class File(DataModel):
         elif placement == "etag":
             path = f"{self.etag}{self.get_file_suffix()}"
         elif placement == "fullpath":
-            fs = self.get_fs()
-            if isinstance(fs, LocalFileSystem):
-                path = unquote(self.get_full_name())
-            else:
-                path = (
-                    Path(urlparse(self.source).netloc) / unquote(self.get_full_name())
-                ).as_posix()
+            path = unquote(self.get_full_name())
+            source = urlparse(self.source)
+            if source.scheme and source.scheme != "file":
+                path = posixpath.join(source.netloc, path)
         elif placement == "checksum":
             raise NotImplementedError("Checksum placement not implemented yet")
         else:

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -17,12 +17,8 @@ from tests.utils import images_equal
 
 
 @pytest.mark.parametrize("anon", [True, False])
-def test_catalog_anon(catalog, anon):
-    chain = (
-        DataChain.from_storage("gs://dvcx-datalakes/dogs-and-cats/", anon=anon)
-        .limit(5)
-        .save("test_catalog_anon")
-    )
+def test_catalog_anon(tmp_dir, catalog, anon):
+    chain = DataChain.from_storage(tmp_dir.as_uri(), anon=anon)
     assert chain.catalog.client_config.get("anon", False) is anon
 
 


### PR DESCRIPTION
`S3Client.create_fs()` tries to sign an s3 uri, which might hit the remote. So, all of the current
`get_destination_path` and `get_path` tests are
hitting AWS S3, which might fail if you don't have credentials set.

https://github.com/iterative/datachain/blob/0ed1e2cf2e66ba1913301c81b0a907941b0c6953/src/datachain/client/s3.py#L46

So this PR tries to avoid constructing them wherever possible (at least in these path operations).

An alternative fix might be to run tests inside `s3_server`.

Also removes one test that hits gcs.