### PR TITLE
Optimizations: low-hanging fruits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,7 @@ dev = [
   "types-python-dateutil",
   "types-pytz",
   "types-PyYAML",
-  "types-requests",
-  "types-orjson"
+  "types-requests"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "multiprocess==0.70.16",
   "dill==0.3.8",
   "cloudpickle",
-  "ujson>=5.9.0",
+  "orjson>=3.10.5",
   "pydantic>=2,<3",
   "jmespath>=1.0",
   "datamodel-code-generator>=0.25",
@@ -92,7 +92,7 @@ dev = [
   "types-pytz",
   "types-PyYAML",
   "types-requests",
-  "types-ujson"
+  "types-orjson"
 ]
 
 [project.urls]

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -48,10 +48,14 @@ def _flatten_fields_values(fields, obj: BaseModel):
         value = getattr(obj, name)
 
         if isinstance(value, list):
-            yield [
-                val.model_dump() if ModelStore.is_pydantic(type(val)) else val
-                for val in value
-            ]
+            if len(value) == 0:
+                yield []
+            # Optimization: Assume arrays are homogeneous, so check first element only
+            # to avoid unnecessary iterations.
+            elif ModelStore.is_pydantic(type(value[0])):
+                yield [val.model_dump() for val in value]
+            else:
+                yield value
         elif isinstance(value, dict):
             yield {
                 key: val.model_dump() if ModelStore.is_pydantic(type(val)) else val

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -48,11 +48,7 @@ def _flatten_fields_values(fields, obj: BaseModel):
         value = getattr(obj, name)
 
         if isinstance(value, list):
-            if len(value) == 0:
-                yield []
-            # Optimization: Assume arrays are homogeneous, so check first element only
-            # to avoid unnecessary iterations.
-            elif ModelStore.is_pydantic(type(value[0])):
+            if value and ModelStore.is_pydantic(type(value[0])):
                 yield [val.model_dump() for val in value]
             else:
                 yield value

--- a/src/datachain/sql/sqlite/base.py
+++ b/src/datachain/sql/sqlite/base.py
@@ -5,8 +5,8 @@ from datetime import MAXYEAR, MINYEAR, datetime, timezone
 from types import MappingProxyType
 from typing import Callable, Optional
 
+import orjson
 import sqlalchemy as sa
-import ujson
 from sqlalchemy.dialects import sqlite
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.elements import literal
@@ -149,7 +149,7 @@ def missing_vector_function(name, exc):
 
 
 def sqlite_string_split(string: str, sep: str, maxsplit: int = -1) -> str:
-    return ujson.dumps(string.split(sep, maxsplit))
+    return orjson.dumps(string.split(sep, maxsplit))
 
 
 def register_user_defined_sql_functions() -> None:
@@ -274,7 +274,7 @@ def compile_euclidean_distance(element, compiler, **kwargs):
 
 
 def py_json_array_length(arr):
-    return len(ujson.loads(arr))
+    return len(orjson.loads(arr))
 
 
 def compile_array_length(element, compiler, **kwargs):

--- a/src/datachain/sql/sqlite/base.py
+++ b/src/datachain/sql/sqlite/base.py
@@ -149,7 +149,7 @@ def missing_vector_function(name, exc):
 
 
 def sqlite_string_split(string: str, sep: str, maxsplit: int = -1) -> str:
-    return orjson.dumps(string.split(sep, maxsplit))
+    return orjson.dumps(string.split(sep, maxsplit)).decode("utf-8")
 
 
 def register_user_defined_sql_functions() -> None:

--- a/src/datachain/sql/sqlite/types.py
+++ b/src/datachain/sql/sqlite/types.py
@@ -1,7 +1,6 @@
-import json
 import sqlite3
 
-import ujson
+import orjson
 from sqlalchemy import types
 
 from datachain.sql.types import TypeConverter, TypeReadConverter
@@ -29,22 +28,15 @@ class Array(types.UserDefinedType):
 
 
 def adapt_array(arr):
-    return ujson.dumps(arr)
+    return orjson.dumps(arr)
 
 
 def convert_array(arr):
-    return ujson.loads(arr)
+    return orjson.loads(arr)
 
 
 def adapt_np_array(arr):
-    def _json_serialize(obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        return obj
-
-    if np.issubdtype(arr.dtype, np.object_):
-        return json.dumps(arr.tolist(), default=_json_serialize)
-    return ujson.dumps(arr.tolist())
+    return orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
 
 
 def adapt_np_generic(val):
@@ -70,5 +62,5 @@ class SQLiteTypeConverter(TypeConverter):
 class SQLiteTypeReadConverter(TypeReadConverter):
     def array(self, value, item_type, dialect):
         if isinstance(value, str):
-            value = ujson.loads(value)
+            value = orjson.loads(value)
         return super().array(value, item_type, dialect)

--- a/src/datachain/sql/sqlite/types.py
+++ b/src/datachain/sql/sqlite/types.py
@@ -28,7 +28,7 @@ class Array(types.UserDefinedType):
 
 
 def adapt_array(arr):
-    return orjson.dumps(arr)
+    return orjson.dumps(arr).decode("utf-8")
 
 
 def convert_array(arr):
@@ -36,7 +36,7 @@ def convert_array(arr):
 
 
 def adapt_np_array(arr):
-    return orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
+    return orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8")
 
 
 def adapt_np_generic(val):


### PR DESCRIPTION
# Preparation

Let's profile laion embeddings generation from `gs://dvcx-datacomp-small/metadata` bucket.

List bucket:
```
$ gsutil ls -l gs://dvcx-datacomp-small/metadata
3106844080  2024-01-15T15:37:25Z  gs://dvcx-datacomp-small/metadata/0020f0cbd157d470aa56bea08e304b90.npz
 120845372  2024-01-15T15:28:20Z  gs://dvcx-datacomp-small/metadata/0020f0cbd157d470aa56bea08e304b90.parquet
...
 673764696  2024-01-15T15:29:52Z  gs://dvcx-datacomp-small/metadata/036d6b9ae87a00e738f8fc554130b65b.npz
  26585624  2024-01-15T15:27:58Z  gs://dvcx-datacomp-small/metadata/036d6b9ae87a00e738f8fc554130b65b.parquet
TOTAL: 52 objects, 81707590807 bytes (76.1 GiB)
$
```

Pre-download "small" `643Mb`, `109662` rows `npz` file (just to make it easier to profile):
```
$ mkdir -p dvcx-datacomp-small/metadata
$ gsutil cp -v gs://dvcx-datacomp-small/metadata/036d6b9ae87a00e738f8fc554130b65b.npz dvcx-datacomp-small/metadata/
Copying gs://dvcx-datacomp-small/metadata/036d6b9ae87a00e738f8fc554130b65b.npz...

Created: file://dvcx-datacomp-small/metadata/036d6b9ae87a00e738f8fc554130b65b.npz

Operation completed over 1 objects/642.6 MiB.
$
```

## Script to profile with

`laion_emb.py`:
```python
from datachain.lib.dc import C, DataChain
from datachain.lib.webdataset_laion import process_laion_meta

(
    DataChain.from_storage("dvcx-datacomp-small/metadata/")
    .gen(emd=process_laion_meta)
    .map(stem=lambda file: file.get_file_stem(), params=["emd.file"], output=str)
    .save("laion_emb")
)
```

## Original

#### Run time
```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2582.70 rows/s]
Download: 643MB [01:51, 6.02MB/s]
Processed: 1 rows [01:51, 111.84s/ rows]
Generated: 109662 rows [01:51, 981.86 rows/s]
Processed: 109662 rows [00:33, 3250.94 rows/s]
python laion_emb.py  136.53s user 38.04s system 77% cpu 3:46.02 total
$
```

#### cProfile
```
$ python -m cProfile laion_emb.py
```

```
         1612839267 function calls (1609675654 primitive calls) in 357.574 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   1856/1    0.015    0.000  356.575  356.575 {built-in method builtins.exec}
      2/1    0.000    0.000  356.575  356.575 laion_emb.py:1(<module>)
      2/1    0.010    0.005  356.575  356.575 dc.py:472(save)
      2/1    0.010    0.005  356.564  356.564 dataset.py:1627(save)
      4/3    0.018    0.004  308.124  102.708 dataset.py:1160(apply_steps)
      4/3    0.000    0.000  307.654  102.551 dataset.py:610(apply)
        3    0.151    0.050  268.223   89.408 dataset.py:460(populate_udf_table)
        3    1.455    0.485  239.475   79.825 dataset.py:385(process_udf_outputs)
   109663    0.097    0.000  188.669    0.002 udf.py:147(<genexpr>)
   328989    0.325    0.000  188.652    0.001 udf.py:251(<genexpr>)
   109663    0.155    0.000  173.282    0.002 flatten.py:34(flatten)
3070547/1864265   33.800    0.000  173.131    0.000 flatten.py:44(_flatten_fields_values)
310234294   38.162    0.000  139.167    0.000 model_store.py:70(is_pydantic)
    36/35    0.065    0.002  111.413    3.183 threading.py:637(wait)
311009146   33.567    0.000   86.872    0.000 {built-in method builtins.issubclass}
    36/35    0.001    0.000   82.815    2.366 threading.py:323(wait)
  148/142   74.944    0.506   82.808    0.583 {method 'acquire' of '_thread.lock' objects}
311002897/311002132   23.788    0.000   53.306    0.000 <frozen abc>:121(__subclasscheck__)
      121    0.000    0.000   43.716    0.361 sqlite.py:68(wrapper)
       23    0.001    0.000   41.055    1.785 sqlite.py:665(insert_rows)
        2    0.000    0.000   39.426   19.713 dataset.py:674(process_input_query)
        2    0.000    0.000   39.426   19.713 dataset.py:651(create_pre_udf_table)
   109667    1.217    0.000   34.698    0.000 udf.py:43(run)
311002897/311002132   29.518    0.000   29.518    0.000 {built-in method _abc._abc_subclasscheck}
       23    0.000    0.000   29.039    1.263 sqlite.py:158(executemany)
       23   10.652    0.463   29.036    1.262 {method 'executemany' of 'sqlite3.Connection' objects}
   109667   10.402    0.000   28.332    0.000 warehouse.py:184(dataset_select_paginated)
   548310    0.053    0.000   26.113    0.000 types.py:31(adapt_array)
   548310   26.060    0.000   26.060    0.000 {built-in method ujson.dumps}
   548410    0.074    0.000   17.485    0.000 types.py:35(convert_array)
   548410   17.410    0.000   17.410    0.000 {built-in method ujson.loads}
        3    0.000    0.000   17.194    5.731 dataset.py:1225(cleanup)
        1    0.000    0.000   17.175   17.175 warehouse.py:903(cleanup_temp_tables)
        5    0.000    0.000   17.175    3.435 sqlite.py:213(drop_table)
   219326    0.055    0.000   15.786    0.000 main.py:166(__init__)
   219326   14.424    0.000   15.731    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
   109663    0.099    0.000   14.873    0.000 webdataset_laion.py:46(process_laion_meta)
       98    0.000    0.000   14.678    0.150 sqlite.py:140(execute)
      190   14.656    0.077   14.656    0.077 {method 'execute' of 'sqlite3.Connection' objects}
310487282/310485944   12.157    0.000   14.551    0.000 {built-in method builtins.hasattr}
   109664    0.143    0.000    5.036    0.000 udf.py:65(run_once)
   109664    0.143    0.000    4.437    0.000 udf.py:225(__call__)
   109664    0.086    0.000    3.544    0.000 udf.py:270(_parse_rows)
   109664    0.180    0.000    3.229    0.000 signal_schema.py:167(row_to_objs)
```

#### Memory usage
```
$ mprof run --include-children laion_emb.py
$ mprof plot
```

<img width="1372" alt="Pasted image 20240724175038" src="https://github.com/user-attachments/assets/0dd15a1a-7c24-4db5-a7f3-74784b42efae">

To compare, this is how "big" `2.9Gb`, `505671` row `npz` file memory consumption looks like:
<img width="1372" alt="Pasted image 20240724185544" src="https://github.com/user-attachments/assets/af3c49eb-c292-46b8-9c8a-62a87e7d81f4">

## Optimizing run time

#### flatten

From cProfile report we can see `flatten` function from `flatten.py:34` took 173 seconds out of 357 total, it is almost 50% of runtime.

Let's take a look at "call graph":
```
flatten (109663 calls, 173 sec cumtime)
  ↓
_flatten_fields_values (3070547 calls, 173 sec cumtime)
  ↓
is_pydantic (310234294 calls, 139 sec cumtime)
  ↓
issubclass (311009146 calls, 87 sec cumtime)
```
(note `issubclass` is called from both `_flatten_fields_values` and `is_pydantic`)

Huge amount of `is_pydantic` calls is result of checking and flatten arrays:
```python
if isinstance(value, list):  
    yield [  
        val.model_dump() if ModelStore.is_pydantic(type(val)) else val  
        for val in value  
    ]
```

Let's pretend all arrays are homogeneous (contains elements of the same type) and update the code:

```python
if isinstance(value, list):  
    if len(value) == 0:  
        yield []  
    # Optimization: Assume arrays are homogeneous, so check first element only  
    # to avoid unnecessary iterations.    elif ModelStore.is_pydantic(type(value[0])):  
        yield [val.model_dump() for val in value]
    else:  
        yield value
```

See [this commit](https://github.com/iterative/datachain/commit/af2a82b0fcc102b2fbc4b2bc5426794d35c57979). Checking:

Run time:
```
$ time python laion_emb.py
Listing file:///: 5 objects [00:00, 1697.69 objects/s]
Processed: 1 rows [00:00, 2431.48 rows/s]
Download: 643MB [01:07, 10.0MB/s]
Processed: 1 rows [01:07, 67.16s/ rows]
Generated: 109662 rows [01:06, 1636.93 rows/s]
Processed: 109662 rows [00:27, 3982.80 rows/s]
python laion_emb.py  84.98s user 39.34s system 68% cpu 3:02.77 total
$
```

Performance improvements:
```
Action     |  Original               |  After                  |  Speedup
-----------+-------------------------+-------------------------+-----------
Generated  |  01:51, 981.86 rows/s   |  01:06, 1636.93 rows/s  |  168%
Processed  |  00:33, 3250.94 rows/s  |  00:27, 3982.80 rows/s  |  122%
Total time |  3:46                   |  3:03                   |  123%
```

Profiling after this change:
```
         61127095 function calls (59750427 primitive calls) in 179.316 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   1856/1    0.015    0.000  178.307  178.307 {built-in method builtins.exec}
      2/1    0.000    0.000  178.307  178.307 laion_emb.py:1(<module>)
      2/1    0.001    0.000  178.307  178.307 dc.py:472(save)
      2/1    0.001    0.000  178.306  178.306 dataset.py:1627(save)
      4/3    0.001    0.000  127.395   42.465 dataset.py:1160(apply_steps)
      4/3    0.000    0.000  127.368   42.456 dataset.py:610(apply)
        3    0.146    0.049   96.273   32.091 dataset.py:460(populate_udf_table)
    18/17    0.061    0.003   94.666    5.569 threading.py:637(wait)
        3    1.501    0.500   70.027   23.342 dataset.py:385(process_udf_outputs)
    18/17    0.000    0.000   68.568    4.033 threading.py:323(wait)
    76/70   63.996    0.842   68.565    0.980 {method 'acquire' of '_thread.lock' objects}
      121    0.000    0.000   53.737    0.444 sqlite.py:68(wrapper)
       23    0.002    0.000   40.233    1.749 sqlite.py:665(insert_rows)
       23    0.000    0.000   33.497    1.456 sqlite.py:158(executemany)
       23   11.751    0.511   33.493    1.456 {method 'executemany' of 'sqlite3.Connection' objects}
   109667    1.213    0.000   32.152    0.000 udf.py:43(run)
        2    0.000    0.000   31.094   15.547 dataset.py:674(process_input_query)
        2    0.000    0.000   31.094   15.547 dataset.py:651(create_pre_udf_table)
   548310    0.053    0.000   26.182    0.000 types.py:31(adapt_array)
   548310   26.129    0.000   26.129    0.000 {built-in method ujson.dumps}
   109667    7.971    0.000   25.898    0.000 warehouse.py:184(dataset_select_paginated)
       98    0.000    0.000   20.240    0.207 sqlite.py:140(execute)
   109663    0.087    0.000   20.222    0.000 udf.py:147(<genexpr>)
      190   20.217    0.106   20.217    0.106 {method 'execute' of 'sqlite3.Connection' objects}
   328989    0.092    0.000   20.215    0.000 udf.py:251(<genexpr>)
   548410    0.073    0.000   17.507    0.000 types.py:35(convert_array)
   548410   17.435    0.000   17.435    0.000 {built-in method ujson.loads}
   219326    0.057    0.000   15.518    0.000 main.py:166(__init__)
   219326   14.178    0.000   15.460    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
   109663    0.098    0.000   14.630    0.000 webdataset_laion.py:46(process_laion_meta)
        3    0.000    0.000   10.197    3.399 dataset.py:1225(cleanup)
        1    0.000    0.000   10.179   10.179 warehouse.py:903(cleanup_temp_tables)
        5    0.000    0.000   10.179    2.036 sqlite.py:213(drop_table)
   109663    0.141    0.000    5.335    0.000 flatten.py:34(flatten)
3070547/1864265    0.965    0.000    5.193    0.000 flatten.py:44(_flatten_fields_values)
   109664    0.132    0.000    4.936    0.000 udf.py:65(run_once)
   109664    0.141    0.000    4.350    0.000 udf.py:225(__call__)
  1974412    0.343    0.000    4.049    0.000 model_store.py:70(is_pydantic)
   109664    0.085    0.000    3.473    0.000 udf.py:270(_parse_rows)
   109664    0.174    0.000    3.162    0.000 signal_schema.py:167(row_to_objs)
```

Note: another possible future optimization will be to cache result of `is_pydantic` function inside `ModelStore` class variable, but it is good for now.

#### ujson.dumps

Next good optimization is to take a look at the `ujson` library. It is good and much faster than standart `json` package, but we can do better. There is one more good library for json serialization/deserialization: `orjson` (https://github.com/ijl/orjson), one good reason to use it is because it serializes [dataclass](https://github.com/ijl/orjson?tab=readme-ov-file#dataclass) and [numpy](https://github.com/ijl/orjson?tab=readme-ov-file#numpy) instances natively.

Replace `ujson` with `orjson` with some updates in the code, see [this commit](https://github.com/iterative/datachain/commit/9611c9e9444db4627d0960b566ab47b7d3234692). Checking:

Run time:
```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2380.42 rows/s]
Download: 643MB [00:42, 16.0MB/s]
Processed: 1 rows [00:42, 42.18s/ rows]
Generated: 109662 rows [00:42, 2609.50 rows/s]
Processed: 109662 rows [00:17, 6229.83 rows/s]
python laion_emb.py  58.35s user 38.27s system 69% cpu 2:18.21 total
$
```

Performance improvements:
```
Action     |  Original               |  After                  |  Speedup
-----------+-------------------------+-------------------------+-----------
Generated  |  01:51, 981.86 rows/s   |  00:42, 2609.50 rows/s  |  264%
Processed  |  00:33, 3250.94 rows/s  |  00:17, 6229.83 rows/s  |  194%
Total time |  3:46                   |  2:18                   |  164%
```

Profiling after this change:
```
         62155971 function calls (60606396 primitive calls) in 162.015 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   1857/1    0.015    0.000  161.030  161.030 {built-in method builtins.exec}
      2/1    0.000    0.000  161.030  161.030 laion_emb.py:1(<module>)
      2/1    0.002    0.001  161.029  161.029 dc.py:472(save)
      2/1    0.002    0.001  161.027  161.027 dataset.py:1627(save)
      4/3    0.002    0.001  112.335   37.445 dataset.py:1160(apply_steps)
      4/3    0.000    0.000  112.267   37.422 dataset.py:610(apply)
    17/16    0.071    0.004   90.583    5.661 threading.py:637(wait)
        3    0.149    0.050   72.709   24.236 dataset.py:460(populate_udf_table)
    17/16    0.000    0.000   66.963    4.185 threading.py:323(wait)
    72/66   66.538    0.924   66.961    1.015 {method 'acquire' of '_thread.lock' objects}
      121    0.000    0.000   45.493    0.376 sqlite.py:68(wrapper)
        2    0.000    0.000   39.556   19.778 dataset.py:674(process_input_query)
        2    0.000    0.000   39.555   19.778 dataset.py:651(create_pre_udf_table)
        3    1.336    0.445   38.802   12.934 dataset.py:385(process_udf_outputs)
   109667    1.189    0.000   24.760    0.000 udf.py:43(run)
       23    0.002    0.000   24.018    1.044 sqlite.py:665(insert_rows)
       23    0.000    0.000   23.074    1.003 sqlite.py:158(executemany)
       23   12.913    0.561   23.069    1.003 {method 'executemany' of 'sqlite3.Connection' objects}
       98    0.000    0.000   22.419    0.229 sqlite.py:140(execute)
      190   22.394    0.118   22.394    0.118 {method 'execute' of 'sqlite3.Connection' objects}
   109663    0.087    0.000   20.283    0.000 udf.py:147(<genexpr>)
   328989    0.089    0.000   20.277    0.000 udf.py:251(<genexpr>)
   109667   11.839    0.000   18.476    0.000 warehouse.py:184(dataset_select_paginated)
   219326    0.056    0.000   15.631    0.000 main.py:166(__init__)
   219326   14.278    0.000   15.576    0.000 {method 'validate_python' of 'pydantic_core._pydantic_core.SchemaValidator' objects}
   109663    0.097    0.000   14.729    0.000 webdataset_laion.py:46(process_laion_meta)
        3    0.000    0.000   13.595    4.532 dataset.py:1225(cleanup)
        1    0.000    0.000   13.575   13.575 warehouse.py:903(cleanup_temp_tables)
        5    0.000    0.000   13.575    2.715 sqlite.py:213(drop_table)
   548310    0.047    0.000   10.450    0.000 types.py:31(adapt_array)
   548310   10.403    0.000   10.403    0.000 {orjson.dumps}
      450    0.158    0.000   10.162    0.023 std.py:1325(refresh)
   548410    0.074    0.000    6.013    0.000 types.py:35(convert_array)
   548410    5.940    0.000    5.940    0.000 {orjson.loads}
   109663    0.139    0.000    5.112    0.000 flatten.py:34(flatten)
   109664    0.134    0.000    4.994    0.000 udf.py:65(run_once)
3070547/1864265    0.958    0.000    4.974    0.000 flatten.py:44(_flatten_fields_values)
   109664    0.139    0.000    4.406    0.000 udf.py:225(__call__)
  1974412    0.341    0.000    3.842    0.000 model_store.py:70(is_pydantic)
   109664    0.082    0.000    3.523    0.000 udf.py:270(_parse_rows)
   109664    0.178    0.000    3.211    0.000 signal_schema.py:167(row_to_objs)
```

# Things to think about next

Overall speedup looks like not a big deal, but the bottleneck now is SQLite insert performance. Out of 162 seconds total:
- `populate_udf_table` took 73 seconds, including:
	- `process_udf_outputs` — 39 seconds, including:
		- `insert_rows` — 24 seconds
- `create_pre_udf_table` took 40 seconds
- `drop_table` took another 14 seconds

It is possible to speed up SQLite by disabling `WAL`:
```diff
- db.execute("PRAGMA journal_mode = WAL")
+ db.execute("PRAGMA journal_mode = OFF")
```

```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2584.29 rows/s]
Download: 643MB [00:38, 17.3MB/s]
Processed: 1 rows [00:38, 38.90s/ rows]
Generated: 109662 rows [00:38, 2830.63 rows/s]
Processed: 109662 rows [00:11, 9430.43 rows/s]
python laion_emb.py  47.06s user 19.07s system 89% cpu 1:14.00 total
$
```

Performance improvements:
```
Action     |  Original               |  After                  |  Speedup
-----------+-------------------------+-------------------------+-----------
Generated  |  01:51, 981.86 rows/s   |  00:38, 2830.63 rows/s  |  292%
Processed  |  00:33, 3250.94 rows/s  |  00:11, 9430.43 rows/s  |  300%
Total time |  3:46                   |  1:14                   |  305%
```