### PR TITLE
allow File.read outside of a UDF

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -17,6 +17,7 @@ from PIL import Image
 from pydantic import Field, field_validator
 
 from datachain.cache import UniqueId
+from datachain.catalog.loader import get_catalog
 from datachain.client.fileslice import FileSlice
 from datachain.lib.data_model import DataModel
 from datachain.lib.utils import DataChainError
@@ -194,6 +195,11 @@ class File(DataModel):
                 yield f
 
         uid = self.get_uid()
+        if not self._catalog:
+            kwargs = {"caching_enabled": self._caching_enabled}
+            if hasattr(self, "_download_cb"):
+                kwargs["download_cb"] = self._download_cb
+            self._set_stream(get_catalog(), **kwargs)
         client = self._catalog.get_client(self.source)
         if self._caching_enabled:
             client.download(uid, callback=self._download_cb)

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -135,7 +135,6 @@ def test_read_binary_data(tmp_path, catalog: Catalog):
         fd.write(data)
 
     file = File(name=file_name, source=f"file://{tmp_path}")
-    file._set_stream(catalog, False)
     assert file.read() == data
 
 
@@ -148,7 +147,6 @@ def test_read_binary_data_as_text(tmp_path, catalog: Catalog):
         fd.write(data)
 
     file = TextFile(name=file_name, source=f"file://{tmp_path}")
-    file._set_stream(catalog, False)
     try:
         x = file.read()
     except UnicodeDecodeError:  # Unix
@@ -179,12 +177,10 @@ def test_save_binary_data(tmp_path, catalog: Catalog):
         fd.write(data)
 
     file1 = File(name=file1_name, source=f"file://{tmp_path}")
-    file1._set_stream(catalog, False)
 
     file1.save(tmp_path / file2_name)
 
     file2 = File(name=file2_name, source=f"file://{tmp_path}")
-    file2._set_stream(catalog, False)
     assert file2.read() == data
 
 
@@ -197,12 +193,10 @@ def test_save_text_data(tmp_path, catalog: Catalog):
         fd.write(data)
 
     file1 = TextFile(name=file1_name, source=f"file://{tmp_path}")
-    file1._set_stream(catalog, False)
 
     file1.save(tmp_path / file2_name)
 
     file2 = TextFile(name=file2_name, source=f"file://{tmp_path}")
-    file2._set_stream(catalog, False)
     assert file2.read() == data
 
 
@@ -216,12 +210,10 @@ def test_save_image_data(tmp_path, catalog: Catalog):
     image.save(tmp_path / file1_name)
 
     file1 = ImageFile(name=file1_name, source=f"file://{tmp_path}")
-    file1._set_stream(catalog, False)
 
     file1.save(tmp_path / file2_name)
 
     file2 = ImageFile(name=file2_name, source=f"file://{tmp_path}")
-    file2._set_stream(catalog, False)
     assert images_equal(image, file2.read())
 
 
@@ -301,7 +293,6 @@ def test_read_length(tmp_path, catalog):
         fd.write(data)
 
     file = File(name=file_name, source=f"file://{tmp_path}")
-    file._set_stream(catalog, False)
     assert file.read(length=4) == data[:4]
 
 
@@ -314,7 +305,6 @@ def test_read_bytes(tmp_path, catalog):
         fd.write(data)
 
     file = File(name=file_name, source=f"file://{tmp_path}")
-    file._set_stream(catalog, False)
     assert file.read_bytes() == data
 
 
@@ -327,5 +317,4 @@ def test_read_text(tmp_path, catalog):
         fd.write(data)
 
     file = File(name=file_name, source=f"file://{tmp_path}")
-    file._set_stream(catalog, True)
     assert file.read_text() == data

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -38,7 +38,6 @@ def test_image_file(tmp_path, catalog):
     IMAGE.save(file_path)
 
     file = ImageFile(name=file_name, source=f"file://{tmp_path}")
-    file._set_stream(catalog, caching_enabled=False)
     assert isinstance(file.read(), Image.Image)
 
 


### PR DESCRIPTION
Needed for the following type of use case (from `docs/index.md`):

```python
import matplotlib.pyplot as plt
import re
from textwrap import wrap

def trim_text(text):
    match = re.search(r'[A-Z][^.]*\.', text)
    return match.group(0) if match else ''

images = chain.collect("file")
captions = chain.collect("scene")
_ , axes = plt.subplots(1, len(captions), figsize=(15, 5))

for ax, img, caption in zip(axes, images, captions):
    ax.imshow(img.read(),cmap='gray')
    ax.axis('off')
    wrapped_caption = "\n".join(wrap(trim_text(caption), 30))
    ax.set_title(wrapped_caption, fontsize=6)

plt.show()
```