### PR TITLE
Support for `DataChain.batch_map()`

### DIFF
--- a/docs/references/udf.md
+++ b/docs/references/udf.md
@@ -13,6 +13,8 @@ steps need to happen before or after the processing function runs.
 
 ::: datachain.lib.udf.Aggregator
 
+::: datachain.lib.udf.BatchMapper
+
 ::: datachain.lib.udf.Generator
 
 ::: datachain.lib.udf.Mapper

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -238,7 +238,6 @@ class DataChain(DatasetQuery):
     def settings(
         self,
         cache=None,
-        batch=None,
         parallel=None,
         workers=None,
         min_task_size=None,
@@ -251,7 +250,6 @@ class DataChain(DatasetQuery):
 
         Parameters:
             cache : data caching (default=False)
-            batch : size of batch to insert to warehouse (default=10000)
             parallel : number of thread for processors. True is a special value to
                 enable all available CPUs (default=1)
             workers : number of distributed workers. Only for Studio mode. (default=1)
@@ -269,7 +267,7 @@ class DataChain(DatasetQuery):
         chain = self.clone()
         if sys is not None:
             chain._sys = sys
-        chain._settings.add(Settings(cache, batch, parallel, workers, min_task_size))
+        chain._settings.add(Settings(cache, parallel, workers, min_task_size))
         return chain
 
     def reset_settings(self, settings: Optional[Settings] = None) -> "Self":
@@ -696,7 +694,7 @@ class DataChain(DatasetQuery):
         func: Optional[Callable] = None,
         params: Union[None, str, Sequence[str]] = None,
         output: OutputType = None,
-        batch: int = 0,
+        batch: int = 1000,
         **signal_map,
     ) -> "Self":
         """This is a batch version of `map()`.
@@ -706,8 +704,7 @@ class DataChain(DatasetQuery):
         It accepts the same parameters plus an
         additional parameter:
 
-            batch : Size of each batch passed to `func`. Defaults to
-                    `DataChain._settings.batch`.
+            batch : Size of each batch passed to `func`. Defaults to 1000.
 
         Example:
             ```py
@@ -721,7 +718,7 @@ class DataChain(DatasetQuery):
         udf_obj = self._udf_to_obj(BatchMapper, func, params, output, signal_map)
         chain = DatasetQuery.add_signals(
             self,
-            udf_obj.to_udf_wrapper(batch or self._settings.batch),
+            udf_obj.to_udf_wrapper(batch),
             **self._settings.to_dict(),
         )
 

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -539,7 +539,9 @@ class DataChain(DatasetQuery):
 
             Using func and output as a map:
             ```py
-            chain = chain.map(lambda name: name[:-4] + ".json", output={"res": str})
+            chain = chain.map(
+                lambda name: name.split("."), output={"stem": str, "ext": str}
+            )
             chain.save("new_dataset")
             ```
         """
@@ -559,7 +561,7 @@ class DataChain(DatasetQuery):
         output: OutputType = None,
         **signal_map,
     ) -> "Self":
-        """Apply a function to each row to create new rows (with potentially new
+        r"""Apply a function to each row to create new rows (with potentially new
         signals). The function needs to return a new objects for each of the new rows.
         It returns a chain itself with new signals.
 
@@ -569,6 +571,15 @@ class DataChain(DatasetQuery):
         one key differences: It produces a sequence of rows for each input row (like
         extracting multiple file records from a single tar file or bounding boxes from a
         single image file).
+
+        Example:
+            ```py
+            chain = chain.gen(
+                line=lambda file: [l for l in file.read().split("\n")],
+                output=str,
+            )
+            chain.save("new_dataset")
+            ```
         """
         udf_obj = self._udf_to_obj(Generator, func, params, output, signal_map)
         chain = DatasetQuery.generate(
@@ -593,12 +604,22 @@ class DataChain(DatasetQuery):
 
         Input-output relationship: N:M
 
-        This method bears similarity to `gen()` and map(), employing a comparable set of
-        parameters, yet differs in two crucial aspects:
+        This method bears similarity to `gen()` and `map()`, employing a comparable set
+        of parameters, yet differs in two crucial aspects:
         1. The `partition_by` parameter: This specifies the column name or a list of
            column names that determine the grouping criteria for aggregation.
         2. Group-based UDF function input: Instead of individual rows, the function
            receives a list all rows within each group defined by `partition_by`.
+
+        Example:
+            ```py
+            chain = chain.agg(
+                total=lambda category, amount: [sum(amount)],
+                output=float,
+                partition_by="category",
+            )
+            chain.save("new_dataset")
+            ```
         """
         udf_obj = self._udf_to_obj(Aggregator, func, params, output, signal_map)
         chain = DatasetQuery.generate(
@@ -618,18 +639,27 @@ class DataChain(DatasetQuery):
         batch: int = 0,
         **signal_map,
     ) -> "Self":
-        """This is a batch version of map().
+        """This is a batch version of `map()`.
 
-        Input-output relationship: N:M
+        Input-output relationship: N:N
 
         It accepts the same parameters plus an
         additional parameter:
 
             batch : Size of each batch passed to `func`. Defaults to
                     `DataChain._settings.batch`.
+
+        Example:
+            ```py
+            chain = chain.batch_map(
+                sqrt=lambda size: np.sqrt(size),
+                output=float
+            )
+            chain.save("new_dataset")
+            ```
         """
         udf_obj = self._udf_to_obj(BatchMapper, func, params, output, signal_map)
-        chain = DatasetQuery.generate(
+        chain = DatasetQuery.add_signals(
             self,
             udf_obj.to_udf_wrapper(batch or self._settings.batch),
             **self._settings.to_dict(),

--- a/src/datachain/lib/settings.py
+++ b/src/datachain/lib/settings.py
@@ -1,5 +1,4 @@
 from datachain.lib.utils import DataChainParamsError
-from datachain.query.dataset import INSERT_BATCH_SIZE
 
 
 class SettingsError(DataChainParamsError):
@@ -8,11 +7,8 @@ class SettingsError(DataChainParamsError):
 
 
 class Settings:
-    def __init__(
-        self, cache=None, batch=None, parallel=None, workers=None, min_task_size=None
-    ):
+    def __init__(self, cache=None, parallel=None, workers=None, min_task_size=None):
         self._cache = cache
-        self._batch = batch
         self.parallel = parallel
         self._workers = workers
         self.min_task_size = min_task_size
@@ -21,12 +17,6 @@ class Settings:
             raise SettingsError(
                 "'cache' argument must be bool"
                 f" while {cache.__class__.__name__} was given"
-            )
-
-        if not isinstance(batch, int) and batch is not None:
-            raise SettingsError(
-                "'batch' argument must be int or None"
-                f" while {batch.__class__.__name__} was given"
             )
 
         if not isinstance(parallel, int) and parallel is not None:
@@ -56,10 +46,6 @@ class Settings:
         return self._cache if self._cache is not None else False
 
     @property
-    def batch(self):
-        return self._batch if self._batch is not None else INSERT_BATCH_SIZE
-
-    @property
     def workers(self):
         return self._workers if self._workers is not None else False
 
@@ -67,8 +53,6 @@ class Settings:
         res = {}
         if self._cache is not None:
             res["cache"] = self.cache
-        if self._batch is not None:
-            res["batch"] = self.batch
         if self.parallel is not None:
             res["parallel"] = self.parallel
         if self._workers is not None:
@@ -79,7 +63,6 @@ class Settings:
 
     def add(self, settings: "Settings"):
         self._cache = settings._cache or self._cache
-        self._batch = settings._batch or self._batch
         self.parallel = settings.parallel or self.parallel
         self._workers = settings._workers or self._workers
         self.min_task_size = settings.min_task_size or self.min_task_size

--- a/src/datachain/lib/settings.py
+++ b/src/datachain/lib/settings.py
@@ -1,4 +1,5 @@
 from datachain.lib.utils import DataChainParamsError
+from datachain.query.dataset import INSERT_BATCH_SIZE
 
 
 class SettingsError(DataChainParamsError):
@@ -56,7 +57,7 @@ class Settings:
 
     @property
     def batch(self):
-        return self._batch if self._batch is not None else 1
+        return self._batch if self._batch is not None else INSERT_BATCH_SIZE
 
     @property
     def workers(self):

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -225,11 +225,10 @@ class UDFBase(AbstractUDF):
     def __call__(self, *rows, cache, download_cb):
         if self.is_input_grouped:
             objs = self._parse_grouped_rows(rows[0], cache, download_cb)
+        elif self.is_input_batched:
+            objs = zip(*self._parse_rows(rows[0], cache, download_cb))
         else:
-            objs = self._parse_rows(rows, cache, download_cb)
-
-        if not self.is_input_batched:
-            objs = objs[0]
+            objs = self._parse_rows([rows], cache, download_cb)[0]
 
         result_objs = self.process_safe(objs)
 
@@ -268,8 +267,6 @@ class UDFBase(AbstractUDF):
         return res
 
     def _parse_rows(self, rows, cache, download_cb):
-        if not self.is_input_batched:
-            rows = [rows]
         objs = []
         for row in rows:
             obj_row = self.params.row_to_objs(row)

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -263,6 +263,15 @@ class UDFBase(AbstractUDF):
             )
             if isinstance(res[0], tuple):
                 res = res[0]
+        elif (
+            self.is_input_batched
+            and self.is_output_batched
+            and not self.is_input_grouped
+        ):
+            res = list(res)
+            assert len(res) == len(rows[0]), (
+                f"{self.name} returns {len(res)} " f"rows while len(rows[0]) expected"
+            )
 
         return res
 
@@ -327,7 +336,9 @@ class Mapper(UDFBase):
     """Inherit from this class to pass to `DataChain.map()`."""
 
 
-class BatchMapper(Mapper):
+class BatchMapper(UDFBase):
+    """Inherit from this class to pass to `DataChain.batch_map()`."""
+
     is_input_batched = True
     is_output_batched = True
 

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -258,9 +258,9 @@ class UDFBase(AbstractUDF):
 
         if not self.is_output_batched:
             res = list(res)
-            assert len(res) == 1, (
-                f"{self.name} returns {len(res)} " f"rows while it's not batched"
-            )
+            assert (
+                len(res) == 1
+            ), f"{self.name} returns {len(res)} rows while it's not batched"
             if isinstance(res[0], tuple):
                 res = res[0]
         elif (
@@ -269,9 +269,9 @@ class UDFBase(AbstractUDF):
             and not self.is_input_grouped
         ):
             res = list(res)
-            assert len(res) == len(rows[0]), (
-                f"{self.name} returns {len(res)} " f"rows while len(rows[0]) expected"
-            )
+            assert len(res) == len(
+                rows[0]
+            ), f"{self.name} returns {len(res)} rows while len(rows[0]) expected"
 
         return res
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -381,7 +381,7 @@ def process_udf_outputs(
     udf_table: "Table",
     udf_results: Iterator[Iterable["UDFResult"]],
     udf: UDFBase,
-    batch: int = INSERT_BATCH_SIZE,
+    batch_size=INSERT_BATCH_SIZE,
     cb: Callback = DEFAULT_CALLBACK,
 ) -> None:
     rows: list[UDFResult] = []
@@ -394,13 +394,13 @@ def process_udf_outputs(
         for row in udf_output:
             cb.relative_update()
             rows.append(adjust_outputs(warehouse, row, udf_col_types))
-            if len(rows) >= batch:
-                for row_chunk in batched(rows, batch):
+            if len(rows) >= batch_size:
+                for row_chunk in batched(rows, batch_size):
                     warehouse.insert_rows(udf_table, row_chunk)
                 rows.clear()
 
     if rows:
-        for row_chunk in batched(rows, batch):
+        for row_chunk in batched(rows, batch_size):
             warehouse.insert_rows(udf_table, row_chunk)
 
 
@@ -430,7 +430,6 @@ class UDFStep(Step, ABC):
     min_task_size: Optional[int] = None
     is_generator = False
     cache: bool = False
-    batch: int = INSERT_BATCH_SIZE
 
     @abstractmethod
     def create_udf_table(self, query: Select) -> "Table":
@@ -546,7 +545,6 @@ class UDFStep(Step, ABC):
                             udf_table,
                             udf_results,
                             udf,
-                            batch=self.batch,
                             cb=generated_cb,
                         )
                     finally:
@@ -1526,7 +1524,6 @@ class DatasetQuery:
         min_task_size: Optional[int] = None,
         partition_by: Optional[PartitionByType] = None,
         cache: bool = False,
-        batch: int = INSERT_BATCH_SIZE,
     ) -> "Self":
         """
         Adds one or more signals based on the results from the provided UDF.
@@ -1555,7 +1552,6 @@ class DatasetQuery:
                 workers=workers,
                 min_task_size=min_task_size,
                 cache=cache,
-                batch=batch,
             )
         )
         return query
@@ -1585,7 +1581,6 @@ class DatasetQuery:
         min_task_size: Optional[int] = None,
         partition_by: Optional[PartitionByType] = None,
         cache: bool = False,
-        batch: int = INSERT_BATCH_SIZE,
     ) -> "Self":
         if isinstance(udf, UDFClassWrapper):  # type: ignore[unreachable]
             # This is a bare decorated class, "instantiate" it now.
@@ -1601,7 +1596,6 @@ class DatasetQuery:
                 workers=workers,
                 min_task_size=min_task_size,
                 cache=cache,
-                batch=batch,
             )
         )
         return query

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -434,7 +434,7 @@ def test_batch_map(catalog):
         assert x.my_name == test_fr.my_name
 
 
-def test_batch_map_agg(catalog):
+def test_batch_map_wrong_size(catalog):
     class _TestFr(BaseModel):
         total: int
         names: str
@@ -450,7 +450,8 @@ def test_batch_map_agg(catalog):
         output={"x": _TestFr},
     )
 
-    assert list(dc.collect("x")) == [_TestFr(total=9, names="n1-n2-n1")]
+    with pytest.raises(AssertionError):
+        list(dc.collect())
 
 
 def test_batch_map_two_params(catalog):


### PR DESCRIPTION
Fixes #84.

I think we should keep open #170. That request seems to be specifically about using futures to batch individual results using the existing `.map` without needing a separate `.batch_map()`. I think `.batch_map()` may be both simpler to implement and explain for now, but I think we could come back to the ideas in #170 in the future.