### PR TITLE
prevent cryptic error messages when running llm claude examples

### DIFF
--- a/examples/llm_and_nlp/llm-claude-aggregate-query.py
+++ b/examples/llm_and_nlp/llm-claude-aggregate-query.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import anthropic
 from anthropic.types import Message
@@ -24,6 +25,11 @@ TEMPERATURE = 0.9
 DEFAULT_OUTPUT_TOKENS = 1024
 
 API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+
+if not API_KEY:
+    print("This example requires an Anthropic API key")
+    print("Add your key using the ANTHROPIC_API_KEY environment variable.")
+    sys.exit(0)
 
 
 chain = (

--- a/examples/llm_and_nlp/llm-claude-simple-query.py
+++ b/examples/llm_and_nlp/llm-claude-simple-query.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 import anthropic
 from anthropic.types import Message
@@ -25,6 +26,11 @@ TEMPERATURE = 0.9
 DEFAULT_OUTPUT_TOKENS = 1024
 
 API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+
+if not API_KEY:
+    print("This example requires an Anthropic API key")
+    print("Add your key using the ANTHROPIC_API_KEY environment variable.")
+    sys.exit(0)
 
 
 class Rating(BaseModel):

--- a/examples/llm_and_nlp/llm-claude.py
+++ b/examples/llm_and_nlp/llm-claude.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import anthropic
 from anthropic.types import Message
@@ -12,6 +13,12 @@ TEMPERATURE = 0.9
 DEFAULT_OUTPUT_TOKENS = 1024
 
 API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+
+if not API_KEY:
+    print("This example requires an Anthropic API key")
+    print("Add your key using the ANTHROPIC_API_KEY environment variable.")
+    sys.exit(0)
+
 
 chain = (
     DataChain.from_storage(DATA, type="text")


### PR DESCRIPTION
Small UX improvement for these scripts when a user tries to run them without first setting an API key. Without an API key they will be presented with something like:


```
Processed: 50 rows [00:00, 17568.50 rows/s]
============== Error in user code: 'Mapper' ==============
Traceback (most recent call last):
  File "/datachain/src/datachain/lib/udf.py", line 156, in process
    return self._func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/examples/llm_and_nlp/llm-claude.py", line 23, in <lambda>
    claude=lambda client, file: client.messages.create(
                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_utils/_utils.py", line 277, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/resources/messages.py", line 902, in create
    return self._post(
           ^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 1266, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 942, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 968, in _request
    request = self._build_request(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 461, in _build_request
    headers = self._build_headers(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 416, in _build_headers
    self._validate_headers(headers_dict, custom_headers)
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_client.py", line 192, in _validate_headers
    raise TypeError(
TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
============== Error in user code: 'Mapper' ==============
==========================================================
Process Worker-UDF-0:
Traceback (most recent call last):
  File "/datachain/src/datachain/lib/udf.py", line 156, in process
    return self._func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/examples/llm_and_nlp/llm-claude.py", line 23, in <lambda>
    claude=lambda client, file: client.messages.create(
                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_utils/_utils.py", line 277, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/resources/messages.py", line 902, in create
    return self._post(
           ^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 1266, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 942, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 968, in _request
    request = self._build_request(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 461, in _build_request
    headers = self._build_headers(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 416, in _build_headers
    self._validate_headers(headers_dict, custom_headers)
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_client.py", line 192, in _validate_headers
    raise TypeError(
TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
Traceback (most recent call last):
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 314, in _bootstrap
    self.run()
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/datachain/src/datachain/query/dispatch.py", line 234, in _run_worker
    worker.run()
  File "/datachain/src/datachain/query/dispatch.py", line 392, in run
    for udf_output in udf_results:
  File "/datachain/src/datachain/lib/udf.py", line 58, in run
    output = self.run_once(catalog, batch, is_generator, cache, cb=download_cb)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 82, in run_once
    udf_outputs = self.inner(*udf_inputs, cache=cache, download_cb=cb)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 234, in __call__
    result_objs = self.process_safe(objs)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 323, in process_safe
    raise DataChainError(
datachain.lib.utils.DataChainError: Error in user code in class 'Mapper': "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
==========================================================
Process Worker-UDF-2:
Traceback (most recent call last):
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 314, in _bootstrap
    self.run()
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/datachain/src/datachain/query/dispatch.py", line 234, in _run_worker
    worker.run()
  File "/datachain/src/datachain/query/dispatch.py", line 392, in run
    for udf_output in udf_results:
  File "/datachain/src/datachain/lib/udf.py", line 58, in run
    output = self.run_once(catalog, batch, is_generator, cache, cb=download_cb)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 82, in run_once
    udf_outputs = self.inner(*udf_inputs, cache=cache, download_cb=cb)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 234, in __call__
    result_objs = self.process_safe(objs)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 323, in process_safe
    raise DataChainError(
datachain.lib.utils.DataChainError: Error in user code in class 'Mapper': "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
============== Error in user code: 'Mapper' ==============
Traceback (most recent call last):
  File "/datachain/src/datachain/lib/udf.py", line 156, in process
    return self._func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/examples/llm_and_nlp/llm-claude.py", line 23, in <lambda>
    claude=lambda client, file: client.messages.create(
                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_utils/_utils.py", line 277, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/resources/messages.py", line 902, in create
    return self._post(
           ^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 1266, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 942, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 968, in _request
    request = self._build_request(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 461, in _build_request
    headers = self._build_headers(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 416, in _build_headers
    self._validate_headers(headers_dict, custom_headers)
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_client.py", line 192, in _validate_headers
    raise TypeError(
TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
==========================================================
Process Worker-UDF-1:
Traceback (most recent call last):
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 314, in _bootstrap
    self.run()
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/datachain/src/datachain/query/dispatch.py", line 234, in _run_worker
    worker.run()
  File "/datachain/src/datachain/query/dispatch.py", line 392, in run
    for udf_output in udf_results:
  File "/datachain/src/datachain/lib/udf.py", line 58, in run
    output = self.run_once(catalog, batch, is_generator, cache, cb=download_cb)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 82, in run_once
    udf_outputs = self.inner(*udf_inputs, cache=cache, download_cb=cb)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 234, in __call__
    result_objs = self.process_safe(objs)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 323, in process_safe
    raise DataChainError(
datachain.lib.utils.DataChainError: Error in user code in class 'Mapper': "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
============== Error in user code: 'Mapper' ==============
Traceback (most recent call last):
  File "/datachain/src/datachain/lib/udf.py", line 156, in process
    return self._func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/examples/llm_and_nlp/llm-claude.py", line 23, in <lambda>
    claude=lambda client, file: client.messages.create(
                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_utils/_utils.py", line 277, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/resources/messages.py", line 902, in create
    return self._post(
           ^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 1266, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 942, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 968, in _request
    request = self._build_request(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 461, in _build_request
    headers = self._build_headers(options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_base_client.py", line 416, in _build_headers
    self._validate_headers(headers_dict, custom_headers)
  File "/datachain/.env/lib/python3.12/site-packages/anthropic/_client.py", line 192, in _validate_headers
    raise TypeError(
TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
==========================================================
Process Worker-UDF-3:
Traceback (most recent call last):
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 314, in _bootstrap
    self.run()
  File "/datachain/.env/lib/python3.12/site-packages/multiprocess/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/datachain/src/datachain/query/dispatch.py", line 234, in _run_worker
    worker.run()
  File "/datachain/src/datachain/query/dispatch.py", line 392, in run
    for udf_output in udf_results:
  File "/datachain/src/datachain/lib/udf.py", line 58, in run
    output = self.run_once(catalog, batch, is_generator, cache, cb=download_cb)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 82, in run_once
    udf_outputs = self.inner(*udf_inputs, cache=cache, download_cb=cb)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 234, in __call__
    result_objs = self.process_safe(objs)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/udf.py", line 323, in process_safe
    raise DataChainError(
datachain.lib.utils.DataChainError: Error in user code in class 'Mapper': "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/datachain/src/datachain/__main__.py", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/datachain/src/datachain/cli.py", line 933, in main
    return udf_entrypoint()
           ^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/query/dispatch.py", line 129, in udf_entrypoint
    process_udf_outputs(warehouse, table, udf_results, udf, cb=generated_cb)
  File "/datachain/src/datachain/query/dataset.py", line 391, in process_udf_outputs
    for udf_output in udf_results:
  File "/datachain/src/datachain/query/dispatch.py", line 313, in run_udf_parallel
    raise exc
datachain.lib.utils.DataChainError: Error in user code in class 'Mapper': "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
Traceback (most recent call last):
  File "/datachain/examples/llm_and_nlp/llm-claude.py", line 39, in <module>
    chain.show()
  File "/datachain/src/datachain/lib/dc.py", line 1143, in show
    df = dc.to_pandas(flatten)
         ^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/dc.py", line 1123, in to_pandas
    transposed_result = list(map(list, zip(*self.results())))
                                            ^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/dc.py", line 821, in results
    return list(self.collect_flatten())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/lib/dc.py", line 806, in collect_flatten
    with super().select(*db_signals).as_iterable() as rows:
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/datachain/src/datachain/query/dataset.py", line 1256, in as_iterable
    query = self.apply_steps().select()
            ^^^^^^^^^^^^^^^^^^
  File "/datachain/src/datachain/query/dataset.py", line 1196, in apply_steps
    result = step.apply(
             ^^^^^^^^^^^
  File "/datachain/src/datachain/query/dataset.py", line 625, in apply
    self.populate_udf_table(udf_table, query)
  File "/datachain/src/datachain/query/dataset.py", line 516, in populate_udf_table
    raise RuntimeError("UDF Execution Failed!")
RuntimeError: UDF Execution Failed!
```