### PR TITLE
Fix for nested lists of models in schema

### DIFF
--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -41,21 +41,22 @@ def flatten_list(obj_list):
     )
 
 
-def _flatten_fields_values(fields, obj: BaseModel):
-    def _flatten_list(value):
-        assert isinstance(value, list)
-        if value and ModelStore.is_pydantic(type(value[0])):
-            return [val.model_dump() for val in value]
-        if value and isinstance(value[0], list):
-            return [_flatten_list(v) for v in value]
-        return value
+def _flatten_list_field(value: list):
+    assert isinstance(value, list)
+    if value and ModelStore.is_pydantic(type(value[0])):
+        return [val.model_dump() for val in value]
+    if value and isinstance(value[0], list):
+        return [_flatten_list_field(v) for v in value]
+    return value
 
+
+def _flatten_fields_values(fields, obj: BaseModel):
     for name, f_info in fields.items():
         anno = f_info.annotation
         # Optimization: Access attributes directly to skip the model_dump() call.
         value = getattr(obj, name)
         if isinstance(value, list):
-            yield _flatten_list(value)
+            yield _flatten_list_field(value)
         elif isinstance(value, dict):
             yield {
                 key: val.model_dump() if ModelStore.is_pydantic(type(val)) else val

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -46,7 +46,7 @@ def _flatten_fields_values(fields, obj: BaseModel):
         assert isinstance(value, list)
         if value and ModelStore.is_pydantic(type(value[0])):
             return [val.model_dump() for val in value]
-        if isinstance(value[0], list):
+        if value and isinstance(value[0], list):
             return [_flatten_list(v) for v in value]
         return value
 

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -42,16 +42,20 @@ def flatten_list(obj_list):
 
 
 def _flatten_fields_values(fields, obj: BaseModel):
+    def _flatten_list(value):
+        assert isinstance(value, list)
+        if value and ModelStore.is_pydantic(type(value[0])):
+            return [val.model_dump() for val in value]
+        if isinstance(value[0], list):
+            return [_flatten_list(v) for v in value]
+        return value
+
     for name, f_info in fields.items():
         anno = f_info.annotation
         # Optimization: Access attributes directly to skip the model_dump() call.
         value = getattr(obj, name)
-
         if isinstance(value, list):
-            if value and ModelStore.is_pydantic(type(value[0])):
-                yield [val.model_dump() for val in value]
-            else:
-                yield value
+            yield _flatten_list(value)
         elif isinstance(value, dict):
             yield {
                 key: val.model_dump() if ModelStore.is_pydantic(type(val)) else val

--- a/src/datachain/sql/types.py
+++ b/src/datachain/sql/types.py
@@ -12,6 +12,7 @@ for sqlite we can use `sqlite.register_converter`
 ( https://docs.python.org/3/library/sqlite3.html#sqlite3.register_converter )
 """
 
+import json
 from datetime import datetime
 from types import MappingProxyType
 from typing import Any, Union
@@ -247,7 +248,10 @@ class Array(SQLType):
         return type_defaults(dialect).array()
 
     def on_read_convert(self, value, dialect):
-        return read_converter(dialect).array(value, self.item_type, dialect)
+        r = read_converter(dialect).array(value, self.item_type, dialect)
+        if isinstance(self.item_type, JSON):
+            r = [json.loads(item) if isinstance(item, str) else item for item in r]
+        return r
 
 
 class JSON(SQLType):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import BaseModel
 
 from datachain import Column
+from datachain.lib.data_model import DataModel
 from datachain.lib.dc import C, DataChain, Sys
 from datachain.lib.file import File
 from datachain.lib.signal_schema import (
@@ -1055,3 +1056,37 @@ def test_from_values_array_of_floats():
     chain = DataChain.from_values(emd=embeddings)
 
     assert list(chain.collect("emd")) == embeddings
+
+
+def test_custom_model_with_nested_lists():
+    ds_name = "nested"
+
+    class Trace(BaseModel):
+        x: float
+        y: float
+
+    class Nested(BaseModel):
+        values: list[list[float]]
+        traces_single: list[Trace]
+        traces_double: list[list[Trace]]
+
+    DataModel.register(Nested)
+
+    DataChain.from_values(
+        nested=[
+            Nested(
+                values=[[0.5, 0.5], [0.6, 0.6]],
+                traces_single=[{"x": 0.5, "y": 0.5}, {"x": 0.6, "y": 0.6}],
+                traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.6, "y": 0.6}]],
+            )
+        ],
+        nums=[1],
+    ).save(ds_name)
+
+    assert list(DataChain(name=ds_name).collect("nested")) == [
+        Nested(
+            values=[[0.5, 0.5], [0.6, 0.6]],
+            traces_single=[{"x": 0.5, "y": 0.5}, {"x": 0.6, "y": 0.6}],
+            traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.6, "y": 0.6}]],
+        )
+    ]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1090,9 +1090,9 @@ def test_custom_model_with_nested_lists():
     DataChain.from_values(
         nested=[
             Nested(
-                values=[[0.5, 0.5], [0.6, 0.6]],
-                traces_single=[{"x": 0.5, "y": 0.5}, {"x": 0.6, "y": 0.6}],
-                traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.6, "y": 0.6}]],
+                values=[[0.5, 0.5], [0.5, 0.5]],
+                traces_single=[{"x": 0.5, "y": 0.5}, {"x": 0.5, "y": 0.5}],
+                traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.5, "y": 0.5}]],
             )
         ],
         nums=[1],
@@ -1100,8 +1100,8 @@ def test_custom_model_with_nested_lists():
 
     assert list(DataChain(name=ds_name).collect("nested")) == [
         Nested(
-            values=[[0.5, 0.5], [0.6, 0.6]],
-            traces_single=[{"x": 0.5, "y": 0.5}, {"x": 0.6, "y": 0.6}],
-            traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.6, "y": 0.6}]],
+            values=[[0.5, 0.5], [0.5, 0.5]],
+            traces_single=[{"x": 0.5, "y": 0.5}, {"x": 0.5, "y": 0.5}],
+            traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.5, "y": 0.5}]],
         )
     ]

--- a/tests/unit/lib/test_feature.py
+++ b/tests/unit/lib/test_feature.py
@@ -65,6 +65,53 @@ def test_flatten_nested():
     assert flatten(t1) == ("sfo", "sf", 567, {"42": 999}, 1849)
 
 
+def test_flatten_list_field():
+    class Trace(BaseModel):
+        x: int
+        y: int
+
+    class Nested(BaseModel):
+        traces: list[Trace]
+
+    n = Nested(traces=[Trace(x=1, y=1), Trace(x=2, y=2)])
+    assert flatten(n) == ([{"x": 1, "y": 1}, {"x": 2, "y": 2}],)
+
+
+def test_flatten_nested_list_field():
+    class Trace(BaseModel):
+        x: int
+        y: int
+
+    class Nested(BaseModel):
+        traces: list[list[Trace]]
+
+    n = Nested(traces=[[Trace(x=1, y=1)], [Trace(x=2, y=2)]])
+    assert flatten(n) == ([[{"x": 1, "y": 1}], [{"x": 2, "y": 2}]],)
+
+
+def test_flatten_multiple_nested_list_field():
+    class Trace(BaseModel):
+        x: int
+        y: int
+
+    class Nested(BaseModel):
+        traces: list[list[list[Trace]]]
+
+    n = Nested(
+        traces=[
+            [[Trace(x=1, y=1)], [Trace(x=2, y=2)]],
+            [[Trace(x=3, y=3)], [Trace(x=4, y=4)]],
+        ]
+    )
+
+    assert flatten(n) == (
+        [
+            [[{"x": 1, "y": 1}], [{"x": 2, "y": 2}]],
+            [[{"x": 3, "y": 3}], [{"x": 4, "y": 4}]],
+        ],
+    )
+
+
 def test_flatten_list():
     t1 = FileInfo(parent="p1", name="n4", size=3, location={"a": "b"})
     t2 = FileInfo(parent="p2", name="n5", size=2, location={"c": "d"})


### PR DESCRIPTION
The problem was if we had `list[list[SomeModel]]` as a field in our custom model as flattening worked only for one level of lists with models.

This PR fixes `flatten(obj)` function to be able to flatten any number of nested lists and adds tests.