### PR TITLE
Parallel UDF optimizations

### DIFF
--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from datachain.catalog import Catalog
-    from datachain.query.batch import RowsInput, UDFInput
+    from datachain.query.batch import RowsOutput, UDFInput
     from datachain.query.udf import UDFResult
 
 
@@ -37,7 +37,7 @@ class UDFAdapter(_UDFBase):
     def __init__(
         self,
         inner: "UDFBase",
-        properties: "UDFProperties",
+        properties: UDFProperties,
     ):
         self.inner = inner
         super().__init__(properties)
@@ -45,7 +45,7 @@ class UDFAdapter(_UDFBase):
     def run(
         self,
         udf_fields: "Sequence[str]",
-        udf_inputs: "Iterable[RowsInput]",
+        udf_inputs: "Iterable[RowsOutput]",
         catalog: "Catalog",
         is_generator: bool,
         cache: bool,

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -1,6 +1,5 @@
 import sys
 import traceback
-from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Callable, Optional
 
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
@@ -14,16 +13,19 @@ from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.udf_signature import UdfSignature
 from datachain.lib.utils import AbstractUDF, DataChainError, DataChainParamsError
-from datachain.query.batch import RowBatch
+from datachain.query.batch import UDFInputBatch
 from datachain.query.schema import ColumnParameter
 from datachain.query.udf import UDFBase as _UDFBase
-from datachain.query.udf import UDFProperties, UDFResult
+from datachain.query.udf import UDFProperties
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
     from typing_extensions import Self
 
     from datachain.catalog import Catalog
-    from datachain.query.batch import BatchingResult
+    from datachain.query.batch import RowsInput, UDFInput
+    from datachain.query.udf import UDFResult
 
 
 class UdfError(DataChainParamsError):
@@ -35,29 +37,34 @@ class UDFAdapter(_UDFBase):
     def __init__(
         self,
         inner: "UDFBase",
-        properties: UDFProperties,
+        properties: "UDFProperties",
     ):
         self.inner = inner
         super().__init__(properties)
 
     def run(
         self,
-        udf_inputs: "Iterable[BatchingResult]",
+        udf_fields: "Sequence[str]",
+        udf_inputs: "Iterable[RowsInput]",
         catalog: "Catalog",
         is_generator: bool,
         cache: bool,
         download_cb: Callback = DEFAULT_CALLBACK,
         processed_cb: Callback = DEFAULT_CALLBACK,
-    ) -> Iterator[Iterable["UDFResult"]]:
+    ) -> "Iterator[Iterable[UDFResult]]":
         self.inner._catalog = catalog
         if hasattr(self.inner, "setup") and callable(self.inner.setup):
             self.inner.setup()
 
-        for batch in udf_inputs:
-            n_rows = len(batch.rows) if isinstance(batch, RowBatch) else 1
-            output = self.run_once(catalog, batch, is_generator, cache, cb=download_cb)
-            processed_cb.relative_update(n_rows)
-            yield output
+        yield from super().run(
+            udf_fields,
+            udf_inputs,
+            catalog,
+            is_generator,
+            cache,
+            download_cb,
+            processed_cb,
+        )
 
         if hasattr(self.inner, "teardown") and callable(self.inner.teardown):
             self.inner.teardown()
@@ -65,12 +72,12 @@ class UDFAdapter(_UDFBase):
     def run_once(
         self,
         catalog: "Catalog",
-        arg: "BatchingResult",
+        arg: "UDFInput",
         is_generator: bool = False,
         cache: bool = False,
         cb: Callback = DEFAULT_CALLBACK,
-    ) -> Iterable[UDFResult]:
-        if isinstance(arg, RowBatch):
+    ) -> "Iterable[UDFResult]":
+        if isinstance(arg, UDFInputBatch):
             udf_inputs = [
                 self.bind_parameters(catalog, row, cache=cache, cb=cb)
                 for row in arg.rows

--- a/src/datachain/query/batch.py
+++ b/src/datachain/query/batch.py
@@ -5,21 +5,29 @@ from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
-import sqlalchemy as sa
-
 from datachain.data_storage.schema import PARTITION_COLUMN_ID
 from datachain.data_storage.warehouse import SELECT_BATCH_SIZE
 
 if TYPE_CHECKING:
+    from sqlalchemy import Select
+
     from datachain.dataset import RowDict
 
 
 @dataclass
-class RowBatch:
+class RowsInputBatch:
+    rows: Sequence[Sequence]
+
+
+RowsInput = Union[Sequence, RowsInputBatch]
+
+
+@dataclass
+class UDFInputBatch:
     rows: Sequence["RowDict"]
 
 
-BatchingResult = Union["RowDict", RowBatch]
+UDFInput = Union["RowDict", UDFInputBatch]
 
 
 class BatchingStrategy(ABC):
@@ -28,9 +36,9 @@ class BatchingStrategy(ABC):
     @abstractmethod
     def __call__(
         self,
-        execute: Callable,
-        query: sa.sql.selectable.Select,
-    ) -> Generator[BatchingResult, None, None]:
+        execute: Callable[..., Generator[Sequence, None, None]],
+        query: "Select",
+    ) -> Generator[RowsInput, None, None]:
         """Apply the provided parameters to the UDF."""
 
 
@@ -42,10 +50,10 @@ class NoBatching(BatchingStrategy):
 
     def __call__(
         self,
-        execute: Callable,
-        query: sa.sql.selectable.Select,
-    ) -> Generator["RowDict", None, None]:
-        return execute(query, limit=query._limit, order_by=query._order_by_clauses)
+        execute: Callable[..., Generator[Sequence, None, None]],
+        query: "Select",
+    ) -> Generator[Sequence, None, None]:
+        return execute(query)
 
 
 class Batch(BatchingStrategy):
@@ -59,31 +67,24 @@ class Batch(BatchingStrategy):
 
     def __call__(
         self,
-        execute: Callable,
-        query: sa.sql.selectable.Select,
-    ) -> Generator[RowBatch, None, None]:
+        execute: Callable[..., Generator[Sequence, None, None]],
+        query: "Select",
+    ) -> Generator[RowsInputBatch, None, None]:
         # choose page size that is a multiple of the batch size
         page_size = math.ceil(SELECT_BATCH_SIZE / self.count) * self.count
 
         # select rows in batches
-        results: list[RowDict] = []
+        results: list[Sequence] = []
 
-        with contextlib.closing(
-            execute(
-                query,
-                page_size=page_size,
-                limit=query._limit,
-                order_by=query._order_by_clauses,
-            )
-        ) as rows:
+        with contextlib.closing(execute(query, page_size=page_size)) as rows:
             for row in rows:
                 results.append(row)
                 if len(results) >= self.count:
                     batch, results = results[: self.count], results[self.count :]
-                    yield RowBatch(batch)
+                    yield RowsInputBatch(batch)
 
             if len(results) > 0:
-                yield RowBatch(results)
+                yield RowsInputBatch(results)
 
 
 class Partition(BatchingStrategy):
@@ -95,27 +96,30 @@ class Partition(BatchingStrategy):
 
     def __call__(
         self,
-        execute: Callable,
-        query: sa.sql.selectable.Select,
-    ) -> Generator[RowBatch, None, None]:
+        execute: Callable[..., Generator[Sequence, None, None]],
+        query: "Select",
+    ) -> Generator[RowsInputBatch, None, None]:
         current_partition: Optional[int] = None
-        batch: list[RowDict] = []
+        batch: list[Sequence] = []
 
-        with contextlib.closing(
-            execute(
-                query,
-                order_by=(PARTITION_COLUMN_ID, "sys__id", *query._order_by_clauses),
-                limit=query._limit,
-            )
-        ) as rows:
+        query_fields = [str(c.name) for c in query.selected_columns]
+        partition_column_idx = query_fields.index(PARTITION_COLUMN_ID)
+
+        ordered_query = query.order_by(None).order_by(
+            PARTITION_COLUMN_ID,
+            "sys__id",
+            *query._order_by_clauses,
+        )
+
+        with contextlib.closing(execute(ordered_query)) as rows:
             for row in rows:
-                partition = row[PARTITION_COLUMN_ID]
+                partition = row[partition_column_idx]
                 if current_partition != partition:
                     current_partition = partition
                     if len(batch) > 0:
-                        yield RowBatch(batch)
+                        yield RowsInputBatch(batch)
                         batch = []
                 batch.append(row)
 
             if len(batch) > 0:
-                yield RowBatch(batch)
+                yield RowsInputBatch(batch)

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -461,6 +461,8 @@ class UDFStep(Step, ABC):
 
         processes = determine_processes(self.parallel)
 
+        udf_fields = [str(c.name) for c in query.selected_columns]
+
         try:
             if workers:
                 from datachain.catalog.loader import get_distributed_class
@@ -473,6 +475,7 @@ class UDFStep(Step, ABC):
                     query,
                     workers,
                     processes,
+                    udf_fields=udf_fields,
                     is_generator=self.is_generator,
                     use_partitioning=use_partitioning,
                     cache=self.cache,
@@ -489,6 +492,7 @@ class UDFStep(Step, ABC):
                     "warehouse_clone_params": self.catalog.warehouse.clone_params(),
                     "table": udf_table,
                     "query": query,
+                    "udf_fields": udf_fields,
                     "batching": batching,
                     "processes": processes,
                     "is_generator": self.is_generator,
@@ -519,7 +523,6 @@ class UDFStep(Step, ABC):
                     udf = self.udf
 
                 warehouse = self.catalog.warehouse
-                udf_fields = [str(c.name) for c in query.selected_columns]
 
                 with contextlib.closing(
                     batching(warehouse.dataset_select_paginated, query)

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1248,7 +1248,7 @@ class DatasetQuery:
             query = self.apply_steps().select()
             query_fields = [str(c.name) for c in query.selected_columns]
 
-            def row_iter() -> Generator[RowDict, None, None]:
+            def row_iter() -> Generator[Sequence, None, None]:
                 # warehouse isn't threadsafe, we need to clone() it
                 # in the thread that uses the results
                 with self.catalog.warehouse.clone() as warehouse:

--- a/src/datachain/query/queue.py
+++ b/src/datachain/query/queue.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import msgpack
 
-from datachain.query.batch import RowsInput, RowsInputBatch
+from datachain.query.batch import RowsOutput, RowsOutputBatch
 
 DEFAULT_BATCH_SIZE = 10000
 STOP_SIGNAL = "STOP"
@@ -70,7 +70,7 @@ def _msgpack_pack_extended_types(obj: Any) -> msgpack.ExtType:
         data = (obj.timestamp(),)  # type: ignore   # noqa: PGH003
         return msgpack.ExtType(MSGPACK_EXT_TYPE_DATETIME, pack("!d", *data))
 
-    if isinstance(obj, RowsInputBatch):
+    if isinstance(obj, RowsOutputBatch):
         return msgpack.ExtType(
             MSGPACK_EXT_TYPE_ROWS_INPUT_BATCH,
             msgpack_pack(obj.rows),
@@ -101,7 +101,7 @@ def _msgpack_unpack_extended_types(code: int, data: bytes) -> Any:
         return datetime.datetime.fromtimestamp(timestamp, tz=tz_info)
 
     if code == MSGPACK_EXT_TYPE_ROWS_INPUT_BATCH:
-        return RowsInputBatch(msgpack_unpack(data))
+        return RowsOutputBatch(msgpack_unpack(data))
 
     return msgpack.ExtType(code, data)
 
@@ -110,11 +110,11 @@ def msgpack_unpack(data: bytes) -> Any:
     return msgpack.unpackb(data, ext_hook=_msgpack_unpack_extended_types)
 
 
-def marshal(obj: Iterator[RowsInput]) -> Iterable[bytes]:
+def marshal(obj: Iterator[RowsOutput]) -> Iterable[bytes]:
     for row in obj:
         yield msgpack_pack(row)
 
 
-def unmarshal(obj: Iterator[bytes]) -> Iterable[RowsInput]:
+def unmarshal(obj: Iterator[bytes]) -> Iterable[RowsOutput]:
     for row in obj:
         yield msgpack_unpack(row)

--- a/src/datachain/query/queue.py
+++ b/src/datachain/query/queue.py
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import Iterator, Generator, Iterable
+from collections.abc import Iterable, Iterator
 from queue import Empty, Full, Queue
 from struct import pack, unpack
 from time import sleep
@@ -7,7 +7,7 @@ from typing import Any
 
 import msgpack
 
-from datachain.query.batch import RowsInputBatch, RowsInput
+from datachain.query.batch import RowsInput, RowsInputBatch
 
 DEFAULT_BATCH_SIZE = 10000
 STOP_SIGNAL = "STOP"

--- a/src/datachain/query/queue.py
+++ b/src/datachain/query/queue.py
@@ -1,0 +1,120 @@
+import datetime
+from collections.abc import Iterator, Generator, Iterable
+from queue import Empty, Full, Queue
+from struct import pack, unpack
+from time import sleep
+from typing import Any
+
+import msgpack
+
+from datachain.query.batch import RowsInputBatch, RowsInput
+
+DEFAULT_BATCH_SIZE = 10000
+STOP_SIGNAL = "STOP"
+OK_STATUS = "OK"
+FINISHED_STATUS = "FINISHED"
+FAILED_STATUS = "FAILED"
+NOTIFY_STATUS = "NOTIFY"
+
+
+# For more context on the get_from_queue and put_into_queue functions, see the
+# discussion here:
+# https://github.com/iterative/dvcx/pull/1297#issuecomment-2026308773
+# This problem is not exactly described by, but is also related to these Python issues:
+# https://github.com/python/cpython/issues/66587
+# https://github.com/python/cpython/issues/88628
+# https://github.com/python/cpython/issues/108645
+
+
+def get_from_queue(queue: Queue) -> Any:
+    """
+    Gets an item from a queue.
+    This is required to handle signals, such as KeyboardInterrupt exceptions
+    while waiting for items to be available, although only on certain installations.
+    (See the above comment for more context.)
+    """
+    while True:
+        try:
+            return queue.get_nowait()
+        except Empty:
+            sleep(0.01)
+
+
+def put_into_queue(queue: Queue, item: Any) -> None:
+    """
+    Puts an item into a queue.
+    This is required to handle signals, such as KeyboardInterrupt exceptions
+    while waiting for items to be queued, although only on certain installations.
+    (See the above comment for more context.)
+    """
+    while True:
+        try:
+            queue.put_nowait(item)
+            return
+        except Full:
+            sleep(0.01)
+
+
+MSGPACK_EXT_TYPE_DATETIME = 42
+MSGPACK_EXT_TYPE_ROWS_INPUT_BATCH = 43
+
+
+def _msgpack_pack_extended_types(obj: Any) -> msgpack.ExtType:
+    if isinstance(obj, datetime.datetime):
+        # packing date object as 1 or 2 variables, depending if timezone info is present
+        #   - timestamp
+        #   - [OPTIONAL] timezone offset from utc in seconds if timezone info exists
+        if obj.tzinfo:
+            data = (obj.timestamp(), int(obj.utcoffset().total_seconds()))  # type: ignore   # noqa: PGH003
+            return msgpack.ExtType(MSGPACK_EXT_TYPE_DATETIME, pack("!dl", *data))
+        data = (obj.timestamp(),)  # type: ignore   # noqa: PGH003
+        return msgpack.ExtType(MSGPACK_EXT_TYPE_DATETIME, pack("!d", *data))
+
+    if isinstance(obj, RowsInputBatch):
+        return msgpack.ExtType(
+            MSGPACK_EXT_TYPE_ROWS_INPUT_BATCH,
+            msgpack_pack(obj.rows),
+        )
+
+    raise TypeError(f"Unknown type: {obj}")
+
+
+def msgpack_pack(obj: Any) -> bytes:
+    return msgpack.packb(obj, default=_msgpack_pack_extended_types)
+
+
+def _msgpack_unpack_extended_types(code: int, data: bytes) -> Any:
+    if code == MSGPACK_EXT_TYPE_DATETIME:
+        has_timezone = False
+        if len(data) == 8:
+            # we send only timestamp without timezone if data is 8 bytes
+            values = unpack("!d", data)
+        else:
+            has_timezone = True
+            values = unpack("!dl", data)
+
+        timestamp = values[0]
+        tz_info = None
+        if has_timezone:
+            timezone_offset = values[1]
+            tz_info = datetime.timezone(datetime.timedelta(seconds=timezone_offset))
+        return datetime.datetime.fromtimestamp(timestamp, tz=tz_info)
+
+    if code == MSGPACK_EXT_TYPE_ROWS_INPUT_BATCH:
+        return RowsInputBatch(msgpack_unpack(data))
+
+    return msgpack.ExtType(code, data)
+
+
+def msgpack_unpack(data: bytes) -> Any:
+    return msgpack.unpackb(data, ext_hook=_msgpack_unpack_extended_types)
+
+
+def marshal(obj: Iterator[RowsInput]) -> Iterable[bytes]:
+    for row in obj:
+        yield msgpack_pack(row)
+
+
+def unmarshal(obj: Iterator[bytes]) -> Iterable[RowsInput]:
+    for row in obj:
+        yield msgpack_unpack(row)

--- a/src/datachain/query/udf.py
+++ b/src/datachain/query/udf.py
@@ -15,7 +15,14 @@ from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 
 from datachain.dataset import RowDict
 
-from .batch import Batch, BatchingStrategy, NoBatching, Partition, RowBatch
+from .batch import (
+    Batch,
+    BatchingStrategy,
+    NoBatching,
+    Partition,
+    RowsInputBatch,
+    UDFInputBatch,
+)
 from .schema import (
     UDFParameter,
     UDFParamSpec,
@@ -25,7 +32,7 @@ from .schema import (
 if TYPE_CHECKING:
     from datachain.catalog import Catalog
 
-    from .batch import BatchingResult
+    from .batch import RowsInput, UDFInput
 
 ColumnType = Any
 
@@ -107,7 +114,8 @@ class UDFBase:
 
     def run(
         self,
-        udf_inputs: "Iterable[BatchingResult]",
+        udf_fields: "Sequence[str]",
+        udf_inputs: "Iterable[RowsInput]",
         catalog: "Catalog",
         is_generator: bool,
         cache: bool,
@@ -115,15 +123,22 @@ class UDFBase:
         processed_cb: Callback = DEFAULT_CALLBACK,
     ) -> Iterator[Iterable["UDFResult"]]:
         for batch in udf_inputs:
-            n_rows = len(batch.rows) if isinstance(batch, RowBatch) else 1
-            output = self.run_once(catalog, batch, is_generator, cache, cb=download_cb)
+            if isinstance(batch, RowsInputBatch):
+                n_rows = len(batch.rows)
+                inputs: UDFInput = UDFInputBatch(
+                    [RowDict(zip(udf_fields, row)) for row in batch.rows]
+                )
+            else:
+                n_rows = 1
+                inputs = RowDict(zip(udf_fields, batch))
+            output = self.run_once(catalog, inputs, is_generator, cache, cb=download_cb)
             processed_cb.relative_update(n_rows)
             yield output
 
     def run_once(
         self,
         catalog: "Catalog",
-        arg: "BatchingResult",
+        arg: "UDFInput",
         is_generator: bool = False,
         cache: bool = False,
         cb: Callback = DEFAULT_CALLBACK,
@@ -199,12 +214,12 @@ class UDFWrapper(UDFBase):
     def run_once(
         self,
         catalog: "Catalog",
-        arg: "BatchingResult",
+        arg: "UDFInput",
         is_generator: bool = False,
         cache: bool = False,
         cb: Callback = DEFAULT_CALLBACK,
     ) -> Iterable[UDFResult]:
-        if isinstance(arg, RowBatch):
+        if isinstance(arg, UDFInputBatch):
             udf_inputs = [
                 self.bind_parameters(catalog, row, cache=cache, cb=cb)
                 for row in arg.rows

--- a/src/datachain/query/udf.py
+++ b/src/datachain/query/udf.py
@@ -20,7 +20,7 @@ from .batch import (
     BatchingStrategy,
     NoBatching,
     Partition,
-    RowsInputBatch,
+    RowsOutputBatch,
     UDFInputBatch,
 )
 from .schema import (
@@ -32,7 +32,7 @@ from .schema import (
 if TYPE_CHECKING:
     from datachain.catalog import Catalog
 
-    from .batch import RowsInput, UDFInput
+    from .batch import RowsOutput, UDFInput
 
 ColumnType = Any
 
@@ -115,7 +115,7 @@ class UDFBase:
     def run(
         self,
         udf_fields: "Sequence[str]",
-        udf_inputs: "Iterable[RowsInput]",
+        udf_inputs: "Iterable[RowsOutput]",
         catalog: "Catalog",
         is_generator: bool,
         cache: bool,
@@ -123,7 +123,7 @@ class UDFBase:
         processed_cb: Callback = DEFAULT_CALLBACK,
     ) -> Iterator[Iterable["UDFResult"]]:
         for batch in udf_inputs:
-            if isinstance(batch, RowsInputBatch):
+            if isinstance(batch, RowsOutputBatch):
                 n_rows = len(batch.rows)
                 inputs: UDFInput = UDFInputBatch(
                     [RowDict(zip(udf_fields, row)) for row in batch.rows]

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -10,7 +10,7 @@ import sys
 import time
 from collections.abc import Iterable, Iterator, Sequence
 from datetime import date, datetime, timezone
-from itertools import islice
+from itertools import chain, islice
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 from uuid import UUID
 
@@ -241,7 +241,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 def batched(iterable: Iterable[_T_co], n: int) -> Iterator[tuple[_T_co, ...]]:
-    "Batch data into tuples of length n. The last batch may be shorter."
+    """Batch data into tuples of length n. The last batch may be shorter."""
     # Based on: https://docs.python.org/3/library/itertools.html#itertools-recipes
     # batched('ABCDEFG', 3) --> ABC DEF G
     if n < 1:
@@ -249,6 +249,21 @@ def batched(iterable: Iterable[_T_co], n: int) -> Iterator[tuple[_T_co, ...]]:
     it = iter(iterable)
     while batch := tuple(islice(it, n)):
         yield batch
+
+
+def batched_it(iterable: Iterable[_T_co], n: int) -> Iterator[Iterator[_T_co]]:
+    """Batch data into iterators of length n. The last batch may be shorter."""
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError("Batch size must be at least one")
+    it = iter(iterable)
+    while True:
+        chunk_it = islice(it, n)
+        try:
+            first_el = next(chunk_it)
+        except StopIteration:
+            return
+        yield chain((first_el,), chunk_it)
 
 
 def flatten(items):

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -3,7 +3,7 @@ from sqlalchemy import Integer
 
 from datachain.dataset import RowDict
 from datachain.query import udf
-from datachain.query.batch import RowBatch
+from datachain.query.batch import UDFInputBatch
 from datachain.query.schema import ColumnParameter
 
 
@@ -36,7 +36,7 @@ def test_udf_batching():
     results = []
     for row_id, (size, id) in enumerate(inputs):
         row = RowDict(sys__id=row_id, sys__rand=1234 + row_id, id=id, size=size)
-        batch = RowBatch([row])
+        batch = UDFInputBatch([row])
         result = t.run_once(None, batch)
         if result:
             assert len(result) == 1  # Matches batch size.


### PR DESCRIPTION
"Parallel" mode is not optimal now. It took more time and much more memory (script can even be killed by OOMKiller). In this PR we are going to profile and optimize parallel mode.

---

### Before optimization

Test dataset with `109662` rows:
```
$ ls -l dvcx-datacomp-small/metadata-small
total 1315952
-rw-r--r--@ 1 vlad  staff  673764696 Jul 24 17:15 036d6b9ae87a00e738f8fc554130b65b.npz
$
```

#### Single process mode

Test query `laion_emb.py`:
```python
from datachain.lib.dc import DataChain
from datachain.lib.webdataset_laion import process_laion_meta

(
    DataChain.from_storage("dvcx-datacomp-small/metadata-small/")
    .gen(emd=process_laion_meta)
    .map(stem=lambda file: file.get_file_stem(), params=["emd.file"], output=str)
    .save("laion_emb")
)
```

##### Run time

```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2532.79 rows/s]
Download: 643MB [00:53, 12.7MB/s]s]
Processed: 1 rows [00:53, 53.10s/ rows]
Generated: 109662 rows [00:52, 2071.59 rows/s]
Processed: 109662 rows [00:18, 6039.80 rows/s]
python laion_emb.py  58.26s user 37.74s system 62% cpu 2:32.64 total
$
```

##### Memory consumption

<img width="1372" alt="Pasted image 20240806224139" src="https://github.com/user-attachments/assets/21de7639-1fe9-43d8-bbe2-002160956483">

#### Parallel mode

Test query `laion_emb_parallel.py`:

```python
from datachain.lib.dc import DataChain
from datachain.lib.webdataset_laion import process_laion_meta

(
    DataChain.from_storage("dvcx-datacomp-small/metadata-small/")
    .settings(cache=True, parallel=4)
    .gen(emd=process_laion_meta)
    .map(stem=lambda file: file.get_file_stem(), params=["emd.file"], output=str)
    .save("laion_emb")
)
```

##### Run time

```
$ time python laion_emb_parallel.py
Processed: 1 rows [00:00, 2236.96 rows/s]
Processed: 1 rows [00:34, 34.10s/ rows]
Generated: 109662 rows [00:34, 3216.25 rows/s]
Processed: 109662 rows [03:54, 467.85 rows/s]
python laion_emb_parallel.py  372.29s user 61.47s system 84% cpu 8:30.86 total
$
```

##### Memory consumption

<img width="1372" alt="Pasted image 20240806225238" src="https://github.com/user-attachments/assets/b93316e8-8ec5-4e10-b749-8225dad303ce">

#### Comparing

```
 Action     | Single process        | Parallel              | Difference
------------+-----------------------+-----------------------+------------
 Generated  | 00:52, 2071.59 rows/s | 00:34, 3216.25 rows/s | 65%
 Processed  | 00:18, 6039.80 rows/s | 03:54,  467.85 rows/s | 1300%
 Total time | 02:32                 | 08:30                 | 336%
 Max memory | 3,2 Gb                | 15 Gb                 | 469%
```
Parallel mode is three times slower and take 4-5 times more memory.

#### Profiling

Let's profile "processing" step:

```
.map(stem=lambda file: file.get_file_stem(), params=["emd.file"], output=str)
```

#### Main process

```
         4409226518 function calls (3759456933 primitive calls) in 720.459 seconds

   Ordered by: cumulative time

   ncalls         tottime  percall cumtime  percall filename:lineno(function)
109665/109663      1.638    0.000 1643.795    0.015 /Users/vlad/work/iterative/datachain/src/datachain/query/dispatch.py:262(run_udf_parallel)
109667/109666      0.423    0.000  760.557    0.007 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/reduction.py:51(dumps)
109675/109674      0.081    0.000  727.287    0.007 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:418(dump)
323616022/109674  68.524    0.000  708.879    0.006 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:367(save)
109675/109674      0.179    0.000  708.331    0.006 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:470(dump)
323616022/109674 247.330    0.000  705.380    0.006 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:529(save)
2412816/109670     2.871    0.000  689.873    0.006 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:615(save_reduce)
109830/109670      0.646    0.000  664.102    0.006 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:970(_batch_setitems)
   548358          0.586    0.000  661.603    0.001 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:919(save_list)
   548358         29.646    0.000  630.127    0.001 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:932(_batch_appends)
109699/109698      0.290    0.000  412.868    0.004 {built-in method builtins.next}
308808192         63.378    0.000  146.392    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:776(save_float)
109664/109663      2.066    0.000   90.228    0.001 /Users/vlad/work/iterative/datachain/src/datachain/data_storage/warehouse.py:187(dataset_select_paginated)
323725696         46.299    0.000   68.786    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:211(commit_frame)
334694224         40.225    0.000   66.634    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:235(write)
   109666         0.056     0.000   63.358    0.001 /Users/vlad/work/iterative/datachain/src/datachain/query/dispatch.py:58(get_from_queue)
   219324         0.119     0.000   48.065    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/fsspec/callbacks.py:112(relative_update)
   109666         0.057     0.000   43.746    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/queues.py:137(get_nowait)
   109666         0.198     0.000   33.116    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/queues.py:101(get)
   109662         0.069     0.000   27.632    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/fsspec/callbacks.py:309(call)
326796653        27.490     0.000   27.490    0.000 {method 'get' of 'dict' objects}
335132904        25.960     0.000   25.960    0.000 {method 'write' of '_io.BytesIO' objects}
2413072/2193268   2.039     0.000   24.792    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:868(save_tuple)
315828804        21.915     0.000   21.915    0.000 {built-in method _struct.pack}
323835370        21.769     0.000   21.769    0.000 {method 'tell' of '_io.BytesIO' objects}
334474033        20.220     0.000   20.220    0.000 {built-in method builtins.getattr}
321421742        19.009     0.000   20.129    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:316(get)
348075682        18.344     0.000   18.344    0.000 {built-in method builtins.id}
   109662         0.063     0.000   18.231    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/tqdm/std.py:1198(update)
       11         0.007     0.001   16.315    1.483 /Users/vlad/work/iterative/datachain/src/datachain/data_storage/sqlite.py:666(insert_rows)
   109666         0.103     0.000   15.016    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:256(poll)
   109666         0.131     0.000   13.051    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:211(recv_bytes)
323616022        12.606     0.000   12.982    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:599(persistent_id)
       14         0.022     0.002   12.723    0.909 /Users/vlad/work/iterative/datachain/src/datachain/data_storage/sqlite.py:69(wrapper)
   658072         1.167     0.000   12.602    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:1750(save_type)
     6244         0.012     0.000   12.444    0.002 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/tqdm/std.py:1325(refresh)
   109666         0.150     0.000   12.357    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:432(_recv_bytes)
     6245         0.027     0.000   11.388    0.002 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/tqdm/std.py:1464(display)
   109666         0.150     0.000    9.715    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:185(send_bytes)
  9542462         5.320     0.000    9.456    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:485(memoize)
  3510012         2.393     0.000    7.910    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:845(save_str)
   109666         0.138     0.000    7.589    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:442(_poll)
   658092         1.060     0.000    7.583    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:1048(save_global)
     6245         0.043     0.000    6.994    0.001 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/tqdm/std.py:457(print_status)
   548310         0.257     0.000    6.839    0.000 /Users/vlad/work/iterative/datachain/src/datachain/sql/sqlite/types.py:34(convert_array)
   548310         6.582     0.000    6.582    0.000 {orjson.loads}
   109666         0.304     0.000    6.496    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:1125(wait)
     6245         0.041     0.000    5.556    0.001 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/tqdm/std.py:451(fp_write)
```

From `720` total seconds:

- `69 sec` is `dill.save`
- `247 sec` is `pickle.save`
- `30 sec` is `pickle._batch_appends`
- `63 sec` is `pickle.save_float`
- `46 sec` is `pickle.commit_frame`
- `40 sec` is `pickle.write`
- `168` more seconds on other conversion calls

It is ~`660` seconds summarized or ~`92%` of time for types conversion and pickling.

##### Subprocess (parallel worker)

```
         20331539 function calls (19619464 primitive calls) in 719.039 seconds

   Ordered by: cumulative time

   ncalls    tottime  percall  cumtime  percall filename:lineno(function)
27536/27535    0.397    0.000  756.787    0.027 /Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py:43(run)
27536/27535    0.021    0.000  750.928    0.027 /Users/vlad/work/iterative/datachain/src/datachain/query/dispatch.py:419(get_inputs)
    27535      0.151    0.000  750.903    0.027 /Users/vlad/work/iterative/datachain/src/datachain/query/dispatch.py:58(get_from_queue)
    57478    462.631    0.008  462.631    0.008 {built-in method time.sleep}
    25085      0.043    0.000  143.502    0.006 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:185(send_bytes)
    25085      0.031    0.000  143.454    0.006 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:409(_send_bytes)
    25085      0.028    0.000  143.408    0.006 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:384(_send)
137634/53453 140.569    0.001  140.512    0.003 {method 'acquire' of '_multiprocessing.SemLock' objects}
    25085    107.034    0.004  107.034    0.004 {built-in method posix.write}
    85013      0.027    0.000    4.398    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/queues.py:137(get_nowait)
    85013      0.106    0.000    4.371    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/queues.py:101(get)
    25086      0.071    0.000    2.290    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/reduction.py:51(dumps)
    25086      0.017    0.000    2.020    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:418(dump)
    70003      0.044    0.000    1.987    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/multiprocess/connection.py:256(poll)
    25086      0.047    0.000    1.983    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:470(dump)
    27534      0.068    0.000    1.949    0.000 /Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py:65(run_once)
    27535      0.014    0.000    1.872    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:291(loads)
    27535      0.061    0.000    1.858    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:283(load)
301032/25086   0.110    0.000    1.816    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:367(save)
301032/25086   0.359    0.000    1.793    0.000 /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pickle.py:529(save)
    27535      0.019    0.000    1.738    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:443(load)
    27535      1.115    0.000    1.716    0.000 {function Unpickler.load at 0x103436ca0}
50172/25086    0.086    0.000    1.710    0.000 /Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/dill/_dill.py:1195(save_module_dict)
    27534      0.065    0.000    1.704    0.000 /Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py:225(__call__)
```

From `719` total seconds:

- `463 sec` is `time.sleep` (waiting for a data in input queue using `queue.get_nowait`)
- `141 sec` is acquiring `_multiprocessing.SemLock`
- `107 sec` is writing to output queue


### Optimization

From these results it is clear the problem is in pickling/types conversion and writing/reading to/from multiprocessing queues.

Taking this steps to optimize this:
- return rows instead of dicts from SQL query (reduce memory consumption)
- marshal UDF rows with msgpack instead of dill (speedup pickling/types conversion)
- add batching to UDF results (speedup writing/reading to/from multiprocessing queues)

### Measurements after optimizations

#### Single process mode

##### Run time

```
$ time python laion_emb.py
Listing file:///: 1 objects [00:00, 378.34 objects/s]
Processed: 1 rows [00:00, 2864.96 rows/s]
Download: 643MB [00:42, 15.9MB/s]s]
Processed: 1 rows [00:42, 42.45s/ rows]
Generated: 109662 rows [00:42, 2594.06 rows/s]
Processed: 109662 rows [00:14, 7325.12 rows/s]
python laion_emb.py  55.90s user 36.86s system 73% cpu 2:05.88 total
$
```

##### Memory consumption

<img width="1372" alt="Pasted image 20240806233046" src="https://github.com/user-attachments/assets/21fda38b-fa75-415c-a56d-2528db7a7356">

##### Comparison

Difference with "before optimization" (just to be sure we don't break anything):

```
 Action     | Before                | After                 | Difference
------------+-----------------------+-----------------------+------------
 Generated  | 00:52, 2071.59 rows/s | 00:42, 2594.06 rows/s | 81%
 Processed  | 00:18, 6039.80 rows/s | 00:14, 7325.12 rows/s | 78%
 Total time | 02:32                 | 02:06                 | 83%
 Max memory | 3,2 Gb                | 3,2 Gb                | same
```

~`80%` faster after optimization with same amount of memory.

#### Parallel mode

##### Run time

```
$ time python laion_emb_parallel.py
Listing file:///: 1 objects [00:00, 343.18 objects/s]
Processed: 1 rows [00:00, 2866.92 rows/s]
Processed: 1 rows [00:02,  2.30s/ rows]rows/s]
Generated: 109662 rows [00:45, 2434.31 rows/s]
Processed: 109662 rows [00:20, 5329.11 rows/s]
python laion_emb_parallel.py  96.14s user 63.98s system 126% cpu 2:06.77 total
(datachain) ~/work/iterative/playground/laion
```

##### Memory consumption

<img width="1372" alt="Pasted image 20240806234514" src="https://github.com/user-attachments/assets/23d5a1d5-0658-4fa8-b580-50cd95e014e6">

##### Comparison

Difference with "before optimization" (just to be sure we don't break anything):

```
 Action     | Before                | After                 | Difference
------------+-----------------------+-----------------------+------------
 Generated  | 00:34, 3216.25 rows/s | 00:45, 2434.31 rows/s | 132%
 Processed  | 03:54,  467.85 rows/s | 00:20, 5329.11 rows/s | 9%
 Total time | 08:30                 | 02:07                 | 25%
 Max memory | 15 Gb                 | 3,6 Gb                | 23%
```

4 times faster and 4 times less memory.
"Processing" step was 13 times slower than in "single process" mode, now it is 10 times faster than before.

### Result

Overall now total time and max memory consumption is about the same as in single process mode.

For CPU-intensive jobs difference should be more visible.