### PR TITLE
test union of chains with different columns

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1010,14 +1010,12 @@ def fill_columns(
 
     result: list[list[ColumnElement]] = [[] for _ in column_dicts]
     for n in combined_columns:
-        col = next(col_dict[n] for col_dict in column_dicts if n in col_dict)
         for col_dict, out in zip(column_dicts, result):
             if n in col_dict:
                 out.append(col_dict[n])
             else:
-                # Cast the NULL to ensure all columns are aware of their type
                 # Label it to ensure it's aware of its name
-                out.append(sqlalchemy.cast(sqlalchemy.null(), col.type).label(n))
+                out.append(sqlalchemy.null().label(n))
     return result
 
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1148,6 +1148,28 @@ def test_union(catalog):
     assert sorted(chain3.collect("value")) == [1, 2, 3, 4]
 
 
+def test_union_different(catalog):
+    chain1 = DataChain.from_values(value=[1, 2], name=["chain", "more"])
+    chain2 = DataChain.from_values(value=[3, 4])
+    chain3 = chain1.union(chain2)
+    chain4 = chain2.union(chain1)
+    assert chain3.count() == chain4.count() == 4
+    assert sorted(chain3.collect()) == [(1, "chain"), (2, "more"), (3, None), (4, None)]
+    assert sorted(chain4.collect()) == [(1,), (2,), (3,), (4,)]
+
+
+def test_union_different_select(catalog):
+    chain1 = DataChain.from_values(value=[1, 2], name=["chain", "more"])
+    chain2 = DataChain.from_values(value=[3, 4], name=["or", "less"]).select_except(
+        "name"
+    )
+    chain3 = chain1.union(chain2)
+    chain4 = chain2.union(chain1)
+    assert chain3.count() == chain4.count() == 4
+    assert sorted(chain3.collect()) == [(1, "chain"), (2, "more"), (3, None), (4, None)]
+    assert sorted(chain4.collect()) == [(1,), (2,), (3,), (4,)]
+
+
 def test_subtract(catalog):
     chain1 = DataChain.from_values(a=[1, 1, 2], b=["x", "y", "z"])
     chain2 = DataChain.from_values(a=[1, 2], b=["x", "y"])


### PR DESCRIPTION
Closes https://github.com/iterative/dvcx/issues/1202

~Adds a regression test for the bug shown in the above issue which is no longer relevant.~

There is an issue in Clickhouse with `out.append(sqlalchemy.cast(sqlalchemy.null(), col.type).label(n))`

In order to fix the syntax / fields need to be updated to be Nullable, i.e. : 

```sql
63f81a59e8fe :) SELECT cast(Null,'Nullable(String)') as name FROM system.databases;

SELECT CAST(NULL, 'Nullable(String)') AS name
FROM system.databases

Query id: 27a1bb4c-8e70-4110-bca5-bd93f2c56adb

   ┌─name─┐
1. │ ᴺᵁᴸᴸ │
2. │ ᴺᵁᴸᴸ │
3. │ ᴺᵁᴸᴸ │
4. │ ᴺᵁᴸᴸ │
5. │ ᴺᵁᴸᴸ │
   └──────┘

5 rows in set. Elapsed: 0.010 sec.

63f81a59e8fe :) SELECT cast(Null,'String') as name FROM system.databases;

SELECT CAST(NULL, 'String') AS name
FROM system.databases

Query id: 4faa70fb-ac15-48c0-a604-140fe53aa36c


Elapsed: 0.006 sec.

Received exception from server (version 24.5.3):
Code: 70. DB::Exception: Received from localhost:9010. DB::Exception: Cannot convert NULL to a non-nullable type: In scope SELECT CAST(NULL, 'String') AS name FROM system.databases. (CANNOT_CONVERT_TYPE)
```