### PR TITLE
Arrow nrows fix

### DIFF
--- a/examples/get_started/json-csv-reader.py
+++ b/examples/get_started/json-csv-reader.py
@@ -90,7 +90,7 @@ def main():
     static_csv_ds.print_schema()
     print(static_csv_ds.to_pandas())
 
-    uri = "gs://datachain-demo/laion-aesthetics-csv"
+    uri = "gs://datachain-demo/laion-aesthetics-csv/laion_aesthetics_1024_33M_1.csv"
     print()
     print("========================================================================")
     print("dynamic CSV with header schema test parsing 3/3M objects")

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -54,7 +54,7 @@ class ArrowGenerator(Generator):
             )
         index = 0
         with tqdm(desc="Parsed by pyarrow", unit=" rows") as pbar:
-            for record_batch in ds.to_batches(use_threads=False):
+            for record_batch in ds.to_batches():
                 for record in record_batch.to_pylist():
                     vals = list(record.values())
                     if self.output_schema:

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -135,8 +135,8 @@ def _nrows_file(file: File, nrows: int) -> str:
     with file.open(mode="r") as reader:
         with open(tf.name, "a") as writer:
             for row, line in enumerate(reader):
-                writer.write(line)
-                writer.write("\n")
                 if row >= nrows:
                     break
+                writer.write(line)
+                writer.write("\n")
     return tf.name

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -7,7 +7,7 @@ import pyarrow as pa
 from pyarrow.dataset import dataset
 from tqdm import tqdm
 
-from datachain.lib.file import File, IndexedFile, TextFile
+from datachain.lib.file import File, IndexedFile
 from datachain.lib.udf import Generator
 
 if TYPE_CHECKING:
@@ -45,11 +45,6 @@ class ArrowGenerator(Generator):
 
     def process(self, file: File):
         if self.nrows:
-            if not isinstance(file, TextFile):
-                raise ValueError(
-                    "Error generating rows from Arrow table - "
-                    "`nrows` only supported for text file but binary file found."
-                )
             path = _nrows_file(file, self.nrows)
             ds = dataset(path, schema=self.input_schema, **self.kwargs)
         else:
@@ -135,9 +130,9 @@ def _arrow_type_mapper(col_type: pa.DataType) -> type:  # noqa: PLR0911
     raise TypeError(f"{col_type!r} datatypes not supported")
 
 
-def _nrows_file(file: TextFile, nrows: int) -> str:
+def _nrows_file(file: File, nrows: int) -> str:
     tf = NamedTemporaryFile(delete=False)
-    with file.open() as reader:
+    with file.open(mode="r") as reader:
         with open(tf.name, "a") as writer:
             for row, line in enumerate(reader):
                 writer.write(line)

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1263,7 +1263,19 @@ class DataChain(DatasetQuery):
             dc = dc.parse_tabular(format="json")
             ```
         """
+        from pyarrow.dataset import CsvFileFormat, JsonFileFormat
+
         from datachain.lib.arrow import ArrowGenerator, infer_schema, schema_to_output
+
+        if nrows:
+            format = kwargs.get("format")
+            if format not in ["csv", "json"] and not isinstance(
+                format, (CsvFileFormat, JsonFileFormat)
+            ):
+                raise ValueError(
+                    "Error in `parse_tabular` - "
+                    "`nrows` only supported for csv and json formats."
+                )
 
         schema = None
         col_names = output if isinstance(output, Sequence) else None
@@ -1346,7 +1358,7 @@ class DataChain(DatasetQuery):
         from pyarrow.csv import ParseOptions, ReadOptions
         from pyarrow.dataset import CsvFileFormat
 
-        chain = DataChain.from_storage(path, **kwargs, type="text")
+        chain = DataChain.from_storage(path, **kwargs)
 
         column_names = None
         if not header:

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1272,9 +1272,10 @@ class DataChain(DatasetQuery):
             if format not in ["csv", "json"] and not isinstance(
                 format, (CsvFileFormat, JsonFileFormat)
             ):
-                raise ValueError(
-                    "Error in `parse_tabular` - "
-                    "`nrows` only supported for csv and json formats."
+                raise DatasetPrepareError(
+                    self.name,
+                    "error in `parse_tabular` - "
+                    "`nrows` only supported for csv and json formats.",
                 )
 
         schema = None
@@ -1374,6 +1375,8 @@ class DataChain(DatasetQuery):
             else:
                 msg = f"error parsing csv - incompatible output type {type(output)}"
                 raise DatasetPrepareError(chain.name, msg)
+        elif nrows:
+            nrows += 1
 
         parse_options = ParseOptions(delimiter=delimiter)
         read_options = ReadOptions(column_names=column_names)

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1346,7 +1346,7 @@ class DataChain(DatasetQuery):
         from pyarrow.csv import ParseOptions, ReadOptions
         from pyarrow.dataset import CsvFileFormat
 
-        chain = DataChain.from_storage(path, **kwargs)
+        chain = DataChain.from_storage(path, **kwargs, type="text")
 
         column_names = None
         if not header:
@@ -1384,7 +1384,6 @@ class DataChain(DatasetQuery):
         object_name: str = "",
         model_name: str = "",
         source: bool = True,
-        nrows=None,
         **kwargs,
     ) -> "DataChain":
         """Generate chain from parquet files.
@@ -1397,7 +1396,6 @@ class DataChain(DatasetQuery):
             object_name : Created object column name.
             model_name : Generated model name.
             source : Whether to include info about the source file.
-            nrows : Optional row limit.
 
         Example:
             Reading a single file:
@@ -1416,7 +1414,6 @@ class DataChain(DatasetQuery):
             object_name=object_name,
             model_name=model_name,
             source=source,
-            nrows=None,
             format="parquet",
             partitioning=partitioning,
         )

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -317,9 +317,9 @@ class TextFile(File):
     """`DataModel` for reading text files."""
 
     @contextmanager
-    def open(self):
-        """Open the file and return a file object in text mode."""
-        with super().open(mode="r") as stream:
+    def open(self, mode: Literal["rb", "r"] = "r"):
+        """Open the file and return a file object (default to text mode)."""
+        with super().open(mode=mode) as stream:
             yield stream
 
     def read_text(self):

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -53,22 +53,6 @@ def test_arrow_generator_nrows(tmp_path, catalog):
     assert len(objs) == 2
 
 
-def test_arrow_generator_nrows_parquet(tmp_path, catalog):
-    ids = [12345, 67890, 34, 0xF0123]
-    texts = ["28", "22", "we", "hello world"]
-    df = pd.DataFrame({"id": ids, "text": texts})
-
-    name = "111.parquet"
-    pq_path = tmp_path / name
-    df.to_parquet(pq_path)
-    stream = File(name=name, parent=tmp_path.as_posix(), source="file:///")
-    stream._set_stream(catalog, caching_enabled=False)
-
-    func = ArrowGenerator(nrows=2)
-    with pytest.raises(ValueError):
-        list(func.process(stream))
-
-
 def test_arrow_generator_no_source(tmp_path, catalog):
     ids = [12345, 67890, 34, 0xF0123]
     texts = ["28", "22", "we", "hello world"]

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -10,7 +10,7 @@ from datachain.lib.arrow import (
     _arrow_type_mapper,
     schema_to_output,
 )
-from datachain.lib.file import File, IndexedFile, TextFile
+from datachain.lib.file import File, IndexedFile
 
 
 def test_arrow_generator(tmp_path, catalog):
@@ -34,23 +34,6 @@ def test_arrow_generator(tmp_path, catalog):
         assert o[0].index == index
         assert o[1] == id
         assert o[2] == text
-
-
-def test_arrow_generator_nrows(tmp_path, catalog):
-    ids = [12345, 67890, 34, 0xF0123]
-    texts = ["28", "22", "we", "hello world"]
-    df = pd.DataFrame({"id": ids, "text": texts})
-
-    name = "111.csv"
-    csv_path = tmp_path / name
-    df.to_csv(csv_path)
-    stream = TextFile(name=name, parent=tmp_path.as_posix(), source="file:///")
-    stream._set_stream(catalog, caching_enabled=False)
-
-    func = ArrowGenerator(nrows=2, format="csv")
-    objs = list(func.process(stream))
-
-    assert len(objs) == 2
 
 
 def test_arrow_generator_no_source(tmp_path, catalog):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -825,6 +825,14 @@ def test_parse_tabular_output_list(tmp_dir, catalog):
     assert df1.equals(df)
 
 
+def test_parse_tabular_nrows_invalid(tmp_dir, catalog):
+    df = pd.DataFrame(DF_DATA)
+    path = tmp_dir / "test.parquet"
+    df.to_parquet(path)
+    with pytest.raises(ValueError):
+        DataChain.from_storage(path.as_uri()).parse_tabular(nrows=2)
+
+
 def test_from_csv(tmp_dir, catalog):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.csv"
@@ -899,6 +907,15 @@ def test_from_csv_null_collect(tmp_dir, catalog):
     dc = DataChain.from_csv(path.as_uri(), object_name="csv")
     for i, row in enumerate(dc.collect()):
         assert row[1].height == height[i]
+
+
+def test_from_csv_nrows(tmp_dir, catalog):
+    df = pd.DataFrame(DF_DATA)
+    path = tmp_dir / "test.csv"
+    df.to_csv(path, index=False)
+    dc = DataChain.from_csv(path.as_uri(), nrows=2)
+    df1 = dc.select("first_name", "age", "city").to_pandas()
+    assert df1.equals(df[:2])
 
 
 def test_from_parquet(tmp_dir, catalog):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -825,11 +825,21 @@ def test_parse_tabular_output_list(tmp_dir, catalog):
     assert df1.equals(df)
 
 
+def test_parse_tabular_nrows(tmp_dir, catalog):
+    df = pd.DataFrame(DF_DATA)
+    path = tmp_dir / "test.parquet"
+    df.to_json(path, orient="records", lines=True)
+    dc = DataChain.from_storage(path.as_uri()).parse_tabular(nrows=2, format="json")
+    df1 = dc.select("first_name", "age", "city").to_pandas()
+
+    assert df1.equals(df[:2])
+
+
 def test_parse_tabular_nrows_invalid(tmp_dir, catalog):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.parquet"
     df.to_parquet(path)
-    with pytest.raises(ValueError):
+    with pytest.raises(DataChainParamsError):
         DataChain.from_storage(path.as_uri()).parse_tabular(nrows=2)
 
 


### PR DESCRIPTION
Fixes #210 

Writes the first nrows to a local temp file to avoid the pyarrow issues with partial reads from cloud filesystems. This means nrows won't work with parquet or other binary formats.

I find this fix hacky but a quick look at pyarrow makes me think it would be much more effort to fix it there, so this might be the best we can do for now.