### PR TITLE
feat(column): add regexp match

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -122,6 +122,11 @@ class SQLiteDatabaseEngine(DatabaseEngine):
             engine = sqlalchemy.create_engine(
                 "sqlite+pysqlite:///", creator=lambda: db, future=True
             )
+            # ensure we run SA on_connect init (e.g it registers regexp function),
+            # also makes sure that it's consistent. Otherwise in some cases it
+            # seems we are getting different results if engine object is used in a
+            # different thread first and enine is not used in the Main thread.
+            engine.connect().close()
 
             db.isolation_level = None  # Use autocommit mode
             db.execute("PRAGMA foreign_keys = ON")

--- a/src/datachain/query/schema.py
+++ b/src/datachain/query/schema.py
@@ -45,6 +45,10 @@ class Column(sa.ColumnClause, metaclass=ColumnMeta):
         """Search for matches using glob pattern matching."""
         return self.op("GLOB")(glob_str)
 
+    def regexp(self, regexp_str):
+        """Search for matches using regexp pattern matching."""
+        return self.op("REGEXP")(regexp_str)
+
 
 class UDFParameter(ABC):
     @abstractmethod

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -212,7 +212,11 @@ def test_filter(cloud_test_catalog, save, from_path):
         catalog.index(sources)
         catalog.create_dataset_from_sources("animals", globs, recursive=True)
         ds = DatasetQuery(name="animals", version=1, catalog=catalog)
-    q = ds.filter(C.size < 13).filter(C.path.glob("cats*") | (C.size < 4))
+    q = (
+        ds.filter(C.size < 13)
+        .filter(C.path.glob("cats*") | (C.size < 4))
+        .filter(C.path.regexp("^cats/cat[0-9]$"))
+    )
     if save:
         ds_name = "animals_cats"
         q.save(ds_name)

--- a/tests/unit/lib/test_schema.py
+++ b/tests/unit/lib/test_schema.py
@@ -1,0 +1,22 @@
+from datachain.lib.dc import C, DataChain
+from datachain.lib.file import File
+
+
+def test_column_filter_by_regex(test_session):
+    names = [
+        "hotdogs.txt",
+        "dogs.txt",
+        "dog.txt",
+        "1dog.txt",
+        "dogatxt.txt",
+        "dog.txtx",
+    ]
+
+    dc = DataChain.from_values(file=[File(path=p) for p in names]).filter(
+        C("file.path").regexp("dog\\.txt$")
+    )
+
+    assert set(dc.collect("file.path")) == {
+        "dog.txt",
+        "1dog.txt",
+    }


### PR DESCRIPTION
Closes https://github.com/iterative/datachain/issues/223

Example:

```python
filter(
        C("file.name").regexp("dog\\.txt$")
    )
```

Need to test if it works on CH the same way and regexp supported is more or less the same.