### PR TITLE
do not modify datachain max limit in show

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -193,8 +193,6 @@ class DataChain(DatasetQuery):
         ```
     """
 
-    max_row_count: Optional[int] = None
-
     DEFAULT_FILE_RECORD: ClassVar[dict] = {
         "source": "",
         "name": "",
@@ -1603,18 +1601,7 @@ class DataChain(DatasetQuery):
     @detach
     def limit(self, n: int) -> "Self":
         """Return the first n rows of the chain."""
-        n = max(n, 0)
-
-        if self.max_row_count is None:
-            self.max_row_count = n
-            return super().limit(n)
-
-        limit = min(n, self.max_row_count)
-        if limit == self.max_row_count:
-            return self
-
-        self.max_row_count = limit
-        return super().limit(self.max_row_count)
+        return super().limit(n)
 
     @detach
     def offset(self, offset: int) -> "Self":

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1383,6 +1383,9 @@ class DatasetQuery:
     @detach
     def limit(self, n: int) -> "Self":
         query = self.clone(new_table=False)
+        for step in query.steps:
+            if isinstance(step, SQLLimit) and step.n < n:
+                return query
         query.steps.append(SQLLimit(n))
         return query
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1228,3 +1228,33 @@ def test_custom_model_with_nested_lists():
             traces_double=[[{"x": 0.5, "y": 0.5}], [{"x": 0.5, "y": 0.5}]],
         )
     ]
+
+
+def test_min_limit():
+    dc = DataChain.from_values(a=[1, 2, 3, 4, 5])
+    assert dc.count() == 5
+    assert dc.limit(4).count() == 4
+    assert dc.count() == 5
+    assert dc.limit(1).count() == 1
+    assert dc.count() == 5
+    assert dc.limit(2).limit(3).count() == 2
+    assert dc.count() == 5
+    assert dc.limit(3).limit(2).count() == 2
+    assert dc.count() == 5
+
+
+def test_show_limit():
+    dc = DataChain.from_values(a=[1, 2, 3, 4, 5])
+    assert dc.count() == 5
+    assert dc.limit(4).count() == 4
+    dc.show(1)
+    assert dc.count() == 5
+    assert dc.limit(1).count() == 1
+    dc.show(1)
+    assert dc.count() == 5
+    assert dc.limit(2).limit(3).count() == 2
+    dc.show(1)
+    assert dc.count() == 5
+    assert dc.limit(3).limit(2).count() == 2
+    dc.show(1)
+    assert dc.count() == 5


### PR DESCRIPTION
Closes #219 by fixing the error introduced in #206. The approach now more closely aligns with the existing mechanics around `clone`.