### PR TITLE
allow show on empty DataChain

### DIFF
--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -248,6 +248,18 @@ def test_show_no_truncate(capsys, catalog):
         assert details[i] in normalized_output
 
 
+def test_show_no_rows(capsys, catalog):
+    dc = DataChain.from_values(a_column=[1], b_column=["also 1"])
+    dc.limit(0).show()
+
+    captured = capsys.readouterr()
+    normalized_output = re.sub(r"\s+", " ", captured.out)
+    assert "Empty DataChain" in normalized_output
+    assert "a_column" in normalized_output
+    assert "b_column" in normalized_output
+    assert "1" not in normalized_output
+
+
 def test_from_storage_dataset_stats(tmp_dir, catalog):
     for i in range(4):
         (tmp_dir / f"file{i}.txt").write_text(f"file{i}")


### PR DESCRIPTION
closes https://github.com/iterative/datachain/issues/237

```python
DataChain.from_values(a=["1"], b=[2]).limit(0).show()

DataChain.from_values(a=["1"], b=[2]).show()

```

will produce the following output:

```console
Processed: 1 rows [00:00, 1886.78 rows/s]
Generated: 1 rows [00:00, 2007.80 rows/s]
Empty DataChain
Columns=[a, b]
Processed: 1 rows [00:00, 3075.00 rows/s]
Generated: 1 rows [00:00, 3163.13 rows/s]
   a  b
0  1  2
```

For reference an empty DataFrame will produce 
```console
Empty DataFrame
Columns: [a, b]
Index: []
```