### PR TITLE
fix(to_pandas): handle empty datachain in to_pandas (and show)

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1206,14 +1206,14 @@ class DataChain(DatasetQuery):
         """
         headers, max_length = self._effective_signals_schema.get_headers_with_length()
         if flatten or max_length < 2:
-            df = pd.DataFrame.from_records(self.to_records())
+            columns = []
             if headers:
-                df.columns = [".".join(filter(None, header)) for header in headers]
-            return df
+                columns = [".".join(filter(None, header)) for header in headers]
+            return pd.DataFrame.from_records(self.to_records(), columns=columns)
 
-        transposed_result = list(map(list, zip(*self.results())))
-        data = {tuple(n): val for n, val in zip(headers, transposed_result)}
-        return pd.DataFrame(data)
+        return pd.DataFrame(
+            self.results(), columns=pd.MultiIndex.from_tuples(map(tuple, headers))
+        )
 
     def show(
         self,
@@ -1232,6 +1232,12 @@ class DataChain(DatasetQuery):
         """
         dc = self.limit(limit) if limit > 0 else self
         df = dc.to_pandas(flatten)
+
+        if df.empty:
+            print("Empty result")
+            print(f"Columns: {list(df.columns)}")
+            return
+
         if transpose:
             df = df.T
 

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -176,6 +176,26 @@ def test_show(capsys, test_session):
         assert f"{i} {first_name[i]}" in normalized_output
 
 
+def test_show_nested_empty(capsys, test_session):
+    files = [File(size=s, path=p) for p, s in zip(list("abcde"), range(5))]
+    DataChain.from_values(file=files, session=test_session).limit(0).show()
+
+    captured = capsys.readouterr()
+    normalized_output = re.sub(r"\s+", " ", captured.out)
+    assert "Empty result" in normalized_output
+    assert "('file', 'path')" in normalized_output
+
+
+def test_show_empty(capsys, test_session):
+    first_name = ["Alice", "Bob", "Charlie"]
+    DataChain.from_values(first_name=first_name, session=test_session).limit(0).show()
+
+    captured = capsys.readouterr()
+    normalized_output = re.sub(r"\s+", " ", captured.out)
+    assert "Empty result" in normalized_output
+    assert "Columns: ['first_name']" in normalized_output
+
+
 def test_show_limit(capsys, test_session):
     first_name = ["Alice", "Bob", "Charlie"]
     DataChain.from_values(

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1159,6 +1159,42 @@ def test_to_pandas_multi_level(test_session):
     assert df["t1"]["count"].tolist() == [3, 5, 1]
 
 
+def test_to_pandas_empty(test_session):
+    df = (
+        DataChain.from_values(t1=[1, 2, 3], session=test_session)
+        .limit(0)
+        .to_pandas(flatten=True)
+    )
+
+    assert df.empty
+    assert "t1" in df.columns
+    assert df["t1"].tolist() == []
+
+    df = (
+        DataChain.from_values(my_n=features_nested, session=test_session)
+        .limit(0)
+        .to_pandas(flatten=False)
+    )
+
+    assert df.empty
+    assert df["my_n"].empty
+    assert list(df.columns) == [
+        ("my_n", "label", ""),
+        ("my_n", "fr", "nnn"),
+        ("my_n", "fr", "count"),
+    ]
+
+    df = (
+        DataChain.from_values(my_n=features_nested, session=test_session)
+        .limit(0)
+        .to_pandas(flatten=True)
+    )
+
+    assert df.empty
+    assert df["my_n.fr.nnn"].tolist() == []
+    assert list(df.columns) == ["my_n.label", "my_n.fr.nnn", "my_n.fr.count"]
+
+
 def test_mutate(test_session):
     chain = DataChain.from_values(t1=features, session=test_session).mutate(
         circle=2 * 3.14 * Column("t1.count"), place="pref_" + Column("t1.nnn")


### PR DESCRIPTION
Closes https://github.com/iterative/datachain/issues/237 + simplifies the code a bit and makes sure that column names are preserved in `df` even if there are no values - consistently across flatten and non-flatten version.

```
files = [File(size=s, path=p) for p, s in zip(list("abcde"), range(5))]
DataChain.from_values(file=files).limit(0).show()
```

returns:

```
Empty result
Columns: [('file', 'source'), ('file', 'path'), ('file', 'size'), ('file', 'version'), ('file', 'etag'), ('file', 'is_latest'), ('file', 'last_modified'), ('file', 'location'), ('file', 'vtype')]
```

(similar to how pandas returns the list of columns to make it easier to debug)

Once thing that I was not able to imitate for now is a schema-less (no columns, no-values DataChain), but let's consider this as a minor edge case that we can test / fix later if we decide to allow that.