### PR TITLE
Autodetect Studio branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   FORCE_COLOR: "1"
+  BRANCH: ${{ github.head_ref || github.ref_name }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -144,12 +145,27 @@ jobs:
           - 6379:6379
     steps:
 
+      - name: Studio branch name
+        env:
+          BRANCH: ${{ env.BRANCH }}
+          STUDIO_READ_ACCESS_TOKEN: ${{ secrets.ITERATIVE_STUDIO_READ_ACCESS_TOKEN }}
+        run: |
+          echo "DataChain branch: $BRANCH"
+          if git ls-remote --heads https://"$STUDIO_READ_ACCESS_TOKEN"@github.com/iterative/studio.git "$BRANCH" | grep -F "$BRANCH" 2>&1>/dev/null
+          then
+              STUDIO_BRANCH="$BRANCH"
+          else
+              STUDIO_BRANCH=develop
+          fi
+          echo "STUDIO_BRANCH=$STUDIO_BRANCH" >> $GITHUB_ENV
+          echo "Studio branch: $STUDIO_BRANCH"
+
       - name: Check out Studio
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: iterative/studio
-          ref: develop
+          ref: ${{ env.STUDIO_BRANCH }}
           token: ${{ secrets.ITERATIVE_STUDIO_READ_ACCESS_TOKEN }}
 
       - name: Check out repository


### PR DESCRIPTION
If Studio repo have branch with the same name PR have use it instead of hardcoded `develop` branch.

It was tested in [this PR](https://github.com/iterative/datachain/pull/252), see [this action](https://github.com/iterative/datachain/actions/runs/10290404411/job/28480287352?pr=252).