### PR TITLE
Skip if not SQLite Improvements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,8 @@ def clean_environment(
 
 @pytest.fixture
 def sqlite_db():
+    if os.environ.get("DATACHAIN_METASTORE") or os.environ.get("DATACHAIN_WAREHOUSE"):
+        pytest.skip("This test only runs on SQLite")
     with SQLiteDatabaseEngine.from_db_file(":memory:") as db:
         yield db
 

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -256,8 +256,8 @@ def test_cp_root(cloud_test_catalog, recursive, star, dir_exists, cloud_type):
     ["s3", "gs", "azure"],
     indirect=True,
 )
+@skip_if_not_sqlite
 def test_cp_local_dataset(cloud_test_catalog, dogs_dataset):
-    skip_if_not_sqlite()
     working_dir = cloud_test_catalog.working_dir
     catalog = cloud_test_catalog.catalog
 

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -141,6 +141,7 @@ def remote_config():
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
 @pytest.mark.parametrize("dataset_uri", ["ds://dogs@v1", "ds://dogs"])
+@skip_if_not_sqlite
 def test_pull_dataset_success(
     requests_mock,
     cloud_test_catalog,
@@ -149,7 +150,6 @@ def test_pull_dataset_success(
     dog_entries_parquet_lz4,
     dataset_uri,
 ):
-    skip_if_not_sqlite()
     data_url = (
         "https://studio-blobvault.s3.amazonaws.com/datachain_ds_export_1_0.parquet.lz4"
     )
@@ -198,6 +198,7 @@ def test_pull_dataset_success(
 
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
+@skip_if_not_sqlite
 def test_pull_dataset_wrong_dataset_uri_format(
     requests_mock,
     cloud_test_catalog,
@@ -205,7 +206,6 @@ def test_pull_dataset_wrong_dataset_uri_format(
     remote_dataset,
     dog_entries_parquet_lz4,
 ):
-    skip_if_not_sqlite()
     catalog = cloud_test_catalog.catalog
 
     with pytest.raises(DataChainError) as exc_info:
@@ -214,13 +214,13 @@ def test_pull_dataset_wrong_dataset_uri_format(
 
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
+@skip_if_not_sqlite
 def test_pull_dataset_wrong_version(
     requests_mock,
     cloud_test_catalog,
     remote_config,
     remote_dataset,
 ):
-    skip_if_not_sqlite()
     requests_mock.post(
         f'{remote_config["url"]}/dataset-info',
         json=remote_dataset,
@@ -233,13 +233,13 @@ def test_pull_dataset_wrong_version(
 
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
+@skip_if_not_sqlite
 def test_pull_dataset_not_found_in_remote(
     requests_mock,
     cloud_test_catalog,
     remote_config,
     remote_dataset,
 ):
-    skip_if_not_sqlite()
     requests_mock.post(
         f'{remote_config["url"]}/dataset-info',
         status_code=404,
@@ -253,13 +253,13 @@ def test_pull_dataset_not_found_in_remote(
 
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
+@skip_if_not_sqlite
 def test_pull_dataset_error_on_fetching_stats(
     requests_mock,
     cloud_test_catalog,
     remote_config,
     remote_dataset,
 ):
-    skip_if_not_sqlite()
     requests_mock.post(
         f'{remote_config["url"]}/dataset-info',
         json=remote_dataset,
@@ -278,6 +278,7 @@ def test_pull_dataset_error_on_fetching_stats(
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
 @pytest.mark.parametrize("export_status", ["failed", "removed"])
+@skip_if_not_sqlite
 def test_pull_dataset_exporting_dataset_failed_in_remote(
     requests_mock,
     cloud_test_catalog,
@@ -285,7 +286,6 @@ def test_pull_dataset_exporting_dataset_failed_in_remote(
     remote_dataset,
     export_status,
 ):
-    skip_if_not_sqlite()
     data_url = (
         "https://studio-blobvault.s3.amazonaws.com/datachain_ds_export_1_0.parquet.lz4"
     )
@@ -310,6 +310,7 @@ def test_pull_dataset_exporting_dataset_failed_in_remote(
 
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
+@skip_if_not_sqlite
 def test_pull_dataset_empty_parquet(
     requests_mock,
     cloud_test_catalog,
@@ -317,7 +318,6 @@ def test_pull_dataset_empty_parquet(
     remote_dataset,
     dog_entries_parquet_lz4,
 ):
-    skip_if_not_sqlite()
     data_url = (
         "https://studio-blobvault.s3.amazonaws.com/datachain_ds_export_1_0.parquet.lz4"
     )

--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -16,7 +16,7 @@ tests_dir = os.path.dirname(os.path.abspath(__file__))
 python_exc = sys.executable or "python3"
 
 
-E2E_STEP_TIMEOUT_SEC = 30
+E2E_STEP_TIMEOUT_SEC = 60
 
 
 E2E_STEPS = (

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -978,10 +978,10 @@ def test_from_csv_tab_delimited(tmp_dir, test_session):
     assert df1.equals(df)
 
 
+@skip_if_not_sqlite
 def test_from_csv_null_collect(tmp_dir, test_session):
     # Clickhouse requires setting type to Nullable(Type).
     # See https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/189.
-    skip_if_not_sqlite()
     df = pd.DataFrame(DF_DATA)
     height = [70, 65, None, 72, 68]
     df["height"] = height
@@ -1263,8 +1263,8 @@ def test_column_math(test_session):
     assert list(ch2.collect("x")) == [1 - (x + 2.0) for x in fib]
 
 
+@skip_if_not_sqlite
 def test_column_math_division(test_session):
-    skip_if_not_sqlite()
     fib = [1, 1, 2, 3, 5, 8]
     chain = DataChain.from_values(num=fib, session=test_session)
 
@@ -1480,8 +1480,8 @@ def test_mutate_with_complex_expression():
     )
 
 
+@skip_if_not_sqlite
 def test_mutate_with_saving():
-    skip_if_not_sqlite()
     ds = DataChain.from_values(id=[1, 2])
     ds = ds.mutate(new=ds.column("id") / 2).save("mutated")
 

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -6,9 +6,11 @@ from sqlalchemy import Column, Integer, Table
 
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteDatabaseEngine
+from tests.utils import skip_if_not_sqlite
 
 
 @pytest.mark.parametrize("db_file", [":memory:", "file.db"])
+@skip_if_not_sqlite
 def test_init_clone(db_file):
     with SQLiteDatabaseEngine.from_db_file(db_file) as db:
         assert db.db_file == db_file

--- a/tests/unit/test_id_generator.py
+++ b/tests/unit/test_id_generator.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteIDGenerator
+from tests.utils import skip_if_not_sqlite
 
 
 def get_rows(id_generator):
@@ -25,6 +26,7 @@ def test_init(sqlite_db):
     assert not sqlite_db.has_table("id_generator")
 
 
+@skip_if_not_sqlite
 def test_init_empty(tmp_dir):
     id_generator = SQLiteIDGenerator()
     assert id_generator._table_prefix is None

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -99,8 +99,8 @@ def test_subname_expansion(listing):
     _match_filenames(nodes, ["dir1", "dir2"])
 
 
+@skip_if_not_sqlite
 def test_multilevel_expansion(listing):
-    skip_if_not_sqlite()
     nodes = listing.expand_path("dir[1,2]/d*")
     _match_filenames(nodes, ["dataset.csv", "diagram.png", "d2"])
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -189,13 +189,13 @@ def test_failed_storage(metastore):
     assert storage.error_stack == error_stack
 
 
+@skip_if_not_sqlite
 def test_unlist_source(
     listed_bucket,
     cloud_test_catalog,
     cloud_type,
 ):
     # TODO remove when https://github.com/iterative/dvcx/pull/868 is merged
-    skip_if_not_sqlite()
     source_uri = cloud_test_catalog.src_uri
     catalog = cloud_test_catalog.catalog
     _partial_id, partial_path = catalog.metastore.get_valid_partial_id(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -121,9 +121,11 @@ def create_tar_dataset(catalog, uri: str, ds_name: str) -> DatasetQuery:
     return ds1.filter(~C.path.glob("*.tar")).union(tar_entries).save(ds_name)
 
 
-def skip_if_not_sqlite():
-    if os.environ.get("DATACHAIN_METASTORE") or os.environ.get("DATACHAIN_WAREHOUSE"):
-        pytest.skip("This test is not supported on other data storages")
+skip_if_not_sqlite = pytest.mark.skipif(
+    os.environ.get("DATACHAIN_METASTORE") is not None
+    or os.environ.get("DATACHAIN_WAREHOUSE") is not None,
+    reason="This test is not supported on other data storages",
+)
 
 
 WEBFORMAT_TREE: dict[str, Any] = {


### PR DESCRIPTION
This provides some improvements to the "Skip if not running on SQLite" option for tests - this changes the skip function to a decorator (to avoid fixture and other test setup if not needed), and also adds an auto-skip for any test using the `sqlite_db` fixture, as these tests don't use other data storages anyways, so running them not on SQLite is unnecessary.

This has been tested locally, including with ClickHouse, and is a followup to #229 and has a temporary fix for #251 (increasing the timeout on the query end-to-end test, since I can't reproduce the problem locally.)