### PR TITLE
Removing `metastore` argument from `Client.parse_url()`

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -676,7 +676,7 @@ class Catalog:
 
     def parse_url(self, uri: str, **config: Any) -> tuple[Client, str]:
         config = config or self.client_config
-        return Client.parse_url(uri, self.metastore, self.cache, **config)
+        return Client.parse_url(uri, self.cache, **config)
 
     def get_client(self, uri: StorageURI, **config: Any) -> Client:
         """

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -37,7 +37,6 @@ from datachain.storage import StorageURI
 if TYPE_CHECKING:
     from fsspec.spec import AbstractFileSystem
 
-    from datachain.data_storage import AbstractMetastore
 
 logger = logging.getLogger("datachain")
 
@@ -116,13 +115,12 @@ class Client(ABC):
     @staticmethod
     def parse_url(
         source: str,
-        metastore: "AbstractMetastore",
         cache: DataChainCache,
         **kwargs,
     ) -> tuple["Client", str]:
         cls = Client.get_implementation(source)
         storage_url, rel_path = cls.split_url(source)
-        client = cls.from_name(storage_url, metastore, cache, kwargs)
+        client = cls.from_name(storage_url, cache, kwargs)
         return client, rel_path
 
     @classmethod
@@ -136,7 +134,6 @@ class Client(ABC):
     def from_name(
         cls,
         name: str,
-        metastore: "AbstractMetastore",
         cache: DataChainCache,
         kwargs: dict[str, Any],
     ) -> "Client":

--- a/src/datachain/client/local.py
+++ b/src/datachain/client/local.py
@@ -2,7 +2,7 @@ import os
 import posixpath
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import urlparse
 
 from fsspec.implementations.local import LocalFileSystem
@@ -11,9 +11,6 @@ from datachain.node import Entry
 from datachain.storage import StorageURI
 
 from .fsspec import Client
-
-if TYPE_CHECKING:
-    from datachain.data_storage import AbstractMetastore
 
 
 class FileClient(Client):
@@ -97,9 +94,7 @@ class FileClient(Client):
         return cls.root_dir(), uri.removeprefix(cls.root_path().as_uri())
 
     @classmethod
-    def from_name(
-        cls, name: str, metastore: "AbstractMetastore", cache, kwargs
-    ) -> "FileClient":
+    def from_name(cls, name: str, cache, kwargs) -> "FileClient":
         use_symlinks = kwargs.pop("use_symlinks", False)
         return cls(name, kwargs, cache, use_symlinks=use_symlinks)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -118,7 +118,7 @@ def test_parse_file_relative_path_home_dir(cloud_test_catalog):
 
 @pytest.mark.parametrize("cloud_type", ["file"], indirect=True)
 def test_parse_file_path_ends_with_slash(cloud_type):
-    client, rel_part = Client.parse_url("./animals/".replace("/", os.sep), None, None)
+    client, rel_part = Client.parse_url("./animals/".replace("/", os.sep), None)
     root_uri = FileClient.root_path().as_uri()
     assert client.uri == root_uri
     assert (


### PR DESCRIPTION
This seem to not be used so trying to remove it