### PR TITLE
Autodetect Studio branch fix for 'main' branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
           STUDIO_READ_ACCESS_TOKEN: ${{ secrets.ITERATIVE_STUDIO_READ_ACCESS_TOKEN }}
         run: |
           echo "DataChain branch: $BRANCH"
-          if $BRANCH == 'main'
+          if [[ "$BRANCH" == "main" ]]
           then
               STUDIO_BRANCH=develop
           elif git ls-remote --heads https://"$STUDIO_READ_ACCESS_TOKEN"@github.com/iterative/studio.git "$BRANCH" | grep -F "$BRANCH" 2>&1>/dev/null


### PR DESCRIPTION
🤦 follow-up for the https://github.com/iterative/datachain/pull/257 + https://github.com/iterative/datachain/pull/253

```
$ BRANCH=foo; if [[ "$BRANCH" == "main" ]]; then echo "MAIN"; else echo "NO"; fi
NO
$ BRANCH=main; if [[ "$BRANCH" == "main" ]]; then echo "MAIN"; else echo "NO"; fi
MAIN
$
```