### PR TITLE
Switch SQLite journal mode from 'WAL' to 'MEMORY'

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -127,7 +127,7 @@ class SQLiteDatabaseEngine(DatabaseEngine):
             db.execute("PRAGMA foreign_keys = ON")
             db.execute("PRAGMA cache_size = -102400")  # 100 MiB
             # Enable Write-Ahead Log Journaling
-            db.execute("PRAGMA journal_mode = WAL")
+            db.execute("PRAGMA journal_mode = MEMORY")
             db.execute("PRAGMA synchronous = NORMAL")
             db.execute("PRAGMA case_sensitive_like = ON")
             if os.environ.get("DEBUG_SHOW_SQL_QUERIES"):


### PR DESCRIPTION
Update SQLite PRAGMAs:
- [journal_mode](https://www.sqlite.org/pragma.html#pragma_journal_mode) from `WAL` to `MEMORY`
- [synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous) no change

---

### Some measurements

Using small dataset with 109662 rows (same as in https://github.com/iterative/datachain/pull/211)

##### journal_mode = WAL, synchronous = NORMAL

```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2666.44 rows/s]
Download: 643MB [00:42, 15.9MB/s]s]
Processed: 1 rows [00:42, 42.31s/ rows]
Generated: 109662 rows [00:42, 2600.67 rows/s]
Created pre-UDF table udf_ultqNZ in 16.39s
Processed: 109662 rows [00:11, 9141.12 rows/s]
Saving result in 17.60s
python laion_emb.py  56.47s user 32.31s system 96% cpu 1:31.95 total
$
```

##### journal_mode = OFF, synchronous = NORMAL

```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2427.26 rows/s]
Download: 643MB [00:39, 17.2MB/s]s]
Processed: 1 rows [00:39, 39.29s/ rows]
Generated: 109662 rows [00:39, 2799.99 rows/s]
Created pre-UDF table udf_UAa7zL in 6.25s
Processed: 109662 rows [00:13, 7909.44 rows/s]
Saving result in 6.28s
python laion_emb.py  45.90s user 21.10s system 97% cpu 1:09.02 total
$
```

##### journal_mode = MEMORY, synchronous = NORMAL

```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2373.69 rows/s]
Download: 643MB [00:39, 17.0MB/s]s]
Processed: 1 rows [00:39, 39.61s/ rows]
Generated: 109662 rows [00:39, 2778.42 rows/s]
Created pre-UDF table udf_jgnpOu in 6.20s
Processed: 109662 rows [00:14, 7815.49 rows/s]
Saving result in 7.35s
python laion_emb.py  46.04s user 21.20s system 94% cpu 1:10.85 total
$
```

##### journal_mode = MEMORY, synchronous = OFF

```
$ time python laion_emb.py
Processed: 1 rows [00:00, 2750.36 rows/s]
Download: 643MB [00:36, 18.3MB/s]s]
Processed: 1 rows [00:36, 36.74s/ rows]
Generated: 109662 rows [00:36, 2994.50 rows/s]
Created pre-UDF table udf_MG3nvv in 4.76s
Processed: 109662 rows [00:18, 5947.26 rows/s]
Saving result in 6.43s
python laion_emb.py  45.99s user 17.15s system 89% cpu 1:10.46 total
$
```

### Memory consumption

Just to be sure putting journal into memory did not affect memory consumption a lot.

##### Memory with journal_mode = WAL

![image](https://github.com/user-attachments/assets/36228cc6-6150-4b93-99cf-143a9b1e6049)

##### Memory with journal_mode = MEMORY

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/430465e5-3e91-4fe1-9241-86f3b13f21ec">

### Summary
```
journal_mode | synchronous | generating           | copying table | processing           | saving | total
-------------+-------------+----------------------+---------------+----------------------+--------+-------
WAL          | NORMAL      | 0:42, 2600.67 rows/s | 0:16          | 0:11, 9141.12 rows/s | 0:18   | 1:32
OFF          | NORMAL      | 0:39, 2799.99 rows/s | 0:06          | 0:13, 7909.44 rows/s | 0:06   | 1:09
MEMORY       | NORMAL      | 0:39, 2778.42 rows/s | 0:06          | 0:14, 7815.49 rows/s | 0:07   | 1:11
MEMORY       | OFF         | 0:36, 2994.50 rows/s | 0:05          | 0:18, 5947.26 rows/s | 0:06   | 1:10
```

Moving journal into memory have almost the same effect as turning journal OFF, but at the same time is a bit more robust.

It gives 50% performance boost for small (100k) dataset and 300% boost for big (1M) dataset (see measurements in the original issue here: https://github.com/iterative/datachain/issues/220).