### PR TITLE
standardise union behaviour between db implementations

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -878,17 +878,14 @@ class SQLUnion(Step):
         temp_tables.extend(self.query1.temp_table_names)
         q2 = self.query2.apply_steps().select().subquery()
         temp_tables.extend(self.query2.temp_table_names)
-        columns1, columns2 = fill_columns(q1.columns, q2.columns)
+
+        columns1, columns2 = _order_columns(q1.columns, q2.columns)
 
         def q(*columns):
             names = {c.name for c in columns}
             col1 = [c for c in columns1 if c.name in names]
             col2 = [c for c in columns2 if c.name in names]
-            res = (
-                sqlalchemy.select(*col1)
-                .select_from(q1)
-                .union_all(sqlalchemy.select(*col2).select_from(q2))
-            )
+            res = sqlalchemy.select(*col1).union_all(sqlalchemy.select(*col2))
 
             subquery = res.subquery()
             return sqlalchemy.select(*subquery.c).select_from(subquery)
@@ -1021,23 +1018,46 @@ class GroupBy(Step):
         return step_result(q, grouped_query.selected_columns)
 
 
-def fill_columns(
-    *column_iterables: Iterable[ColumnElement],
-) -> list[list[ColumnElement]]:
-    column_dicts = [{c.name: c for c in columns} for columns in column_iterables]
-    combined_columns = {n: c for col_dict in column_dicts for n, c in col_dict.items()}
+def _validate_columns(
+    left_columns: Iterable[ColumnElement], right_columns: Iterable[ColumnElement]
+) -> set[str]:
+    left_names = {c.name for c in left_columns}
+    right_names = {c.name for c in right_columns}
 
-    result: list[list[ColumnElement]] = [[] for _ in column_dicts]
-    for n in combined_columns:
-        col = next(col_dict[n] for col_dict in column_dicts if n in col_dict)
-        for col_dict, out in zip(column_dicts, result):
-            if n in col_dict:
-                out.append(col_dict[n])
-            else:
-                # Cast the NULL to ensure all columns are aware of their type
-                # Label it to ensure it's aware of its name
-                out.append(sqlalchemy.cast(sqlalchemy.null(), col.type).label(n))
-    return result
+    if left_names == right_names:
+        return left_names
+
+    missing_right = left_names - right_names
+    missing_left = right_names - left_names
+
+    def _prepare_msg_part(missing_columns: set[str], side: str) -> str:
+        return f"{', '.join(sorted(missing_columns))} only present in {side}"
+
+    msg_parts = [
+        _prepare_msg_part(missing_columns, found_side)
+        for missing_columns, found_side in zip(
+            [
+                missing_right,
+                missing_left,
+            ],
+            ["left", "right"],
+        )
+        if missing_columns
+    ]
+    msg = f"Cannot perform union. {'. '.join(msg_parts)}"
+
+    raise ValueError(msg)
+
+
+def _order_columns(
+    left_columns: Iterable[ColumnElement], right_columns: Iterable[ColumnElement]
+) -> list[list[ColumnElement]]:
+    column_order = _validate_columns(left_columns, right_columns)
+    column_dicts = [
+        {c.name: c for c in columns} for columns in [left_columns, right_columns]
+    ]
+
+    return [[d[n] for n in column_order] for d in column_dicts]
 
 
 @attrs.define

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1392,6 +1392,46 @@ def test_union(test_session):
     assert sorted(chain3.collect("value")) == [1, 2, 3, 4]
 
 
+def test_union_different_columns(test_session):
+    chain1 = DataChain.from_values(
+        value=[1, 2], name=["chain", "more"], session=test_session
+    )
+    chain2 = DataChain.from_values(value=[3, 4], session=test_session)
+    chain3 = DataChain.from_values(
+        other=["a", "different", "thing"], session=test_session
+    )
+    with pytest.raises(
+        ValueError, match="Cannot perform union. name only present in left"
+    ):
+        chain1.union(chain2).show()
+    with pytest.raises(
+        ValueError, match="Cannot perform union. name only present in right"
+    ):
+        chain2.union(chain1).show()
+    with pytest.raises(
+        ValueError,
+        match="Cannot perform union. "
+        "other only present in left. "
+        "name, value only present in right",
+    ):
+        chain3.union(chain1).show()
+
+
+def test_union_different_column_order(test_session):
+    chain1 = DataChain.from_values(
+        value=[1, 2], name=["chain", "more"], session=test_session
+    )
+    chain2 = DataChain.from_values(
+        name=["different", "order"], value=[9, 10], session=test_session
+    )
+    assert list(chain1.union(chain2).collect()) == [
+        (1, "chain"),
+        (2, "more"),
+        (9, "different"),
+        (10, "order"),
+    ]
+
+
 def test_subtract(test_session):
     chain1 = DataChain.from_values(a=[1, 1, 2], b=["x", "y", "z"], session=test_session)
     chain2 = DataChain.from_values(a=[1, 2], b=["x", "y"], session=test_session)


### PR DESCRIPTION
follow up to https://github.com/iterative/datachain/pull/216

closes https://github.com/iterative/dvcx/issues/1202

This PR changes the behaviour of our union operator to throw an obvious error (in all db implementations) when there is a mismatch in columns between the two chains being unioned. Previously we "cast"ed all columns with missing values to nulls. This only worked for SQLite as we do not/do not want to store nulls in Clickhouse. For more details see the above issue.