### PR TITLE
chore: Deserialize only file signals in get_file_signals

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1628,6 +1628,7 @@ class Catalog:
 
         file_signals_values = {}
         file_schemas = {}
+        # TODO: To remove after we properly fix deserialization
         for signal, type_name in version.feature_schema.items():
             from datachain.lib.model_store import ModelStore
 

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1627,8 +1627,16 @@ class Catalog:
         version = self.get_dataset(dataset_name).get_version(dataset_version)
 
         file_signals_values = {}
+        file_schemas = {}
+        for signal, type_name in version.feature_schema.items():
+            from datachain.lib.model_store import ModelStore
 
-        schema = SignalSchema.deserialize(version.feature_schema)
+            type_name_parsed, v = ModelStore.parse_name_version(type_name)
+            fr = ModelStore.get(type_name_parsed, v)
+            if fr and issubclass(fr, File):
+                file_schemas[signal] = type_name
+
+        schema = SignalSchema.deserialize(file_schemas)
         for file_signals in schema.get_signals(File):
             prefix = file_signals.replace(".", DEFAULT_DELIMITER) + DEFAULT_DELIMITER
             file_signals_values[file_signals] = {


### PR DESCRIPTION
Borrowing the logic from https://github.com/iterative/studio/pull/10466/files, this ensures that only the relevant schema (for files) is passed during deserialization. As a result, any other issues or errors during deserialization won’t block the essential function itself. 

Closes https://github.com/iterative/studio/issues/10438 , https://github.com/iterative/studio/issues/10441
