### PR TITLE
fix example - use last working version of unstructured

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ examples = [
   "numpy>=1,<2",
   "defusedxml",
   "accelerate",
-  "unstructured[pdf]",
+  "unstructured[pdf]==0.15.1",
   "pdfplumber==0.11.3",
   "huggingface_hub[hf_transfer]",
   "nltk==3.8.1"


### PR DESCRIPTION
similar to #277

It looks like the team over at unstructured is having nearly as much fun with `nltk` as me. 

It looks like `0.15.2` was yanked from pypi. `0.15.3` was a failed release that `0.15.4` quickly fixed but that version hasn't been released yet.