### PR TITLE
use default delimiter to flatten columns

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -48,7 +48,7 @@ from datachain.query.dataset import (
     PartitionByType,
     detach,
 )
-from datachain.query.schema import Column, DatasetRow
+from datachain.query.schema import DEFAULT_DELIMITER, Column, DatasetRow
 from datachain.sql.functions import path as pathfunc
 from datachain.utils import inside_notebook
 
@@ -1226,7 +1226,9 @@ class DataChain(DatasetQuery):
         if flatten or max_length < 2:
             columns = []
             if headers:
-                columns = [".".join(filter(None, header)) for header in headers]
+                columns = [
+                    DEFAULT_DELIMITER.join(filter(None, header)) for header in headers
+                ]
             return pd.DataFrame.from_records(self.to_records(), columns=columns)
 
         return pd.DataFrame(

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -48,7 +48,7 @@ from datachain.query.dataset import (
     PartitionByType,
     detach,
 )
-from datachain.query.schema import DEFAULT_DELIMITER, Column, DatasetRow
+from datachain.query.schema import Column, DatasetRow
 from datachain.sql.functions import path as pathfunc
 from datachain.utils import inside_notebook
 
@@ -1224,16 +1224,11 @@ class DataChain(DatasetQuery):
         """
         headers, max_length = self._effective_signals_schema.get_headers_with_length()
         if flatten or max_length < 2:
-            columns = []
-            if headers:
-                columns = [
-                    DEFAULT_DELIMITER.join(filter(None, header)) for header in headers
-                ]
-            return pd.DataFrame.from_records(self.to_records(), columns=columns)
+            columns = [".".join(filter(None, header)) for header in headers]
+        else:
+            columns = pd.MultiIndex.from_tuples(map(tuple, headers))
 
-        return pd.DataFrame(
-            self.results(), columns=pd.MultiIndex.from_tuples(map(tuple, headers))
-        )
+        return pd.DataFrame.from_records(self.results(), columns=columns)
 
     def show(
         self,

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1336,6 +1336,17 @@ def test_to_pandas_multi_level(test_session):
     assert df["t1"]["count"].tolist() == [3, 5, 1]
 
 
+def test_to_pandas_multi_level_flatten(test_session):
+    df = DataChain.from_values(t1=features, session=test_session).to_pandas(
+        flatten=True
+    )
+
+    assert "t1__nnn" in df.columns
+    assert "t1__count" in df.columns
+    assert len(df.columns) == 2
+    assert df["t1__count"].tolist() == [3, 5, 1]
+
+
 def test_to_pandas_empty(test_session):
     df = (
         DataChain.from_values(t1=[1, 2, 3], session=test_session)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1341,10 +1341,10 @@ def test_to_pandas_multi_level_flatten(test_session):
         flatten=True
     )
 
-    assert "t1__nnn" in df.columns
-    assert "t1__count" in df.columns
+    assert "t1.nnn" in df.columns
+    assert "t1.count" in df.columns
     assert len(df.columns) == 2
-    assert df["t1__count"].tolist() == [3, 5, 1]
+    assert df["t1.count"].tolist() == [3, 5, 1]
 
 
 def test_to_pandas_empty(test_session):


### PR DESCRIPTION
Fixes #328 

~`to_pandas(flatten=True)` now returns columns in the same way as `to_records` and in the same way we store them in the DB (to fix the bug and for consistency)~ 

changing this use `.`. It is simpler for end users and we don't want them to see DB details (at least it's not how our API operates atm).