### PR TITLE
remove nltk pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,7 @@ examples = [
   "accelerate",
   "unstructured[pdf]",
   "pdfplumber==0.11.3",
-  "huggingface_hub[hf_transfer]",
-  "nltk==3.8.1"
+  "huggingface_hub[hf_transfer]"
 ]
 
 [project.urls]


### PR DESCRIPTION
The most recent version of `unstructured` has moved to `nltk==3.9.1`. We want to use that version of `unstructured` now so we need to remove the pin.