### PR TITLE
add retry locks to SQLiteDatabaseEngine  execute_str

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -209,6 +209,7 @@ class SQLiteDatabaseEngine(DatabaseEngine):
             return cursor.executemany(self.compile(query).string, params)
         return self.db.executemany(self.compile(query).string, params)
 
+    @retry_sqlite_locks
     def execute_str(self, sql: str, parameters=None) -> sqlite3.Cursor:
         if parameters is None:
             return self.db.execute(sql)


### PR DESCRIPTION
`execute_str` is currently the only `execute` function in `SQLiteDatabaseEngine` not to have the `@retry_sqlite_locks` decorator added.
This update should help with intermittent errors in the test suite that look like [this](https://github.com/iterative/datachain/actions/runs/10483364346/job/29035966839#step:7:165).