### PR TITLE
move msgpack to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
   "pydantic>=2,<3",
   "jmespath>=1.0",
   "datamodel-code-generator>=0.25",
-  "Pillow>=10.0.0,<11"
+  "Pillow>=10.0.0,<11",
+  "msgpack>=1.0.4,<2"
 ]
 
 [project.optional-dependencies]
@@ -62,7 +63,6 @@ torch = [
 ]
 remote = [
   "lz4",
-  "msgpack>=1.0.4,<2",
   "requests>=2.22.0"
 ]
 vector = [


### PR DESCRIPTION
Closes #334

`msgpack` is imported [here](https://github.com/iterative/datachain/blob/71c942c43cc17d8457ee72cbb4765d10fb14eecc/src/datachain/query/queue.py#L8) so it should be a core dependency