### PR TITLE
Add ability to set row size for flushing udf results to database

### DIFF
--- a/src/datachain/lib/settings.py
+++ b/src/datachain/lib/settings.py
@@ -7,11 +7,14 @@ class SettingsError(DataChainParamsError):
 
 
 class Settings:
-    def __init__(self, cache=None, parallel=None, workers=None, min_task_size=None):
+    def __init__(
+        self, cache=None, parallel=None, workers=None, min_task_size=None, flush=None
+    ):
         self._cache = cache
         self.parallel = parallel
         self._workers = workers
         self.min_task_size = min_task_size
+        self.flush = flush
 
         if not isinstance(cache, bool) and cache is not None:
             raise SettingsError(
@@ -41,6 +44,12 @@ class Settings:
                 f", {min_task_size.__class__.__name__} was given"
             )
 
+        if not isinstance(flush, int) and flush is not None:
+            raise SettingsError(
+                "'flush' argument must be int or None"
+                f" while {flush.__class__.__name__} was given"
+            )
+
     @property
     def cache(self):
         return self._cache if self._cache is not None else False
@@ -59,6 +68,8 @@ class Settings:
             res["workers"] = self.workers
         if self.min_task_size is not None:
             res["min_task_size"] = self.min_task_size
+        if self.flush is not None:
+            res["flush"] = self.flush
         return res
 
     def add(self, settings: "Settings"):
@@ -66,3 +77,4 @@ class Settings:
         self.parallel = settings.parallel or self.parallel
         self._workers = settings._workers or self._workers
         self.min_task_size = settings.min_task_size or self.min_task_size
+        self.flush = settings.flush or self.flush


### PR DESCRIPTION
Needed as part of #311 but wanted to break it out in a separate PR because it's more generally applicable. For all `DataChain.from_...` methods that generate many rows from a single file or object (like `.from_csv()`), datachain could run into memory issues for a few reasons:
- for any complex output, a udf bug resulted in materializing all udf results in memory
- datachain had a hard-coded batch size of 10,000 rows before it would flush to the db and there was no setting to override it
- even if we had a setting, settings could only be applied after the `from_...` methods

With this PR, you can avoid such memory issues by setting `DataChain.from_csv(.., settings={"flush": 1000})` to flush to the database every 1000 rows.