### PR TITLE
session: support disabling temp datasets cleanup on exit via an envvar

### DIFF
--- a/src/datachain/catalog/loader.py
+++ b/src/datachain/catalog/loader.py
@@ -14,7 +14,7 @@ from datachain.data_storage.sqlite import (
     SQLiteMetastore,
     SQLiteWarehouse,
 )
-from datachain.utils import get_envs_by_prefix
+from datachain.environ import get_envs_by_prefix
 
 ID_GENERATOR_SERIALIZED = "DATACHAIN__ID_GENERATOR"
 ID_GENERATOR_IMPORT_PATH = "DATACHAIN_ID_GENERATOR"

--- a/src/datachain/environ.py
+++ b/src/datachain/environ.py
@@ -1,0 +1,36 @@
+import os
+from typing import TypeVar, Union, overload
+
+T = TypeVar("T")
+
+
+@overload
+def get_bool_env(name: str) -> bool: ...
+
+
+@overload
+def get_bool_env(name: str, undefined: "T" = ...) -> Union["T", bool]: ...
+
+
+def get_bool_env(name, undefined=False):
+    value_str = os.getenv(name, None)
+    if not value_str:
+        return undefined
+
+    try:
+        return int(value_str) != 0
+    except ValueError:
+        return value_str.lower().strip() in ("true", "on", "ok", "y", "yes", "1")
+
+
+def get_envs_by_prefix(prefix: str) -> dict[str, str]:
+    """
+    Function that searches env variables by some name prefix and returns
+    the ones found, but with prefix being excluded from it's names
+    """
+    variables: dict[str, str] = {}
+    for env_name, env_value in os.environ.items():
+        if env_name.startswith(prefix):
+            variables[env_name[len(prefix) :]] = env_value
+
+    return variables

--- a/src/datachain/progress.py
+++ b/src/datachain/progress.py
@@ -1,8 +1,6 @@
 """Manages progress bars."""
 
 import logging
-import os
-import re
 import sys
 from threading import RLock
 from typing import Any, ClassVar
@@ -10,18 +8,10 @@ from typing import Any, ClassVar
 from fsspec.callbacks import TqdmCallback
 from tqdm import tqdm
 
+from datachain.environ import get_bool_env
+
 logger = logging.getLogger(__name__)
 tqdm.set_lock(RLock())
-
-
-def env2bool(var, undefined=False):
-    """
-    undefined: return value if env var is unset
-    """
-    var = os.getenv(var, None)
-    if var is None:
-        return undefined
-    return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
 
 
 class Tqdm(tqdm):
@@ -87,7 +77,7 @@ class Tqdm(tqdm):
         # auto-disable based on TTY
         if (
             not disable
-            and not env2bool("DVC_IGNORE_ISATTY")
+            and not get_bool_env("DVC_IGNORE_ISATTY")
             and hasattr(file, "isatty")
         ):
             disable = not file.isatty()

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -8,7 +8,7 @@ import random
 import stat
 import sys
 import time
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator
 from datetime import date, datetime, timezone
 from itertools import chain, islice
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
@@ -185,19 +185,6 @@ def sql_escape_like(search: str, escape: str = "\\") -> str:
     )
 
 
-def get_envs_by_prefix(prefix: str) -> dict[str, str]:
-    """
-    Function that searches env variables by some name prefix and returns
-    the ones found, but with prefix being excluded from it's names
-    """
-    variables: dict[str, str] = {}
-    for env_name, env_value in os.environ.items():
-        if env_name.startswith(prefix):
-            variables[env_name[len(prefix) :]] = env_value
-
-    return variables
-
-
 def import_object(object_spec):
     filename, identifier = object_spec.rsplit(":", 1)
     filename = filename.strip()
@@ -307,16 +294,6 @@ def determine_processes(parallel: Optional[Union[bool, int]]) -> Union[bool, int
     if parallel < 0:
         return True
     return parallel
-
-
-def get_env_list(
-    key: str, default: Optional[Sequence] = None, sep: str = ","
-) -> Optional[Sequence[str]]:
-    try:
-        str_val = os.environ[key]
-    except KeyError:
-        return default
-    return str_val.split(sep=sep)
 
 
 def show_df(


### PR DESCRIPTION
- Adds `DATACHAIN_SESSION_CLEANUP_ON_EXIT` envvar to enable/disable temp datasets cleanup on exit. (by default is enabled).
- Minor refactoring to move environ-related utils to `datachain.environ`. Also added `get_bool_env` which is based on datachain-server's implementation (`default` is renamed to `undefined`).
- Removed unused `get_env_list`.

Related #327.