### PR TITLE
increase timeout of datachain tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: nox -s lint
 
   datachain:
-    timeout-minutes: 25
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
The suite timed out on windows here: https://github.com/iterative/datachain/actions/runs/10516264552/job/29138114753?pr=346