### PR TITLE
Adding Custom Type (De)Serialization to Signal Schema

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -44,6 +44,7 @@ NAMES_TO_TYPES = {
     "bytes": bytes,
     "datetime": datetime,
     "Literal": Literal,
+    "Union": Union,
 }
 
 
@@ -158,6 +159,9 @@ class SignalSchema:
         if orig in (Literal, LiteralEx):
             # Literal has no __name__ in Python 3.9
             type_name = "Literal"
+        elif orig == Union:
+            # Union also has no __name__ in Python 3.9
+            type_name = "Union"
         else:
             type_name = str(fr_type.__name__)  # type: ignore[union-attr]
         return type_name, fr_type

--- a/tests/func/test_feature_pickling.py
+++ b/tests/func/test_feature_pickling.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from datachain.lib.data_model import DataModel
 from datachain.lib.dc import C, DataChain
 from datachain.lib.file import File
-from datachain.lib.signal_schema import get_or_create_feature_model
+from datachain.lib.signal_schema import create_feature_model
 
 
 class FileInfo(DataModel):
@@ -227,7 +227,7 @@ def test_feature_udf_parallel_dynamic(cloud_test_catalog_tmpfile):
     source = cloud_test_catalog_tmpfile.src_uri
     catalog.index([source])
 
-    file_info_dynamic = get_or_create_feature_model(
+    file_info_dynamic = create_feature_model(
         "FileInfoDynamic",
         {
             "file_name": (str, ""),
@@ -235,7 +235,7 @@ def test_feature_udf_parallel_dynamic(cloud_test_catalog_tmpfile):
         },
     )
 
-    text_block_dynamic = get_or_create_feature_model(
+    text_block_dynamic = create_feature_model(
         "TextBlockDynamic",
         {
             "text": (str, ""),
@@ -243,7 +243,7 @@ def test_feature_udf_parallel_dynamic(cloud_test_catalog_tmpfile):
         },
     )
 
-    ai_message_dynamic = get_or_create_feature_model(
+    ai_message_dynamic = create_feature_model(
         "AIMessageDynamic",
         {
             "id": (str, ""),

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -85,10 +85,11 @@ def test_serialize_basic():
     }
     signals = SignalSchema(schema).serialize()
 
-    assert len(signals) == 3
+    assert len(signals) == 4
     assert signals["name"] == "str"
     assert signals["age"] == "float"
     assert signals["f"] == "File@v1"
+    assert "File@v1" in signals["_custom_types"]
 
 
 def test_feature_schema_serialize_optional():

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -13,6 +13,7 @@ from datachain.lib.signal_schema import (
     SignalResolvingError,
     SignalSchema,
     SignalSchemaError,
+    SignalSchemaWarning,
 )
 from datachain.sql.types import (
     JSON,
@@ -70,7 +71,9 @@ def test_deserialize_error():
     with pytest.raises(SignalSchemaError):
         SignalSchema.deserialize({"name": [1, 2, 3]})
 
-    with pytest.raises(SignalSchemaError):
+    with pytest.warns(SignalSchemaWarning):
+        # Warn if unknown fields are encountered - don't throw an exception to ensure
+        # that all data can be shown.
         SignalSchema.deserialize({"name": "unknown"})
 
 
@@ -95,9 +98,44 @@ def test_feature_schema_serialize_optional():
     }
     signals = SignalSchema(schema).serialize()
 
-    assert len(signals) == 2
+    assert len(signals) == 3
     assert signals["name"] == "str"
     assert signals["feature"] == "MyType1"
+    assert signals["_custom_types"] == {"MyType1@v1": {"aa": "int", "bb": "str"}}
+
+
+def test_feature_schema_serialize_nested_types():
+    schema = {
+        "name": Optional[str],
+        "feature_nested": Optional[MyType2],
+    }
+    signals = SignalSchema(schema).serialize()
+
+    assert len(signals) == 3
+    assert signals["name"] == "str"
+    assert signals["feature_nested"] == "MyType2"
+    assert signals["_custom_types"] == {
+        "MyType1@v1": {"aa": "int", "bb": "str"},
+        "MyType2@v1": {"deep": "MyType1@v1", "name": "str"},
+    }
+
+
+def test_feature_schema_serialize_nested_duplicate_types():
+    schema = {
+        "name": Optional[str],
+        "feature_nested": Optional[MyType2],
+        "feature_not_nested": Optional[MyType1],
+    }
+    signals = SignalSchema(schema).serialize()
+
+    assert len(signals) == 4
+    assert signals["name"] == "str"
+    assert signals["feature_nested"] == "MyType2"
+    assert signals["feature_not_nested"] == "MyType1"
+    assert signals["_custom_types"] == {
+        "MyType1@v1": {"aa": "int", "bb": "str"},
+        "MyType2@v1": {"deep": "MyType1@v1", "name": "str"},
+    }
 
 
 def test_serialize_from_column():
@@ -159,6 +197,27 @@ def test_select():
     assert signals["f.bb"] is str
 
 
+def test_select_custom_type():
+    schema = SignalSchema.deserialize(
+        {
+            "age": "float",
+            "address": "str",
+            "f": "ExternalCustomType1@v1",
+            "_custom_types": {"ExternalCustomType1@v1": {"aa": "int", "bb": "str"}},
+        }
+    )
+
+    new = schema.resolve("age", "f.aa", "f.bb")
+    assert isinstance(new, SignalSchema)
+
+    signals = new.values
+    assert len(signals) == 3
+    assert {"age", "f.aa", "f.bb"} == signals.keys()
+    assert signals["age"] is float
+    assert signals["f.aa"] is int
+    assert signals["f.bb"] is str
+
+
 def test_select_nested_names():
     schema = SignalSchema.deserialize(
         {
@@ -170,6 +229,35 @@ def test_select_nested_names():
     fr_signals = schema.resolve("fr.deep").values
     assert "fr.deep" in fr_signals
     assert fr_signals["fr.deep"] == MyType1
+
+    basic_signals = schema.resolve("fr.deep.aa", "fr.deep.bb").values
+    assert "fr.deep.aa" in basic_signals
+    assert "fr.deep.bb" in basic_signals
+    assert basic_signals["fr.deep.aa"] is int
+    assert basic_signals["fr.deep.bb"] is str
+
+
+def test_select_nested_names_custom_types():
+    schema = SignalSchema.deserialize(
+        {
+            "address": "str",
+            "fr": "NestedType2@v1",
+            "_custom_types": {
+                "NestedType1@v1": {"aa": "int", "bb": "str"},
+                "NestedType2@v1": {"deep": "NestedType1@v1", "name": "str"},
+            },
+        }
+    )
+
+    fr_signals = schema.resolve("fr.deep").values
+    assert "fr.deep" in fr_signals
+    # This is a dynamically restored model
+    nested_type_1 = fr_signals["fr.deep"]
+    assert issubclass(nested_type_1, DataModel)
+    assert {n: fi.annotation for n, fi in nested_type_1.model_fields.items()} == {
+        "aa": int,
+        "bb": str,
+    }
 
     basic_signals = schema.resolve("fr.deep.aa", "fr.deep.bb").values
     assert "fr.deep.aa" in basic_signals


### PR DESCRIPTION
This adds the ability to save and restore model classes (feature classes) to SignalSchema, by saving these in a `_custom_types` key, then restoring them by creating a dynamic pydantic class with the stored definition. This is useful for when a custom model class is declared and used to create a dataset, but then this dataset is viewed or used in a DataChain somewhere else where this original definition is not available. This will also be useful for any other import / export functions where the original types may need to be changed, such as in parquet import/export, although this will be included in a followup/separate PR(s) to avoid this getting too complex and keep these PRs focused.

This has been tested locally and with Studio. This fixes https://github.com/iterative/studio/issues/10417 and is part of #91 