### PR TITLE
increase timeout of datachain tests in CI (Windows)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: nox -s lint
 
   datachain:
-    timeout-minutes: 30
+    timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
After https://github.com/iterative/datachain/pull/347 30 minutes is still not enough for Windows: 

- https://github.com/iterative/datachain/actions/runs/10566407286/job/29273135592?pr=354
- https://github.com/iterative/datachain/actions/runs/10578660222/job/29309290443