### PR TITLE
Fixing get_file_signals for custom types

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1560,17 +1560,8 @@ class Catalog:
         version = self.get_dataset(dataset_name).get_version(dataset_version)
 
         file_signals_values = {}
-        file_schemas = {}
-        # TODO: To remove after we properly fix deserialization
-        for signal, type_name in version.feature_schema.items():
-            from datachain.lib.model_store import ModelStore
 
-            type_name_parsed, v = ModelStore.parse_name_version(type_name)
-            fr = ModelStore.get(type_name_parsed, v)
-            if fr and issubclass(fr, File):
-                file_schemas[signal] = type_name
-
-        schema = SignalSchema.deserialize(file_schemas)
+        schema = SignalSchema.deserialize(version.feature_schema)
         for file_signals in schema.get_signals(File):
             prefix = file_signals.replace(".", DEFAULT_DELIMITER) + DEFAULT_DELIMITER
             file_signals_values[file_signals] = {

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -1151,6 +1151,36 @@ def test_get_file_signals(cloud_test_catalog, dogs_dataset):
     }
 
 
+def test_get_file_signals_with_custom_types(cloud_test_catalog, dogs_dataset):
+    catalog = cloud_test_catalog.catalog
+    catalog.metastore.update_dataset_version(
+        dogs_dataset,
+        1,
+        feature_schema={
+            "name": "str",
+            "age": "str",
+            "f1": "File@v1",
+            "f2": "File@v1",
+            "_custom_types": {
+                "File@v1": {"source": "str", "name": "str"},
+            },
+        },
+    )
+    row = {
+        "name": "Jon",
+        "age": 25,
+        "f1__source": "s3://first_bucket",
+        "f1__name": "image1.jpg",
+        "f2__source": "s3://second_bucket",
+        "f2__name": "image2.jpg",
+    }
+
+    assert catalog.get_file_signals(dogs_dataset.name, 1, row) == {
+        "source": "s3://first_bucket",
+        "name": "image1.jpg",
+    }
+
+
 def test_get_file_signals_no_signals(cloud_test_catalog, dogs_dataset):
     catalog = cloud_test_catalog.catalog
     catalog.metastore.update_dataset_version(


### PR DESCRIPTION
This fixes `get_file_signals` for proper custom type handling, removing the workaround previously added due to lack of custom type serialization / deserialization. This also adds a test to ensure these types are processed correctly, so that this can be caught earlier than Studio end-to-end tests.

This has been tested with my local Studio install to work with both old (no custom types) datasets and new datasets (with custom types) with both custom type display and image preview working. This is a followup to #348 and is part of https://github.com/iterative/studio/issues/10417 and https://github.com/iterative/studio/issues/10547