### PR TITLE
Support for reading from huggingface hub with `hf://` filesystem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "datamodel-code-generator>=0.25",
   "Pillow>=10.0.0,<11",
   "msgpack>=1.0.4,<2",
-  "psutil"
+  "psutil",
+  "huggingface_hub"
 ]
 
 [project.optional-dependencies]

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -87,6 +87,7 @@ class Client(ABC):
     def get_implementation(url: str) -> type["Client"]:
         from .azure import AzureClient
         from .gcs import GCSClient
+        from .hf import HfClient
         from .local import FileClient
         from .s3 import ClientS3
 
@@ -104,6 +105,8 @@ class Client(ABC):
             return AzureClient
         if protocol == FileClient.protocol:
             return FileClient
+        if protocol == HfClient.protocol:
+            return HfClient
 
         raise NotImplementedError(f"Unsupported protocol: {protocol}")
 

--- a/src/datachain/client/hf.py
+++ b/src/datachain/client/hf.py
@@ -1,0 +1,47 @@
+import os
+import posixpath
+from typing import Any, cast
+
+from huggingface_hub import HfFileSystem
+
+from datachain.lib.file import File
+from datachain.node import Entry
+
+from .fsspec import Client
+
+
+class HfClient(Client):
+    FS_CLASS = HfFileSystem
+    PREFIX = "hf://"
+    protocol = "hf"
+
+    @classmethod
+    def create_fs(cls, **kwargs) -> HfFileSystem:
+        if os.environ.get("HF_TOKEN"):
+            kwargs["token"] = os.environ["HF_TOKEN"]
+
+        return cast(HfFileSystem, super().create_fs(**kwargs))
+
+    def convert_info(self, v: dict[str, Any], path: str) -> Entry:
+        return Entry.from_file(
+            path=path,
+            size=v["size"],
+            version=v["last_commit"].oid,
+            etag=v.get("blob_id", ""),
+            last_modified=v["last_commit"].date,
+        )
+
+    def info_to_file(self, v: dict[str, Any], path: str) -> File:
+        return File(
+            path=path,
+            size=v["size"],
+            version=v["last_commit"].oid,
+            etag=v.get("blob_id", ""),
+            last_modified=v["last_commit"].date,
+        )
+
+    async def ls_dir(self, path):
+        return self.fs.ls(path, detail=True)
+
+    def rel_path(self, path):
+        return posixpath.relpath(path, self.name)

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -7,7 +7,9 @@ import pyarrow as pa
 from pyarrow.dataset import dataset
 from tqdm import tqdm
 
+from datachain.lib.data_model import dict_to_data_model
 from datachain.lib.file import File, IndexedFile
+from datachain.lib.model_store import ModelStore
 from datachain.lib.udf import Generator
 
 if TYPE_CHECKING:
@@ -59,7 +61,13 @@ class ArrowGenerator(Generator):
                     vals = list(record.values())
                     if self.output_schema:
                         fields = self.output_schema.model_fields
-                        vals = [self.output_schema(**dict(zip(fields, vals)))]
+                        vals_dict = {}
+                        for (field, field_info), val in zip(fields.items(), vals):
+                            if ModelStore.is_pydantic(field_info.annotation):
+                                vals_dict[field] = field_info.annotation(**val)  # type: ignore[misc]
+                            else:
+                                vals_dict[field] = val
+                        vals = [self.output_schema(**vals_dict)]
                     if self.source:
                         yield [IndexedFile(file=file, index=index), *vals]
                     else:
@@ -95,15 +103,15 @@ def schema_to_output(schema: pa.Schema, col_names: Optional[Sequence[str]] = Non
         if not column:
             column = f"c{default_column}"
             default_column += 1
-        dtype = arrow_type_mapper(field.type)  # type: ignore[assignment]
-        if field.nullable:
+        dtype = arrow_type_mapper(field.type, column)  # type: ignore[assignment]
+        if field.nullable and not ModelStore.is_pydantic(dtype):
             dtype = Optional[dtype]  # type: ignore[assignment]
         output[column] = dtype
 
     return output
 
 
-def arrow_type_mapper(col_type: pa.DataType) -> type:  # noqa: PLR0911
+def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa: PLR0911
     """Convert pyarrow types to basic types."""
     from datetime import datetime
 
@@ -123,7 +131,12 @@ def arrow_type_mapper(col_type: pa.DataType) -> type:  # noqa: PLR0911
         return str
     if pa.types.is_list(col_type):
         return list[arrow_type_mapper(col_type.value_type)]  # type: ignore[return-value, misc]
-    if pa.types.is_struct(col_type) or pa.types.is_map(col_type):
+    if pa.types.is_struct(col_type):
+        type_dict = {
+            field.name: arrow_type_mapper(field.type, field.name) for field in col_type
+        }
+        return dict_to_data_model(column, type_dict)
+    if pa.types.is_map(col_type):
         return dict
     if isinstance(col_type, pa.lib.DictionaryType):
         return arrow_type_mapper(col_type.value_type)  # type: ignore[return-value]

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from datachain.lib.arrow import (
@@ -10,6 +11,7 @@ from datachain.lib.arrow import (
     arrow_type_mapper,
     schema_to_output,
 )
+from datachain.lib.data_model import dict_to_data_model
 from datachain.lib.file import File, IndexedFile
 
 
@@ -55,6 +57,34 @@ def test_arrow_generator_no_source(tmp_path, catalog):
         assert o[1] == text
 
 
+def test_arrow_generator_output_schema(tmp_path, catalog):
+    ids = [12345, 67890, 34, 0xF0123]
+    texts = ["28", "22", "we", "hello world"]
+    dicts = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}, {"a": 7, "b": 8}]
+    df = pd.DataFrame({"id": ids, "text": texts, "dict": dicts})
+    table = pa.Table.from_pandas(df)
+
+    name = "111.parquet"
+    pq_path = tmp_path / name
+    pq.write_table(table, pq_path)
+    stream = File(path=pq_path.as_posix(), source="file:///")
+    stream._set_stream(catalog, caching_enabled=False)
+
+    output_schema = dict_to_data_model("", schema_to_output(table.schema))
+    func = ArrowGenerator(output_schema=output_schema)
+    objs = list(func.process(stream))
+
+    assert len(objs) == len(ids)
+    for index, (o, id, text, dict) in enumerate(zip(objs, ids, texts, dicts)):
+        assert isinstance(o[0], IndexedFile)
+        assert isinstance(o[0].file, File)
+        assert o[0].index == index
+        assert o[1].id == id
+        assert o[1].text == text
+        assert o[1].dict.a == dict["a"]
+        assert o[1].dict.b == dict["b"]
+
+
 @pytest.mark.parametrize(
     "col_type,expected",
     (
@@ -72,7 +102,6 @@ def test_arrow_generator_no_source(tmp_path, catalog):
         (pa.date32(), datetime),
         (pa.string(), str),
         (pa.large_string(), str),
-        (pa.struct({"x": pa.int32(), "y": pa.string()}), dict),
         (pa.map_(pa.string(), pa.int32()), dict),
         (pa.dictionary(pa.int64(), pa.string()), str),
         (pa.list_(pa.string()), list[str]),
@@ -80,6 +109,14 @@ def test_arrow_generator_no_source(tmp_path, catalog):
 )
 def test_arrow_type_mapper(col_type, expected):
     assert arrow_type_mapper(col_type) == expected
+
+
+def test_arrow_type_mapper_struct():
+    col_type = pa.struct({"x": pa.int32(), "y": pa.string()})
+    fields = arrow_type_mapper(col_type).model_fields
+    assert list(fields.keys()) == ["x", "y"]
+    dtypes = [field.annotation for field in fields.values()]
+    assert dtypes == [int, str]
 
 
 def test_arrow_type_error():

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -116,7 +116,7 @@ def test_arrow_type_mapper_struct():
     fields = arrow_type_mapper(col_type).model_fields
     assert list(fields.keys()) == ["x", "y"]
     dtypes = [field.annotation for field in fields.values()]
-    assert dtypes == [int, str]
+    assert dtypes == [Optional[int], Optional[str]]
 
 
 def test_arrow_type_error():


### PR DESCRIPTION
Closes #368.

Example:

```python
>>> DataChain.from_parquet("hf://datasets/ylecun/mnist/**.parquet").show()
Preparing: 2 rows [00:00, 2100.83 rows/s]
Processed: 2 rows [00:00, 3178.71 rows/s]
Cleanup: 2 tables [00:00, 4447.83 tables/s]
Preparing: 2 rows [00:00, 1408.43 rows/s]
Processed: 2 rows [00:00, 2016.01 rows/s]
Parsed by pyarrow: 10000 rows [00:00, 10172.99 rows/s]
Parsed by pyarrow: 60000 rows [00:03, 18752.09 rows/s]
Processed: 2 rows [00:04,  2.21s/ rows]0000.68 rows/s]
Generated: 70000 rows [00:03, 19081.33 rows/s]
Cleanup: 5 tables [00:00, 63.35 tables/s]
           source                                          source   source                                    source                                    source    source  \
             file                                            file     file                                      file                                      file      file
           source                                            path     size                                   version                                      etag is_latest
0   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
1   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
2   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
3   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
4   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
5   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
6   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
7   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
8   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
9   hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
10  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
11  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
12  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
13  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
14  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
15  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
16  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
17  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
18  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1
19  hf://datasets  ylecun/mnist/mnist/test-00000-of-00001.parquet  2595890  77f3279092a1c1579b2250db8eafed0ad422088c  447ec884dcdd99cfb34e5fc7792062787508bfe5         1

                      source   source source source                                              image image label
                        file     file   file  index                                              bytes  path
               last_modified location  vtype
0  2024-08-08 06:07:00+00:00     None             0  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     7
1  2024-08-08 06:07:00+00:00     None             1  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     2
2  2024-08-08 06:07:00+00:00     None             2  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     1
3  2024-08-08 06:07:00+00:00     None             3  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     0
4  2024-08-08 06:07:00+00:00     None             4  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     4
5  2024-08-08 06:07:00+00:00     None             5  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     1
6  2024-08-08 06:07:00+00:00     None             6  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     4
7  2024-08-08 06:07:00+00:00     None             7  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     9
8  2024-08-08 06:07:00+00:00     None             8  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     5
9  2024-08-08 06:07:00+00:00     None             9  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     9
10 2024-08-08 06:07:00+00:00     None            10  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     0
11 2024-08-08 06:07:00+00:00     None            11  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     6
12 2024-08-08 06:07:00+00:00     None            12  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     9
13 2024-08-08 06:07:00+00:00     None            13  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     0
14 2024-08-08 06:07:00+00:00     None            14  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     1
15 2024-08-08 06:07:00+00:00     None            15  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     5
16 2024-08-08 06:07:00+00:00     None            16  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     9
17 2024-08-08 06:07:00+00:00     None            17  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     7
18 2024-08-08 06:07:00+00:00     None            18  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     3
19 2024-08-08 06:07:00+00:00     None            19  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...  None     4

[Limited by 20 rows]
```

Compare to `from_hf()`:

```python
>>> DataChain.from_hf("ylecun/mnist").show()
Processed: 1 rows [00:00, 3116.12 rows/s]
Generated: 2 rows [00:00, 6684.15 rows/s]
Parsed Hugging Face dataset split 'train': 60000 rows [00:12, 4669.06 rows/s]
Parsed Hugging Face dataset split 'test': 10000 rows [00:02, 4366.57 rows/s]]
Processed: 2 rows [00:15,  7.57s/ rows]': 9821 rows [00:02, 5554.35 rows/s]
Generated: 70000 rows [00:14, 4797.79 rows/s]
Cleanup: 2 tables [00:00, 39.10 tables/s]
    split                                              image  label   label
                                                         img string integer
0   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      5       5
1   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      0       0
2   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      4       4
3   train  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      1       1
4   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      9       9
5   train  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      2       2
6   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      1       1
7   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      3       3
8   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      1       1
9   train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      4       4
10  train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      3       3
11  train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      5       5
12  train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      3       3
13  train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      6       6
14  train  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      1       1
15  train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      7       7
16  train  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      2       2
17  train  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      8       8
18  train  b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      6       6
19  train  b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\...      9       9

[Limited by 20 rows]
```

This PR reads parquet files like it would from any other filesystem and does not apply any special logic for huggingface. Not all huggingface datasets are comprised of parquet files, and even in the above example, it would be up to the user to extract the image data from the `image.bytes` column for downstream tasks like pytorch training. Still, it's at least useful to see that you can easily generate a dataset from files hosted on the huggingface hub and more performant and flexible than `from_hf()`.
