### PR TITLE
Use stderr for sql debug prints

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -143,7 +143,9 @@ class SQLiteDatabaseEngine(DatabaseEngine):
             db.execute("PRAGMA synchronous = NORMAL")
             db.execute("PRAGMA case_sensitive_like = ON")
             if os.environ.get("DEBUG_SHOW_SQL_QUERIES"):
-                db.set_trace_callback(print)
+                import sys
+
+                db.set_trace_callback(sys.stderr.write)
 
             load_usearch_extension(db)
 


### PR DESCRIPTION
Quick fix for `DEBUG_SHOW_SQL_QUERIES` when queries with `src/datachain/lib/meta_formats.py` `read_meta` are used. It's broken since we have:

`# ugly hack: datachain is run redirecting printed outputs to a variable`

there, where we execute command output. It breaks if there are some debug statements.

We need to get back and review `src/datachain/lib/meta_formats.py`.