### PR TITLE
metrics: save metrics in realtime

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -157,7 +157,6 @@ class QueryResult(NamedTuple):
     version: Optional[int]
     output: str
     preview: Optional[list[dict]]
-    metrics: dict[str, Any]
 
 
 class DatasetRowsFetcher(NodesThreadPool):
@@ -1973,7 +1972,6 @@ class Catalog:
             version=version,
             output=output,
             preview=exec_result.preview,
-            metrics=exec_result.metrics,
         )
 
     def run_query(

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -864,8 +864,7 @@ def query(
             error_stack=error_stack,
         )
         raise
-
-    catalog.metastore.set_job_status(job_id, JobStatus.COMPLETE, metrics=result.metrics)
+    catalog.metastore.set_job_status(job_id, JobStatus.COMPLETE)
 
     show_records(result.preview, collapse_columns=not no_collapse)
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -60,7 +60,6 @@ from datachain.utils import (
     get_datachain_executable,
 )
 
-from .metrics import metrics
 from .schema import C, UDFParamSpec, normalize_param
 from .session import Session
 from .udf import UDFBase, UDFClassWrapper, UDFFactory, UDFType
@@ -1729,7 +1728,6 @@ def _get_output_fd_for_write() -> Union[str, int]:
 class ExecutionResult:
     preview: list[dict] = attrs.field(factory=list)
     dataset: Optional[tuple[str, int]] = None
-    metrics: dict[str, Any] = attrs.field(factory=dict)
 
 
 def _send_result(dataset_query: DatasetQuery) -> None:
@@ -1766,7 +1764,7 @@ def _send_result(dataset_query: DatasetQuery) -> None:
         dataset = dataset_query.name, dataset_query.version
 
     preview = preview_query.to_db_records()
-    result = ExecutionResult(preview, dataset, metrics)
+    result = ExecutionResult(preview, dataset)
     data = attrs.asdict(result)
 
     with open(_get_output_fd_for_write(), mode="w") as f:

--- a/src/datachain/query/metrics.py
+++ b/src/datachain/query/metrics.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Union
 
 metrics: dict[str, Union[str, int, float, bool, None]] = {}
@@ -12,6 +13,13 @@ def set(key: str, value: Union[str, int, float, bool, None]) -> None:  # noqa: P
     if not isinstance(value, (str, int, float, bool, type(None))):
         raise TypeError("Value must be a string, int, float or bool")
     metrics[key] = value
+
+    if job_id := os.getenv("DATACHAIN_JOB_ID"):
+        from datachain.data_storage.job import JobStatus
+        from datachain.query.session import Session
+
+        metastore = Session.get().catalog.metastore
+        metastore.set_job_status(job_id, JobStatus.RUNNING, metrics=metrics)
 
 
 def get(key: str) -> Optional[Union[str, int, float, bool]]:

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -1,0 +1,14 @@
+from datachain.query import metrics
+
+
+def test_metrics(test_session, catalog, mocker, monkeypatch):
+    mocker.patch("datachain.query.session.Session.get", return_value=test_session)
+    mocker.patch.dict("datachain.query.metrics.metrics", {}, clear=True)
+    job_id = catalog.metastore.create_job("test_metrics", "")
+    monkeypatch.setenv("DATACHAIN_JOB_ID", job_id)
+
+    metrics.set("foo", 42)
+
+    assert metrics.get("foo") == 42
+    (job,) = catalog.metastore.list_jobs_by_ids([job_id])
+    assert job.metrics == metrics.metrics == {"foo": 42}


### PR DESCRIPTION
Partially fixes #384. (We don't save metrics yet if they are not run as a job).