### PR TITLE
allow merge on expressions

### DIFF
--- a/examples/multimodal/wds.py
+++ b/examples/multimodal/wds.py
@@ -1,6 +1,6 @@
 import os
 
-from datachain import C, DataChain
+from datachain import DataChain
 from datachain.lib.webdataset import process_webdataset
 from datachain.lib.webdataset_laion import WDSLaion, process_laion_meta
 from datachain.sql.functions import path
@@ -25,21 +25,20 @@ wds_with_pq = (
     DataChain.from_parquet(PARQUET_METADATA)
     .settings(cache=True)
     .merge(wds_images, on="uid", right_on="laion.json.uid", inner=True)
-    .mutate(stem=path.file_stem(C("source.file.path")))
 )
 
-res = (
+wds_npz = (
     DataChain.from_storage(NPZ_METADATA)
     .settings(cache=True)
     .gen(emd=process_laion_meta)
-    .mutate(stem=path.file_stem(C("emd.file.path")))
-    .merge(
-        wds_with_pq,
-        on=["stem", "emd.index"],
-        right_on=["stem", "source.index"],
-        inner=True,
-    )
-    .save("wds")
 )
+
+
+res = wds_npz.merge(
+    wds_with_pq,
+    on=[path.file_stem(wds_npz.c("emd.file.path")), "emd.index"],
+    right_on=[path.file_stem(wds_with_pq.c("source.file.path")), "source.index"],
+    inner=True,
+).save("wds")
 
 res.show(5)

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -280,17 +280,15 @@ class DataChain(DatasetQuery):
             name_path = [name]
         for path, type_, _, _ in self.signals_schema.get_flat_tree():
             if path == name_path:
-                col = Column(name, python_to_sql(type_))
-                col.table = self.table
-                return col
+                return Column(name, python_to_sql(type_))
 
         raise ValueError(f"Column with name {name} not found in the schema")
 
-    def c(self, c: Union[str, Column]) -> "sqlalchemy.ColumnClause":
+    def c(self, column: Union[str, Column]) -> "sqlalchemy.ColumnClause":
         """Returns ColumnClause instance attached to the current chain."""
-        if isinstance(c, str):
-            return self.column(c)
-        return self.column(c.name)
+        c = self.column(column) if isinstance(column, str) else self.column(column.name)
+        c.table = self.table
+        return c
 
     def print_schema(self) -> None:
         """Print schema of the chain."""

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -129,14 +129,14 @@ class DatasetMergeError(DataChainParamsError):  # noqa: D101
         right_on: Optional[Sequence[Union[str, sqlalchemy.ColumnElement]]],
         msg: str,
     ):
-        def get_str(on: Sequence[Union[str, sqlalchemy.ColumnElement]]) -> str:
+        def _get_str(on: Sequence[Union[str, sqlalchemy.ColumnElement]]) -> str:
             if not isinstance(on, Sequence):
                 return str(on)  # type: ignore[unreachable]
             return ", ".join([_get_merge_error_str(col) for col in on])
 
-        on_str = get_str(on)
+        on_str = _get_str(on)
         right_on_str = (
-            ", right_on='" + get_str(right_on) + "'"
+            ", right_on='" + _get_str(right_on) + "'"
             if right_on and isinstance(right_on, Sequence)
             else ""
         )
@@ -284,8 +284,8 @@ class DataChain(DatasetQuery):
 
         raise ValueError(f"Column with name {name} not found in the schema")
 
-    def c(self, column: Union[str, Column]) -> "sqlalchemy.ColumnClause":
-        """Returns ColumnClause instance attached to the current chain."""
+    def c(self, column: Union[str, Column]) -> Column:
+        """Returns Column instance attached to the current chain."""
         c = self.column(column) if isinstance(column, str) else self.column(column.name)
         c.table = self.table
         return c
@@ -1236,7 +1236,7 @@ class DataChain(DatasetQuery):
 
         errors = []
 
-        def resolve(
+        def _resolve(
             ds: DataChain,
             col: Union[str, sqlalchemy.ColumnElement],
             side: Union[str, None],
@@ -1248,8 +1248,8 @@ class DataChain(DatasetQuery):
                     errors.append(f"{_get_merge_error_str(col)} in {side}")
 
         ops = [
-            resolve(self, left, "left")
-            == resolve(right_ds, right, "right" if right_on else None)
+            _resolve(self, left, "left")
+            == _resolve(right_ds, right, "right" if right_on else None)
             for left, right in zip(on, right_on or on)
         ]
 

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -117,7 +117,7 @@ def _get_merge_error_str(col: Union[str, sqlalchemy.ColumnElement]) -> str:
         return col
     if isinstance(col, sqlalchemy.Column):
         return col.name.replace(DEFAULT_DELIMITER, ".")
-    if isinstance(col, GenericFunction):
+    if isinstance(col, sqlalchemy.ColumnElement) and hasattr(col, "name"):
         return f"{col.name} expression"
     return str(col)
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1168,8 +1168,12 @@ class DatasetQuery:
         """
         return self.name is not None and self.version is not None
 
-    def c(self, name: Union[C, str]) -> "ColumnClause[Any]":
-        col = sqlalchemy.column(name) if isinstance(name, str) else name
+    def c(self, column: Union[C, str]) -> "ColumnClause[Any]":
+        col: sqlalchemy.ColumnClause = (
+            sqlalchemy.column(column)
+            if isinstance(column, str)
+            else sqlalchemy.column(column.name, column.type)
+        )
         col.table = self.table
         return col
 

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -195,7 +195,7 @@ def test_merge_multi_conditions(test_session):
         id=delivery_ids, d_name=delivery_name, time=delivery_time, session=test_session
     )
 
-    ch = ch1.merge(ch2, ("id", "name"), ("id", "d_name"))
+    ch = ch1.merge(ch2, ("id", "name"), ("id", C("d_name")))
 
     res = list(ch.collect())
 
@@ -212,7 +212,7 @@ def test_merge_errors(test_session):
     ch1 = DataChain.from_values(emp=employees, session=test_session)
     ch2 = DataChain.from_values(team=team, session=test_session)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(DatasetMergeError):
         ch1.merge(ch2, "unknown")
 
     ch1.merge(ch2, ["emp.person.name"], ["team.sport"])

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -222,6 +222,11 @@ def test_merge_errors(test_session):
     with pytest.raises(DatasetMergeError):
         ch1.merge(ch2, ["emp.person.name"], ["unknown"])
 
+    with pytest.raises(DatasetMergeError):
+        ch1.merge(
+            ch2, ("emp.person.age", func.substr(["emp.person.name"], 2)), "unknown"
+        )
+
     ch1.merge(ch2, ["emp.person.name"], ["team.sport"])
     ch1.merge(ch2, ["emp.person.name"], ["team.sport"])
 

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -269,21 +269,27 @@ def test_merge_with_itself_column(test_session):
 
 
 def test_merge_on_expression(test_session):
-    ch = DataChain.from_values(team=team, session=test_session)
-    # cross join on "ball" from sport
-    c = ch.c("team.sport")
-    expr = func.substr(c, func.length(c) - 4)
-    merged = ch.merge(ch, on=expr)
+    def _get_expr(dc):
+        c = dc.c("team.sport")
+        return func.substr(c, func.length(c) - 3)
 
-    cross_team = [(l_member, r_member) for l_member in team for r_member in team]
+    dc = DataChain.from_values(team=team, session=test_session)
+    right_dc = dc.clone(new_table=True)
+
+    # cross join on "ball" from sport
+    merged = dc.merge(right_dc, on=_get_expr(dc), right_on=_get_expr(right_dc))
+
+    cross_team = [
+        (left_member, right_member) for left_member in team for right_member in team
+    ]
 
     count = 0
-    for left, right in merged.collect():
+    for left, right_dc in merged.collect():
         assert isinstance(left, TeamMember)
-        assert isinstance(right, TeamMember)
-        l_member, r_member = cross_team[count]
-        assert left == l_member
-        assert right == r_member
+        assert isinstance(right_dc, TeamMember)
+        left_member, right_member = cross_team[count]
+        assert left == left_member
+        assert right_dc == right_member
         count += 1
 
     assert count == len(team) * len(team)


### PR DESCRIPTION
Closes #299

This PR allows users to merge DataChains using `Column`s and/or expressions (e.g. `path.file_stem(dc.c("source.path"))`). Examples of the new syntax are shown in `examples/multimodal/clip_inference.py` & `examples/multimodal/wds.py`. Once this change has been merged I will make the appropriate changes in the `datachain-examples` repo.

It should be noted that the change is backwards compatible and `merge` will continue to accept strings for the `on` and `right_on` parameters.