### PR TITLE
cli: remove preview from `datachain query` command

### DIFF
--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -484,7 +484,6 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
             "N defaults to the CPU count."
         ),
     )
-    add_show_args(query_parser)
     query_parser.add_argument(
         "-p",
         "--param",
@@ -811,14 +810,9 @@ def query(
     catalog: "Catalog",
     script: str,
     parallel: Optional[int] = None,
-    limit: int = 10,
-    offset: int = 0,
-    columns: Optional[list[str]] = None,
-    no_collapse: bool = False,
     params: Optional[dict[str, str]] = None,
 ) -> None:
     from datachain.data_storage import JobQueryType, JobStatus
-    from datachain.utils import show_records
 
     with open(script, encoding="utf-8") as f:
         script_content = f.read()
@@ -839,12 +833,9 @@ def query(
     )
 
     try:
-        result = catalog.query(
+        catalog.query(
             script_content,
             python_executable=python_executable,
-            preview_limit=limit,
-            preview_offset=offset,
-            preview_columns=columns,
             capture_output=False,
             params=params,
             job_id=job_id,
@@ -860,8 +851,6 @@ def query(
         )
         raise
     catalog.metastore.set_job_status(job_id, JobStatus.COMPLETE)
-
-    show_records(result.preview, collapse_columns=not no_collapse)
 
 
 def clear_cache(catalog: "Catalog"):
@@ -1037,10 +1026,6 @@ def main(argv: Optional[list[str]] = None) -> int:  # noqa: C901, PLR0912, PLR09
                 catalog,
                 args.script,
                 parallel=args.parallel,
-                limit=args.limit,
-                offset=args.offset,
-                columns=args.columns,
-                no_collapse=args.no_collapse,
                 params=args.param,
             )
         elif args.command == "apply-udf":

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -75,7 +75,7 @@ def mock_popen_dataset_created(
 
     _, w = mock_os_pipe
     with open(w, mode="w", closefd=False) as f:
-        f.write(json.dumps({"dataset": (ds_name, ds_version)}))
+        f.write(json.dumps((ds_name, ds_version)))
 
     mock_popen.configure_mock(stdout=io.StringIO("user log 1\nuser log 2"))
     yield mock_popen

--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -107,13 +107,10 @@ def test_query_cli(cloud_test_catalog_tmpfile, tmp_path, catalog_info_filepath, 
     filepath = tmp_path / "query_script.py"
     filepath.write_text(query_script)
 
-    query(catalog, str(filepath), columns=["name"])
-    captured = capsys.readouterr()
-
-    header, *rows = captured.out.splitlines()
-    assert header.strip() == "name"
-    name_rows = {row.split()[1] for row in rows}
-    assert name_rows == {"cat1", "cat2", "description", "dog1", "dog2", "dog3", "dog4"}
+    query(catalog, str(filepath))
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err
 
     dataset = catalog.get_dataset("my-ds")
     assert dataset
@@ -152,7 +149,7 @@ def test_query_cli_no_dataset_returned(
         QueryScriptRunError,
         match="Last line in a script was not an instance of DataChain",
     ):
-        query(catalog, str(filepath), columns=["name"])
+        query(catalog, str(filepath))
 
     latest_job = get_latest_job(catalog.metastore)
     assert latest_job

--- a/tests/scripts/feature_class.py
+++ b/tests/scripts/feature_class.py
@@ -14,5 +14,5 @@ ds = (
     .limit(5)
     .map(emd=lambda file: Embedding(value=512), output=Embedding)
 )
-
+ds.select("file.path", "emd.value").show(limit=5, flatten=True)
 ds.save(ds_name)

--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -89,17 +89,17 @@ E2E_STEPS = (
             "datachain",
             "query",
             os.path.join(tests_dir, "scripts", "feature_class.py"),
-            "--columns",
-            "file.path,emd.value",
         ),
         "expected_rows": dedent(
             """
-                               file__path  emd__value
+                               file.path  emd.value
             0     dogs-and-cats/cat.1.jpg       512.0
             1    dogs-and-cats/cat.10.jpg       512.0
             2   dogs-and-cats/cat.100.jpg       512.0
             3  dogs-and-cats/cat.1000.jpg       512.0
             4  dogs-and-cats/cat.1001.jpg       512.0
+
+            [Limited by 5 rows]
             """
         ),
     },


### PR DESCRIPTION
Part of #360.

After removing last expression wrapping, we will not be able to get access to the dataset query, nor we'll be able to show previews.

Also, CLI is hidden at the moment. So, it is better if we disable the preview support altogether for now, as this simplifes a lot for #360.

