### PR TITLE
query: remove use of pipe for communication

### DIFF
--- a/src/datachain/job.py
+++ b/src/datachain/job.py
@@ -1,7 +1,8 @@
 import json
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar, Union
 
 J = TypeVar("J", bound="Job")
 
@@ -25,7 +26,7 @@ class Job:
     @classmethod
     def parse(
         cls: type[J],
-        id: str,
+        id: Union[str, uuid.UUID],
         name: str,
         status: int,
         created_at: datetime,
@@ -40,7 +41,7 @@ class Job:
         metrics: str,
     ) -> "Job":
         return cls(
-            id,
+            str(id),
             name,
             status,
             created_at,

--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -186,15 +186,16 @@ def test_query(
     query_script = setup_catalog(query_script, catalog_info_filepath)
 
     result = catalog.query(query_script, save=save)
-    if not save:
-        assert result.dataset is None
-        return
-
     if save_dataset:
         assert result.dataset.name == save_dataset
         assert catalog.get_dataset(save_dataset)
-    else:
+    elif save:
         assert result.dataset.name.startswith(QUERY_DATASET_PREFIX)
+    else:
+        assert result.dataset is None
+        assert result.version is None
+        return
+
     assert result.version == 1
     assert result.dataset.versions_values == [1]
     assert result.dataset.query_script == query_script


### PR DESCRIPTION
Now, we fetch all dataset versions created with a given `job_id`, and then choose the latest one by its `datetime`. (If there are multiple dataset versions with the same datetime, the first one encountered is used but that may be rare).

This removes the need for using a pipe to read and write dataset version from a script, which is too complicated.

