### PR TITLE
Explore downloading hf datasets and read images from cache

### DIFF
--- a/src/datachain/lib/hf.py
+++ b/src/datachain/lib/hf.py
@@ -17,6 +17,7 @@ try:
     )
     from datasets.features.features import string_to_arrow
     from datasets.features.image import image_to_bytes
+    from datasets.table import MemoryMappedTable
 
 except ImportError as exc:
     raise ImportError(
@@ -25,17 +26,21 @@ except ImportError as exc:
         "  pip install 'datachain[hf]'\n"
     ) from exc
 
+import inspect
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Union
 
 import PIL
 from tqdm import tqdm
 
+from datachain.client.local import FileClient
 from datachain.lib.arrow import arrow_type_mapper
 from datachain.lib.data_model import DataModel, DataType, dict_to_data_model
+from datachain.lib.file import File
 from datachain.lib.udf import Generator
 
 if TYPE_CHECKING:
+    from datasets.features.features import Features
     from pydantic import BaseModel
 
 
@@ -63,7 +68,27 @@ class HFAudio(DataModel):
     sampling_rate: int
 
 
-class HFGenerator(Generator):
+class HFFile(DataModel):
+    file: File
+    col: str
+    row: int
+
+    def read(self):
+        tbl = _file_to_pyarrow(self.file)
+        return tbl[self.col][self.row]
+
+
+class HFImageFile(HFFile):
+    file: File
+    col: str
+    row: int
+
+    def read(self):
+        raw = super().read()["bytes"].as_py()
+        return PIL.Image.open(BytesIO(raw))
+
+
+class HFGeneratorStream(Generator):
     def __init__(
         self,
         ds: Union[str, HFDatasetType],
@@ -78,7 +103,7 @@ class HFGenerator(Generator):
         self.kwargs = kwargs
 
     def setup(self):
-        self.ds_dict = stream_splits(self.ds, *self.args, **self.kwargs)
+        self.ds_dict = get_splits(self.ds, *self.args, streaming=True, **self.kwargs)
 
     def process(self, split: str = ""):
         desc = "Parsed Hugging Face dataset"
@@ -97,9 +122,47 @@ class HFGenerator(Generator):
                 pbar.update(1)
 
 
-def stream_splits(ds: Union[str, HFDatasetType], *args, **kwargs):
+class HFGeneratorCache(Generator):
+    def __init__(
+        self,
+        input_schema: "Features",
+        output_schema: type["BaseModel"],
+        *args,
+        **kwargs,
+    ):
+        super().__init__()
+        self.input_schema = input_schema
+        self.output_schema = output_schema
+        self.args = args
+        self.kwargs = kwargs
+
+    def process(self, file: File, split: str = ""):
+        desc = f"Parsed Hugging Face dataset file {file.name}"
+        tbl = _file_to_pyarrow(file)
+
+        row = 0
+        with tqdm(desc=desc, unit=" rows") as pbar:
+            for record_batch in tbl.to_batches():
+                for record in record_batch.to_pylist():
+                    output_dict = {}
+                    if split:
+                        output_dict["split"] = split
+                    for name, feat in self.input_schema.items():
+                        anno = self.output_schema.model_fields[name].annotation
+                        if inspect.isclass(anno) and issubclass(anno, HFFile):
+                            output_dict[name] = anno(file=file, row=row, col=name)  # type: ignore[assignment]
+                        else:
+                            output_dict[name] = _convert_feature(
+                                record[name], feat, anno
+                            )
+                    yield self.output_schema(**output_dict)
+                    row += 1
+                pbar.update(len(record_batch))
+
+
+def get_splits(ds: Union[str, HFDatasetType], *args, **kwargs):
     if isinstance(ds, str):
-        ds = load_dataset(ds, *args, streaming=True, **kwargs)
+        ds = load_dataset(ds, *args, **kwargs)
     if isinstance(ds, (DatasetDict, IterableDatasetDict)):
         return ds
     return {"": ds}
@@ -126,15 +189,15 @@ def _convert_feature(val: Any, feat: Any, anno: Any) -> Any:
 
 
 def get_output_schema(
-    ds: Union[Dataset, IterableDataset], model_name: str = ""
+    ds: Union[Dataset, IterableDataset], model_name: str = "", stream: bool = True
 ) -> dict[str, DataType]:
     fields_dict = {}
     for name, val in ds.features.items():
-        fields_dict[name] = _feature_to_chain_type(name, val)  # type: ignore[assignment]
+        fields_dict[name] = _feature_to_chain_type(name, val, stream)  # type: ignore[assignment]
     return fields_dict  # type: ignore[return-value]
 
 
-def _feature_to_chain_type(name: str, val: Any) -> type:  # noqa: PLR0911
+def _feature_to_chain_type(name: str, val: Any, stream: bool = True) -> type:  # noqa: PLR0911
     if isinstance(val, Value):
         return arrow_type_mapper(val.pa_type)
     if isinstance(val, ClassLabel):
@@ -160,7 +223,12 @@ def _feature_to_chain_type(name: str, val: Any) -> type:  # noqa: PLR0911
         dtype = arrow_type_mapper(string_to_arrow(val.dtype))
         return list[list[list[list[list[dtype]]]]]  # type: ignore[valid-type]
     if isinstance(val, Image):
-        return HFImage
+        return HFImage if stream else HFImageFile
     if isinstance(val, Audio):
-        return HFAudio
+        return HFAudio if stream else HFFile
     raise TypeError(f"Unknown huggingface datasets type {type(val)}")
+
+
+def _file_to_pyarrow(file: File):
+    path = FileClient("/", {}, None).get_full_path(file.path)
+    return MemoryMappedTable.from_file(path)


### PR DESCRIPTION
Some exploration related to #369. I don't plan to merge this but wanted to share the results. 

This PR splits `from_hf` into two methods:
- `from_hf_streaming`: This is the method that was implemented in #311. It streams the datasets and store their contents in the warehouse. Images and other binary objects are stored as bytes in the warehouse.
- `from_hf_download`: This method downloads the dataset to the hf cache, which saves them as arrow files (the `datasets` library first downloads the files and then converts them to a uniform arrow format). Images are saved as bytes in those cached arrow files and datachain reads them from there rather than storing them in the warehouse.

I used a sample of coco data to show performance considerations of using each of these approaches:

Here is `from_hf_streaming`:

```python
>>> chain = DataChain.from_hf_streaming("lmms-lab/COCO-Caption2017", split="val")
>>> images = list(chain.select("image").to_pytorch())
Processed: 1 rows [00:00, 1062.66 rows/s]
Generated: 1 rows [00:00, 1109.90 rows/s]
Parsed Hugging Face dataset: 5000 rows [02:21, 35.44 rows/s]
Processed: 1 rows [02:22, 142.01s/ rows]02:21, 77.73 rows/s]
Generated: 5000 rows [02:19, 35.72 rows/s]
Saving: 5000 rows [00:01, 3476.78 rows/s]
Cleanup: 2 tables [00:00,  3.17 tables/s]
Parsed PyTorch dataset for rank=0 worker: 5000 rows [00:11, 423.39 rows/s]
```

Here is `from_hf_download`, including the initial download to the cache:

```python
>>> chain = DataChain.from_hf_download("lmms-lab/COCO-Caption2017", split="val")
Downloading readme: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.78k/1.78k [00:00<00:00, 9.73MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 424M/424M [00:27<00:00, 15.3MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 391M/391M [00:24<00:00, 16.3MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 476M/476M [00:25<00:00, 18.4MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 474M/474M [00:24<00:00, 19.1MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 471M/471M [00:27<00:00, 16.9MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 474M/474M [00:29<00:00, 15.9MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 475M/475M [00:34<00:00, 13.9MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 470M/470M [00:34<00:00, 13.5MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 473M/473M [00:34<00:00, 13.8MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 470M/470M [00:32<00:00, 14.5MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 476M/476M [00:33<00:00, 14.4MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 474M/474M [00:32<00:00, 14.4MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 465M/465M [00:32<00:00, 14.4MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 477M/477M [00:33<00:00, 14.4MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 479M/479M [00:33<00:00, 14.3MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 477M/477M [00:34<00:00, 13.7MB/s]
Generating val split: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 5000/5000 [00:03<00:00, 1405.00 examples/s]
Generating test split: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 40670/40670 [00:10<00:00, 4032.71 examples/s]
>>> images = list(chain.select("image").to_pytorch())
Preparing: 1 rows [00:00, 680.23 rows/s]
Processed: 1 rows [00:00, 1879.17 rows/s]
Preparing: 1 rows [00:00, 984.12 rows/s]
Processed: 1 rows [00:00, 1589.35 rows/s]
Parsed Hugging Face dataset file coco-caption2017-val-00000-of-00002.arrow: 3000 rows [00:01, 2387.91 rows/s]
Parsed Hugging Face dataset file coco-caption2017-val-00001-of-00002.arrow: 2000 rows [00:00, 2663.63 rows/s]
Processed: 2 rows [00:02,  1.01s/ rows]aption2017-val-00001-of-00002.arrow: 2000 rows [00:00, 2758.39 rows/s]
Generated: 5000 rows [00:01, 2518.46 rows/s]
Saving: 5000 rows [00:00, 46027.32 rows/s]
Cleanup: 7 tables [00:00, 294.96 tables/s]
Parsed PyTorch dataset for rank=0 worker: 5000 rows [01:08, 73.23 rows/s]
```

Here is `from_hf_download` with data that has already been cached:

```python
>>> chain = DataChain.from_hf_download("lmms-lab/COCO-Caption2017", split="val")
>>> images = list(chain.select("image").to_pytorch())
Preparing: 1 rows [00:00, 716.85 rows/s]
Processed: 1 rows [00:00, 845.97 rows/s]
Preparing: 1 rows [00:00, 1181.83 rows/s]
Processed: 1 rows [00:00, 1724.63 rows/s]
Parsed Hugging Face dataset file coco-caption2017-val-00000-of-00002.arrow: 3000 rows [00:01, 2353.40 rows/s]
Parsed Hugging Face dataset file coco-caption2017-val-00001-of-00002.arrow: 2000 rows [00:00, 2427.70 rows/s]
Processed: 2 rows [00:02,  1.06s/ rows]aption2017-val-00001-of-00002.arrow: 2000 rows [00:00, 2495.03 rows/s]
Generated: 5000 rows [00:02, 2412.47 rows/s]
Saving: 5000 rows [00:00, 47819.81 rows/s]
Cleanup: 7 tables [00:00, 369.39 tables/s]
Parsed PyTorch dataset for rank=0 worker: 5000 rows [01:09, 71.91 rows/s]
```

From these results, it looks like reading images from cached files doesn't make a lot of sense in this scenario because it has to download the data and the images are slower to load in downstream operations like `to_pytorch`. I would vote to close this PR and #369 and stay with the existing `from_hf` method. As a next step, I'm working on a PR that will build on #375 to be able to handle images from `hf://` files the same way they are handled by `from_hf`.

