### PR TITLE
unpin pydantic, use python API for datamodel_codegen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "dill==0.3.8",
   "cloudpickle",
   "orjson>=3.10.5",
-  "pydantic>2,<2.9",
+  "pydantic>=2,<3",
   "jmespath>=1.0",
   "datamodel-code-generator>=0.25",
   "Pillow>=10.0.0,<11",

--- a/tests/func/test_meta_formats.py
+++ b/tests/func/test_meta_formats.py
@@ -1,0 +1,88 @@
+import json
+
+import pytest
+
+from datachain.lib.file import TextFile
+from datachain.lib.meta_formats import read_meta, read_schema
+
+example = {
+    "id": "1",
+    "split": "test",
+    "image_id": {
+        "author": "author",
+        "title": "title",
+        "size": 5090109,
+        "md5": "md5",
+        "url": "https://example.org/image.jpg",
+        "rotation": 0.0,
+    },
+    "classifications": [
+        {"Source": "verification", "LabelName": "label", "Confidence": 0}
+    ],
+}
+
+
+@pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
+def test_read_schema(tmp_dir, catalog):
+    (tmp_dir / "valid.json").write_text(json.dumps(example), encoding="utf8")
+    file = TextFile(path=tmp_dir / "valid.json")
+    file._set_stream(catalog)
+
+    expected = """\
+from __future__ import annotations
+
+from datachain.lib.data_model import DataModel
+from datachain.lib.meta_formats import UserModel
+
+
+class ImageId(UserModel):
+    author: str
+    title: str
+    size: int
+    md5: str
+    url: str
+    rotation: float
+
+
+class Classification(UserModel):
+    Source: str
+    LabelName: str
+    Confidence: int
+
+
+class Image(UserModel):
+    id: str
+    split: str
+    image_id: ImageId
+    classifications: list[Classification]
+
+Image.model_rebuild()
+DataModel.register(Image)
+spec = Image"""
+
+    actual = read_schema(file, data_type="json", model_name="Image")
+    actual = "\n".join(actual.splitlines()[4:])  # remove header
+    assert actual == expected
+
+
+@pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
+def test_read_meta(tmp_dir, catalog):
+    (tmp_dir / "valid.json").write_text(json.dumps(example), encoding="utf8")
+    file = TextFile(path=tmp_dir / "valid.json")
+    file._set_stream(catalog)
+
+    parser = read_meta(
+        schema_from=str(tmp_dir / "valid.json"),
+        meta_type="jsonl",
+        model_name="Image",
+    )
+    rows = list(parser(file))
+    assert len(rows) == 1
+    assert rows[0].model_dump() == example
+
+    (tmp_dir / "invalid.json").write_text(
+        json.dumps({"hello": "world"}), encoding="utf8"
+    )
+    invalid_file = TextFile(path=tmp_dir / "invalid.json")
+    invalid_file._set_stream(catalog)
+    assert not list(parser(invalid_file))


### PR DESCRIPTION
Latest update of pydantic broke `read_schema()`, which fails to correctly resolve annotations.

Please read more here: https://github.com/pydantic/pydantic/pull/10113#issuecomment-2334100659.