### PR TITLE
remove pytest_asyncio lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ namespaces = false
 
 [tool.pytest.ini_options]
 addopts = "-rfEs -m 'not benchmark and not examples'"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
   "benchmark: benchmarks.",
   "e2e: End-to-end tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ tests = [
   "pytest-mock>=3.12.0",
   "pytest-servers[all]>=0.5.5",
   "pytest-benchmark[histogram]",
-  "pytest-asyncio>=0.23.2",
   "pytest-xdist>=3.3.1",
   "virtualenv",
   "dulwich",
@@ -127,7 +126,6 @@ namespaces = false
 
 [tool.pytest.ini_options]
 addopts = "-rfEs -m 'not benchmark and not examples'"
-asyncio_default_fixture_loop_scope = "function"
 markers = [
   "benchmark: benchmarks.",
   "e2e: End-to-end tests",
@@ -137,7 +135,6 @@ markers = [
   "llm_and_nlp: LLM and NLP examples",
   "multimodal: Multimodal examples"
 ]
-asyncio_mode = "auto"
 filterwarnings = [
   "error::pandas.errors.PerformanceWarning",
   "error::pydantic.warnings.PydanticDeprecatedSince20",


### PR DESCRIPTION
When I use Python 3.12, I receive many warnings about the following issue:
```
/Users/lifei/PycharmProjects/datachain/.nox/tests-3-12/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
```
The reason is that the asyncio_default_fixture_loop_scope needs to be explicitly defined. I have added it in this PR.