### PR TITLE
remove some warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,10 @@ filterwarnings = [
   "error::pytest_mock.PytestMockWarning",
   "error::pytest.PytestCollectionWarning",
   "error::sqlalchemy.exc.SADeprecationWarning",
+  "ignore::DeprecationWarning:timm.*",
+  "ignore::DeprecationWarning:botocore.auth",
+  "ignore::DeprecationWarning:datasets.utils._dill",
+  "ignore::DeprecationWarning:librosa.core.intervals",
   "ignore:Field name .* shadows an attribute in parent:UserWarning"  # datachain.lib.feature
 ]
 

--- a/src/datachain/lib/clip.py
+++ b/src/datachain/lib/clip.py
@@ -18,7 +18,7 @@ def _get_encoder(model: Any, type: Literal["image", "text"]) -> Callable:
         hasattr(model, method_name) and inspect.ismethod(getattr(model, method_name))
     ):
         method = getattr(model, method_name)
-        return lambda x: method(torch.tensor(x))
+        return lambda x: method(torch.as_tensor(x).clone().detach())
 
     # Check for model from clip or open_clip library
     method_name = f"encode_{type}"

--- a/src/datachain/lib/image.py
+++ b/src/datachain/lib/image.py
@@ -34,7 +34,7 @@ def convert_image(
             from transformers.image_processing_utils import BaseImageProcessor
 
             if isinstance(transform, BaseImageProcessor):
-                img = torch.tensor(img.pixel_values[0])  # type: ignore[assignment,attr-defined]
+                img = torch.as_tensor(img.pixel_values[0]).clone().detach()  # type: ignore[assignment,attr-defined]
         except ImportError:
             pass
         if device:

--- a/src/datachain/lib/text.py
+++ b/src/datachain/lib/text.py
@@ -33,7 +33,7 @@ def convert_text(
         res = tokenizer(text)
 
     tokens = res.input_ids if isinstance(tokenizer, PreTrainedTokenizerBase) else res
-    tokens = torch.tensor(tokens)
+    tokens = torch.as_tensor(tokens).clone().detach()
     if device:
         tokens = tokens.to(device)
 

--- a/tests/func/test_pytorch.py
+++ b/tests/func/test_pytorch.py
@@ -1,5 +1,6 @@
 import open_clip
 import pytest
+import torch
 from datasets import load_dataset
 from torch import Size, Tensor
 from torchvision.datasets import FakeData
@@ -33,7 +34,9 @@ def fake_dataset(catalog, fake_image_dir):
 
 
 def test_pytorch_dataset(fake_dataset):
-    transform = v2.Compose([v2.ToTensor(), v2.Resize((64, 64))])
+    transform = v2.Compose(
+        [v2.ToImage(), v2.ToDtype(torch.float32, scale=True), v2.Resize((64, 64))]
+    )
     tokenizer = open_clip.get_tokenizer("ViT-B-32")
     pt_dataset = PytorchDataset(
         name=fake_dataset.name,
@@ -49,7 +52,9 @@ def test_pytorch_dataset(fake_dataset):
 
 
 def test_pytorch_dataset_sample(fake_dataset):
-    transform = v2.Compose([v2.ToTensor(), v2.Resize((64, 64))])
+    transform = v2.Compose(
+        [v2.ToImage(), v2.ToDtype(torch.float32, scale=True), v2.Resize((64, 64))]
+    )
     pt_dataset = PytorchDataset(
         name=fake_dataset.name,
         version=fake_dataset.version,
@@ -62,7 +67,9 @@ def test_pytorch_dataset_sample(fake_dataset):
 def test_to_pytorch(fake_dataset):
     from torch.utils.data import IterableDataset
 
-    transform = v2.Compose([v2.ToTensor(), v2.Resize((64, 64))])
+    transform = v2.Compose(
+        [v2.ToImage(), v2.ToDtype(torch.float32, scale=True), v2.Resize((64, 64))]
+    )
     tokenizer = open_clip.get_tokenizer("ViT-B-32")
     pt_dataset = fake_dataset.to_pytorch(transform=transform, tokenizer=tokenizer)
     assert isinstance(pt_dataset, IterableDataset)


### PR DESCRIPTION
When I run the tests, I often encounter warnings related to library dependencies. In my PR, I've ignored warnings coming from third-party libs. And if they come from our own code, I'm rewriting it.
These warnings are need to rewrite code.
```
tests/unit/lib/test_text.py: 1 warning
  /Users/lifei/PycharmProjects/datachain/.nox/tests-3-12/lib/python3.12/site-packages/datachain/lib/text.py:36: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
    tokens = torch.tensor(tokens)

tests/unit/lib/test_clip.py::test_similarity_scores_hf
tests/unit/lib/test_image.py::test_convert_image_hf
  /Users/lifei/PycharmProjects/datachain/.nox/tests-3-12/lib/python3.12/site-packages/datachain/lib/image.py:37: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
    img = torch.tensor(img.pixel_values[0])  # type: ignore[assignment,attr-defined]

tests/unit/lib/test_clip.py::test_similarity_scores_hf
  /Users/lifei/PycharmProjects/datachain/.nox/tests-3-12/lib/python3.12/site-packages/datachain/lib/clip.py:21: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
    return lambda x: method(torch.tensor(x))
```
