### PR TITLE
increase timeout of test for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: nox -s lint
 
   datachain:
-    timeout-minutes: 40
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Another failure here: https://github.com/iterative/datachain/actions/runs/10750425347/job/29816550855?pr=403

There is some more investigation and discussion in https://github.com/iterative/datachain/pull/406