### PR TITLE
disable execution of last query expression by default

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1886,20 +1886,6 @@ class Catalog:
                 "No dataset found after running Query script",
                 output=output,
             ) from e
-
-        dr = self.update_dataset(
-            dr,
-            script_output=output,
-            query_script=query_script,
-        )
-        self.update_dataset_version_with_warehouse_info(
-            dr,
-            dv.version,
-            script_output=output,
-            query_script=query_script,
-            job_id=job_id,
-            is_job_result=True,
-        )
         return QueryResult(dataset=dr, version=dv.version, output=output)
 
     def run_query(

--- a/src/datachain/error.py
+++ b/src/datachain/error.py
@@ -42,10 +42,6 @@ class QueryScriptRunError(Exception):
         super().__init__(self.message)
 
 
-class QueryScriptDatasetNotFound(QueryScriptRunError):  # noqa: N818
-    pass
-
-
 class QueryScriptCancelError(QueryScriptRunError):
     pass
 

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -12,7 +12,6 @@ from datachain.catalog import parse_edatachain_file
 from datachain.cli import garbage_collect
 from datachain.error import (
     QueryScriptCompileError,
-    QueryScriptDatasetNotFound,
     QueryScriptRunError,
     StorageNotFoundError,
 )
@@ -59,7 +58,7 @@ def mock_popen_dataset_created(
     mocker, monkeypatch, mock_popen, cloud_test_catalog, listed_bucket
 ):
     # create dataset which would be created in subprocess
-    ds_name = cloud_test_catalog.catalog.generate_query_dataset_name()
+    ds_name = "my-ds"
     job_id = cloud_test_catalog.catalog.metastore.create_job(name="", query="")
     mocker.patch.object(
         cloud_test_catalog.catalog.metastore, "create_job", return_value=job_id
@@ -910,24 +909,16 @@ def test_query(cloud_test_catalog, mock_popen_dataset_created):
 
     query_script = f"""\
     from datachain.query import C, DatasetQuery
-    DatasetQuery({src_uri!r})
+    DatasetQuery({src_uri!r}).save("my-ds")
     """
     query_script = dedent(query_script)
 
-    result = catalog.query(query_script, save=True)
-    assert result.dataset
-    assert_row_names(
-        catalog,
-        result.dataset,
-        result.version,
-        {
-            "dog1",
-            "dog2",
-            "dog3",
-            "dog4",
-        },
-    )
-    assert result.dataset.sources == ""
+    catalog.query(query_script)
+
+    dataset = catalog.get_dataset("my-ds")
+    assert dataset
+    assert dataset.versions_values == [1]
+    assert_row_names(catalog, dataset, 1, {"dog1", "dog2", "dog3", "dog4"})
 
 
 def test_query_save_size(cloud_test_catalog, mock_popen_dataset_created):
@@ -936,12 +927,17 @@ def test_query_save_size(cloud_test_catalog, mock_popen_dataset_created):
 
     query_script = f"""\
     from datachain.query import C, DatasetQuery
-    DatasetQuery({src_uri!r})
+    DatasetQuery({src_uri!r}).save("my-ds")
     """
     query_script = dedent(query_script)
 
-    result = catalog.query(query_script, save=True)
-    dataset_version = result.dataset.get_version(result.version)
+    catalog.query(query_script)
+
+    dataset = catalog.get_dataset("my-ds")
+    assert dataset
+    assert dataset.versions_values == [1]
+
+    dataset_version = dataset.get_version(1)
     assert dataset_version.num_objects == 4
     assert dataset_version.size == 15
 
@@ -968,21 +964,6 @@ DatasetQuery('{src_uri}')
     with pytest.raises(QueryScriptRunError) as exc_info:
         catalog.query(query_script)
         assert str(exc_info.value).startswith("Query script exited with error code 1")
-
-
-def test_query_dataset_not_returned(mock_popen, cloud_test_catalog):
-    mock_popen.configure_mock(stdout=io.StringIO("random str"))
-    catalog = cloud_test_catalog.catalog
-    src_uri = cloud_test_catalog.src_uri
-
-    query_script = f"""
-from datachain.query import DatasetQuery, C
-DatasetQuery('{src_uri}')
-    """
-
-    with pytest.raises(QueryScriptDatasetNotFound) as e:
-        catalog.query(query_script, save=True)
-    assert e.value.output == "random str"
 
 
 @pytest.mark.parametrize("cloud_type", ["s3", "azure", "gs"], indirect=True)

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -948,7 +948,7 @@ def test_query_fail_to_compile(cloud_test_catalog):
     query_script = "syntax error"
 
     with pytest.raises(QueryScriptCompileError):
-        catalog.query(query_script)
+        catalog.query(query_script, _execute_last_expression=True)
 
 
 def test_query_subprocess_wrong_return_code(mock_popen, cloud_test_catalog):

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -927,7 +927,6 @@ def test_query(cloud_test_catalog, mock_popen_dataset_created):
             "dog4",
         },
     )
-    assert result.dataset.query_script == query_script
     assert result.dataset.sources == ""
 
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -57,7 +57,6 @@ def test_create_dataset_no_version_specified(cloud_test_catalog, create_rows):
     dataset_version = dataset.get_version(1)
 
     assert dataset.name == name
-    assert dataset.query_script == "script"
     assert dataset_version.query_script == "script"
     assert dataset.schema["similarity"] == Float32
     assert dataset_version.schema["similarity"] == Float32
@@ -87,7 +86,6 @@ def test_create_dataset_with_explicit_version(cloud_test_catalog, create_rows):
     dataset_version = dataset.get_version(1)
 
     assert dataset.name == name
-    assert dataset.query_script == "script"
     assert dataset_version.query_script == "script"
     assert dataset.schema["similarity"] == Float32
     assert dataset_version.schema["similarity"] == Float32

--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -189,7 +189,6 @@ def test_query(
 
     assert result.version == 1
     assert result.dataset.versions_values == [1]
-    assert result.dataset.query_script == query_script
     assert_row_names(
         catalog,
         result.dataset,
@@ -255,7 +254,6 @@ def test_query_where_last_command_is_call_on_save_which_returns_attached_dataset
 
     result = catalog.query(query_script, save=True)
     assert not result.dataset.name.startswith(QUERY_DATASET_PREFIX)
-    assert result.dataset.query_script == query_script
     assert result.version == 1
     assert result.dataset.versions_values == [1]
     assert_row_names(
@@ -293,7 +291,6 @@ def test_query_where_last_command_is_attached_dataset_query_created_from_save(
 
     result = catalog.query(query_script, save=True)
     assert result.dataset.name == "dogs"
-    assert result.dataset.query_script == query_script
     assert result.version == 1
     assert result.dataset.versions_values == [1]
     assert_row_names(
@@ -331,7 +328,6 @@ def test_query_where_last_command_is_attached_dataset_query_created_from_query(
 
     result = catalog.query(query_script, save=True)
     assert result.dataset.name == "dogs"
-    assert result.dataset.query_script == query_script
     assert result.version == 1
     assert result.dataset.versions_values == [1]
     assert_row_names(

--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -136,16 +136,16 @@ def test_query_cli_without_dataset_query_as_a_last_statement(
     query_script = f"""\
     from datachain.query import DatasetQuery
 
-    DatasetQuery({src_uri!r}, catalog=catalog).save("temp")
+    DatasetQuery({src_uri!r}, catalog=catalog).save("my-ds")
 
     print("test")
     """
     query_script = setup_catalog(query_script, catalog_info_filepath)
 
-    result = catalog.query(query_script)
-    assert result.dataset
-    assert result.dataset.name == "temp"
-    assert result.version == 1
+    catalog.query(query_script)
+    dataset = catalog.get_dataset("my-ds")
+    assert dataset
+    assert dataset.versions_values == [1]
 
     out, err = capsys.readouterr()
     assert "test" in out


### PR DESCRIPTION
This PR hides the support for execution of last query expression behind a flag, which I plan to remove when Studio is updated.

Also, few other changes have been made to the `query` API:

1. `envs=` keyword argument has been renamed to `env`, similar to `subprocess.Popen(env=)`.
2. `python_executable` default has been changed from `None` to `sys.executable`. And it no longer accepts `None`.
3. The `query` API no longer returns `QueryResult` API. The responsibility is now with the caller, to find out latest dataset version. They are in much better place to do that, since they are the one responsible for creating a `job`.
4. On `capture_output=True`, `query` API no longer prints to the `stdout`. The `output_hook` is responsible to do so now.
5. Exceptions raised on `query` no longer have `output` set. 
6. `QueryScriptDatasetNotFound` has been removed.
7. We no longer set `script_output` and `query_script` to the `DatasetVersion`. This was not used anyway. 

Closes #360.