### PR TITLE
Move 'join' SQL implementation to warehouse

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
     from sqlalchemy.dialects.sqlite import Insert
     from sqlalchemy.engine.base import Engine
     from sqlalchemy.schema import SchemaItem
+    from sqlalchemy.sql._typing import _FromClauseArgument, _OnClauseArgument
     from sqlalchemy.sql.elements import ColumnElement
+    from sqlalchemy.sql.selectable import Join
     from sqlalchemy.types import TypeEngine
 
     from datachain.lib.file import File
@@ -787,6 +789,23 @@ class SQLiteWarehouse(AbstractWarehouse):
 
             if progress_cb:
                 progress_cb(len(batch_ids))
+
+    def join(
+        self,
+        left: "_FromClauseArgument",
+        right: "_FromClauseArgument",
+        onclause: "_OnClauseArgument",
+        inner: bool = True,
+    ) -> "Join":
+        """
+        Join two tables together.
+        """
+        return sqlalchemy.join(
+            left,
+            right,
+            onclause,
+            isouter=not inner,
+        )
 
     def create_pre_udf_table(self, query: "Select") -> "Table":
         """

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
         _FromClauseArgument,
         _OnClauseArgument,
     )
-    from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.selectable import Join, Select
     from sqlalchemy.types import TypeEngine
 

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -27,8 +27,13 @@ from datachain.storage import StorageURI
 from datachain.utils import sql_escape_like
 
 if TYPE_CHECKING:
-    from sqlalchemy.sql._typing import _ColumnsClauseArgument
-    from sqlalchemy.sql.selectable import Select
+    from sqlalchemy.sql._typing import (
+        _ColumnsClauseArgument,
+        _FromClauseArgument,
+        _OnClauseArgument,
+    )
+    from sqlalchemy.sql.elements import ColumnElement
+    from sqlalchemy.sql.selectable import Join, Select
     from sqlalchemy.types import TypeEngine
 
     from datachain.data_storage import AbstractIDGenerator, schema
@@ -892,6 +897,18 @@ class AbstractWarehouse(ABC, Serializable):
     ) -> None:
         """
         Copy the results of a query into a table.
+        """
+
+    @abstractmethod
+    def join(
+        self,
+        left: "_FromClauseArgument",
+        right: "_FromClauseArgument",
+        onclause: "_OnClauseArgument",
+        inner: bool = True,
+    ) -> "Join":
+        """
+        Join two tables together.
         """
 
     @abstractmethod

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -938,7 +938,7 @@ class AbstractWarehouse(ABC, Serializable):
         are cleaned up as soon as they are no longer needed.
         """
         with tqdm(desc="Cleanup", unit=" tables") as pbar:
-            for name in names:
+            for name in set(names):
                 self.db.drop_table(Table(name, self.db.metadata), if_exists=True)
                 pbar.update(1)
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -33,7 +33,6 @@ from sqlalchemy.sql.elements import ColumnClause, ColumnElement
 from sqlalchemy.sql.expression import label
 from sqlalchemy.sql.schema import TableClause
 from sqlalchemy.sql.selectable import Select
-from tqdm import tqdm
 
 from datachain.asyn import ASYNC_WORKERS, AsyncMapper, OrderedMapper
 from datachain.catalog import QUERY_SCRIPT_CANCELED_EXIT_CODE, get_catalog
@@ -899,11 +898,37 @@ class SQLUnion(Step):
 
 @frozen
 class SQLJoin(Step):
+    catalog: "Catalog"
     query1: "DatasetQuery"
     query2: "DatasetQuery"
     predicates: Union[JoinPredicateType, tuple[JoinPredicateType, ...]]
     inner: bool
     rname: str
+
+    def get_query(self, query: "DatasetQuery", temp_tables: list[str]) -> sa.Subquery:
+        select_query = query.apply_steps().select()
+        temp_tables.extend(query.temp_table_names)
+
+        if not any(isinstance(step, (SQLJoin, SQLUnion)) for step in query.steps):
+            return select_query.subquery(query.table.name)
+
+        warehouse = self.catalog.warehouse
+
+        table_name = warehouse.temp_table_name()
+        columns = [
+            c if isinstance(c, Column) else Column(c.name, c.type)
+            for c in select_query.columns
+        ]
+        temp_table = warehouse.create_dataset_rows_table(
+            table_name,
+            columns=columns,
+            if_not_exists=False,
+        )
+        temp_tables.append(temp_table.name)
+
+        warehouse.copy_table(temp_table, select_query)
+
+        return temp_table.select().subquery(query.table.name)
 
     def validate_expression(self, exp: "ClauseElement", q1, q2):
         """
@@ -937,10 +962,8 @@ class SQLJoin(Step):
     def apply(
         self, query_generator: QueryGenerator, temp_tables: list[str]
     ) -> StepResult:
-        q1 = self.query1.apply_steps().select().subquery(self.query1.table.name)
-        temp_tables.extend(self.query1.temp_table_names)
-        q2 = self.query2.apply_steps().select().subquery(self.query2.table.name)
-        temp_tables.extend(self.query2.temp_table_names)
+        q1 = self.get_query(self.query1, temp_tables)
+        q2 = self.get_query(self.query2, temp_tables)
 
         q1_columns = list(q1.c)
         q1_column_names = {c.name for c in q1_columns}
@@ -979,15 +1002,13 @@ class SQLJoin(Step):
         self.validate_expression(join_expression, q1, q2)
 
         def q(*columns):
-            join_query = sqlalchemy.join(
+            join_query = self.catalog.warehouse.join(
                 q1,
                 q2,
                 join_expression,
-                isouter=not self.inner,
+                inner=self.inner,
             )
-
-            res = sqlalchemy.select(*columns).select_from(join_query)
-            subquery = res.subquery()
+            subquery = sqlalchemy.select(*columns).select_from(join_query).subquery()
             return sqlalchemy.select(*subquery.c).select_from(subquery)
 
         return step_result(
@@ -1511,7 +1532,7 @@ class DatasetQuery:
             if isinstance(predicates, (str, ColumnClause, ColumnElement))
             else tuple(predicates)
         )
-        new_query.steps = [SQLJoin(left, right, predicates, inner, rname)]
+        new_query.steps = [SQLJoin(self.catalog, left, right, predicates, inner, rname)]
         return new_query
 
     @detach
@@ -1687,12 +1708,7 @@ class DatasetQuery:
 
             dr = self.catalog.warehouse.dataset_rows(dataset)
 
-            with tqdm(desc="Saving", unit=" rows") as pbar:
-                self.catalog.warehouse.copy_table(
-                    dr.get_table(),
-                    query.select(),
-                    progress_cb=pbar.update,
-                )
+            self.catalog.warehouse.copy_table(dr.get_table(), query.select())
 
             self.catalog.metastore.update_dataset_status(
                 dataset, DatasetStatus.COMPLETE, version=version

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -1373,20 +1373,20 @@ def test_union_join(cloud_test_catalog, inner):
     if inner:
         assert len(signals) == 4
         assert signals == [
-            {'path': 'dogs/dog1', 'sig1': 1, 'sig2': 2},
-            {'path': 'dogs/dog2', 'sig1': 1, 'sig2': 2},
-            {'path': 'dogs/dog3', 'sig1': 1, 'sig2': 2},
-            {'path': 'dogs/others/dog4', 'sig1': 1, 'sig2': 2},
+            {"path": "dogs/dog1", "sig1": 1, "sig2": 2},
+            {"path": "dogs/dog2", "sig1": 1, "sig2": 2},
+            {"path": "dogs/dog3", "sig1": 1, "sig2": 2},
+            {"path": "dogs/others/dog4", "sig1": 1, "sig2": 2},
         ]
     else:
         assert len(signals) == 6
         assert signals == [
-            {'path': 'dogs/dog1', 'sig1': 1, 'sig2': 2},
-            {'path': 'dogs/dog2', 'sig1': 1, 'sig2': 2},
-            {'path': 'dogs/dog3', 'sig1': 1, 'sig2': 2},
-            {'path': 'dogs/others/dog4', 'sig1': 1, 'sig2': 2},
-            {'path': 'cats/cat1', 'sig1': 1, 'sig2': None},
-            {'path': 'cats/cat2', 'sig1': 1, 'sig2': None},
+            {"path": "dogs/dog1", "sig1": 1, "sig2": 2},
+            {"path": "dogs/dog2", "sig1": 1, "sig2": 2},
+            {"path": "dogs/dog3", "sig1": 1, "sig2": 2},
+            {"path": "dogs/others/dog4", "sig1": 1, "sig2": 2},
+            {"path": "cats/cat1", "sig1": 1, "sig2": None},
+            {"path": "cats/cat2", "sig1": 1, "sig2": None},
         ]
 
 
@@ -1418,7 +1418,7 @@ def test_multiple_join(cloud_test_catalog, inner1, inner2, inner3):
     def signals2():
         return (2,)
 
-    dogs_and_cats = (dogs | cats)
+    dogs_and_cats = dogs | cats
     dogs1 = dogs.add_signals(signals1)
     cats1 = cats.add_signals(signals2)
     dogs2 = dogs_and_cats.join(dogs1, C.path, inner=inner1)
@@ -1431,19 +1431,19 @@ def test_multiple_join(cloud_test_catalog, inner1, inner2, inner3):
     ]
     if inner1:
         assert dogs2_signals == [
-            {'path': 'dogs/dog1', 'sig1': 1},
-            {'path': 'dogs/dog2', 'sig1': 1},
-            {'path': 'dogs/dog3', 'sig1': 1},
-            {'path': 'dogs/others/dog4', 'sig1': 1},
+            {"path": "dogs/dog1", "sig1": 1},
+            {"path": "dogs/dog2", "sig1": 1},
+            {"path": "dogs/dog3", "sig1": 1},
+            {"path": "dogs/others/dog4", "sig1": 1},
         ]
     else:
         assert dogs2_signals == [
-            {'path': 'dogs/dog1', 'sig1': 1},
-            {'path': 'dogs/dog2', 'sig1': 1},
-            {'path': 'dogs/dog3', 'sig1': 1},
-            {'path': 'dogs/others/dog4', 'sig1': 1},
-            {'path': 'cats/cat1', 'sig1': None},
-            {'path': 'cats/cat2', 'sig1': None},
+            {"path": "dogs/dog1", "sig1": 1},
+            {"path": "dogs/dog2", "sig1": 1},
+            {"path": "dogs/dog3", "sig1": 1},
+            {"path": "dogs/others/dog4", "sig1": 1},
+            {"path": "cats/cat1", "sig1": None},
+            {"path": "cats/cat2", "sig1": None},
         ]
 
     cats2_signals = [
@@ -1452,17 +1452,17 @@ def test_multiple_join(cloud_test_catalog, inner1, inner2, inner3):
     ]
     if inner2:
         assert cats2_signals == [
-            {'path': 'cats/cat1', 'sig2': 2},
-            {'path': 'cats/cat2', 'sig2': 2}
+            {"path": "cats/cat1", "sig2": 2},
+            {"path": "cats/cat2", "sig2": 2},
         ]
     else:
         assert cats2_signals == [
-            {'path': 'dogs/dog1', 'sig2': None},
-            {'path': 'dogs/dog2', 'sig2': None},
-            {'path': 'dogs/dog3', 'sig2': None},
-            {'path': 'dogs/others/dog4', 'sig2': None},
-            {'path': 'cats/cat1', 'sig2': 2},
-            {'path': 'cats/cat2', 'sig2': 2},
+            {"path": "dogs/dog1", "sig2": None},
+            {"path": "dogs/dog2", "sig2": None},
+            {"path": "dogs/dog3", "sig2": None},
+            {"path": "dogs/others/dog4", "sig2": None},
+            {"path": "cats/cat1", "sig2": 2},
+            {"path": "cats/cat2", "sig2": 2},
         ]
 
     joined_signals = [
@@ -1473,24 +1473,24 @@ def test_multiple_join(cloud_test_catalog, inner1, inner2, inner3):
         assert joined_signals == []
     elif inner1:
         assert joined_signals == [
-            {'path': 'dogs/dog1', 'sig1': 1, 'sig2': None},
-            {'path': 'dogs/dog2', 'sig1': 1, 'sig2': None},
-            {'path': 'dogs/dog3', 'sig1': 1, 'sig2': None},
-            {'path': 'dogs/others/dog4', 'sig1': 1, 'sig2': None},
+            {"path": "dogs/dog1", "sig1": 1, "sig2": None},
+            {"path": "dogs/dog2", "sig1": 1, "sig2": None},
+            {"path": "dogs/dog3", "sig1": 1, "sig2": None},
+            {"path": "dogs/others/dog4", "sig1": 1, "sig2": None},
         ]
     elif inner2 and inner3:
         assert joined_signals == [
-            {'path': 'cats/cat1', 'sig1': None, 'sig2': 2},
-            {'path': 'cats/cat2', 'sig1': None, 'sig2': 2},
+            {"path": "cats/cat1", "sig1": None, "sig2": 2},
+            {"path": "cats/cat2", "sig1": None, "sig2": 2},
         ]
     else:
         assert joined_signals == [
-            {'path': 'dogs/dog1', 'sig1': 1, 'sig2': None},
-            {'path': 'dogs/dog2', 'sig1': 1, 'sig2': None},
-            {'path': 'dogs/dog3', 'sig1': 1, 'sig2': None},
-            {'path': 'dogs/others/dog4', 'sig1': 1, 'sig2': None},
-            {'path': 'cats/cat1', 'sig1': None, 'sig2': 2},
-            {'path': 'cats/cat2', 'sig1': None, 'sig2': 2},
+            {"path": "dogs/dog1", "sig1": 1, "sig2": None},
+            {"path": "dogs/dog2", "sig1": 1, "sig2": None},
+            {"path": "dogs/dog3", "sig1": 1, "sig2": None},
+            {"path": "dogs/others/dog4", "sig1": 1, "sig2": None},
+            {"path": "cats/cat1", "sig1": None, "sig2": 2},
+            {"path": "cats/cat2", "sig1": None, "sig2": 2},
         ]
 
 


### PR DESCRIPTION
Fix for the https://github.com/iterative/studio/issues/10602

In this PR:

- do not generate multiple `join` SQL queries as it could be quite heavy for some warehouse implementations (e.g. ClickHouse, see related PR), if there is `join` (or `union`) found in chain, save results in temporary table and run chain from there. See implementation [here](https://github.com/iterative/datachain/compare/sql-merge-refactoring?expand=1#diff-5cd0b1bd1147a2704c8c333fdb16b0fa21c66e6f5101e4889f7a624d5da4c7cfR916-R935).
- move `join` implementation to warehouse to be able to tweak `join` (e.g. in ClickHouse, see [related PR](https://github.com/iterative/studio/pull/10634))
- [remove](https://github.com/iterative/datachain/compare/sql-merge-refactoring?expand=1#diff-5cd0b1bd1147a2704c8c333fdb16b0fa21c66e6f5101e4889f7a624d5da4c7cfL1694) `tqdm` from `save` method as it was added in previous PR as an experimental and not really needed here. Questionable.