### PR TITLE
use hf transfer in stateful example

### DIFF
--- a/examples/get_started/udfs/stateful.py
+++ b/examples/get_started/udfs/stateful.py
@@ -5,6 +5,10 @@ To install dependencies:
 
 """
 
+import os
+
+os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
 import open_clip
 
 from datachain import C, DataChain, Mapper


### PR DESCRIPTION
This PR switches on `hf_transfer` in the stateful example. This should speed the example up.

I've also seen some intermittent failures in the CI for this example. Hopefully, this helps with reliability.