### PR TITLE
Ignore Pydantic 'Field name "json" shadows an attribute in parent' warning

### DIFF
--- a/src/datachain/lib/webdataset.py
+++ b/src/datachain/lib/webdataset.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import tarfile
+import warnings
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import (
@@ -18,6 +19,18 @@ from pydantic import Field
 from datachain.lib.data_model import DataModel
 from datachain.lib.file import File, TarVFile
 from datachain.lib.utils import DataChainError
+
+# The `json` method of the Pydantic `BaseModel` class has been deprecated
+# and will be removed in Pydantic v3. For more details, see:
+# https://github.com/pydantic/pydantic/issues/10033
+# Until then, we can ignore the warning.
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message=(
+        'Field name "json" in "WDSAllFile" shadows an attribute in parent "WDSBasic"'
+    ),
+)
 
 
 class WDSError(DataChainError):

--- a/src/datachain/lib/webdataset_laion.py
+++ b/src/datachain/lib/webdataset_laion.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Iterator
 from typing import Optional
 
@@ -6,6 +7,18 @@ from pydantic import BaseModel, Field
 
 from datachain.lib.file import File
 from datachain.lib.webdataset import WDSBasic, WDSReadableSubclass
+
+# The `json` method of the Pydantic `BaseModel` class has been deprecated
+# and will be removed in Pydantic v3. For more details, see:
+# https://github.com/pydantic/pydantic/issues/10033
+# Until then, we can ignore the warning.
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message=(
+        'Field name "json" in "WDSLaion" shadows an attribute in parent "WDSBasic"'
+    ),
+)
 
 
 class Laion(WDSReadableSubclass):


### PR DESCRIPTION
Every time user runs DataChain query they've got these warnings, in both CLI and Studio:

```
/Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/pydantic/_internal/_fields.py:200: UserWarning: Field name "json" in "WDSAllFile" shadows an attribute in parent "WDSBasic"
  warnings.warn(
/Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/pydantic/_internal/_fields.py:200: UserWarning: Field name "json" in "WDSLaion" shadows an attribute in parent "WDSBasic"
  warnings.warn(
```

It is noisy and looks suspicious. Also in parallel mode user gets multiple set of these warnings.

The reason why these warnings appears is in [WDSAllFile](https://github.com/iterative/datachain/compare/ignore-pydantic-parent-shadows-json-attribute-warning?expand=1#diff-efced1e58607a221158f62b6c7fa4ccd86cdcaef0951b208e22db4ebdb9b48bcR76) and [WDSLaion](https://github.com/iterative/datachain/compare/ignore-pydantic-parent-shadows-json-attribute-warning?expand=1#diff-b8c60cfbce9aa3c7b7fb7fe6ab79a78c660864a8b822a77702cf305c1766ea61R46) models we are using `json` field.

Pydantic BaseModel have [deprecated json](https://github.com/pydantic/pydantic/blob/main/pydantic/main.py#L1121-L1122) method, and it [will be removed in Pydantic v3](https://github.com/pydantic/pydantic/issues/10033).

My suggestion is to suppress these two specific warnings until Pydantic v3 release.