### PR TITLE
patch psutil virtual memory for test suite in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os.path
 import uuid
 from collections.abc import Generator
 from pathlib import PosixPath
+from typing import NamedTuple
 
 import attrs
 import pytest
@@ -30,6 +31,29 @@ DEFAULT_DATACHAIN_BIN = "datachain"
 DEFAULT_DATACHAIN_GIT_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 collect_ignore = ["setup.py"]
+
+
+@pytest.fixture(autouse=True)
+def virtual_memory(mocker):
+    class VirtualMemory(NamedTuple):
+        total: int
+        available: int
+        percent: int
+        used: int
+        free: int
+
+    return mocker.patch(
+        "psutil.virtual_memory",
+        return_value=VirtualMemory(
+            total=1073741824,
+            available=5368709120,
+            # prevent dumping of smaller batches to db in process_udf_outputs
+            # we want to avoid this due to tests running concurrently (xdist)
+            percent=50,
+            used=5368709120,
+            free=5368709120,
+        ),
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Related to #405 / #406

I have a theory that in the Windows CI `psutil.virtual_memory().percent > 80` is being hit often in `process_udf_outputs` (which is executed under parallel mode).  Code is below: 
https://github.com/iterative/datachain/blob/424b05b840a047a7801016cf91cb19a545ea5402/src/datachain/query/dataset.py#L383-L410

This would mean that we are concurrently writing to the warehouse more often, giving the UDF far more chance to fail due to SQLite locks.

This PR patches `psutil.virtual_memory` to be automatically pinned at 50% utilised for the entirety of the test suite.