### PR TITLE
use the correct fixtures in tests

### DIFF
--- a/tests/examples/test_wds_e2e.py
+++ b/tests/examples/test_wds_e2e.py
@@ -69,10 +69,10 @@ def webdataset_metadata(tmp_path):
     return metadata_path
 
 
-def test_wds(catalog, webdataset_tars):
-    res = DataChain.from_storage(Path(webdataset_tars).as_uri()).gen(
-        laion=process_webdataset(spec=WDSLaion), params="file"
-    )
+def test_wds(test_session, webdataset_tars):
+    res = DataChain.from_storage(
+        Path(webdataset_tars).as_uri(), session=test_session
+    ).gen(laion=process_webdataset(spec=WDSLaion), params="file")
 
     num_rows = 0
     for laion_wds in res.collect("laion"):
@@ -95,10 +95,12 @@ def test_wds(catalog, webdataset_tars):
     assert num_rows == len(WDS_TAR_SHARDS)
 
 
-def test_wds_merge_with_parquet_meta(catalog, webdataset_tars, webdataset_metadata):
-    wds = DataChain.from_storage(Path(webdataset_tars).as_uri()).gen(
-        laion=process_webdataset(spec=WDSLaion), params="file"
-    )
+def test_wds_merge_with_parquet_meta(
+    test_session, webdataset_tars, webdataset_metadata
+):
+    wds = DataChain.from_storage(
+        Path(webdataset_tars).as_uri(), session=test_session
+    ).gen(laion=process_webdataset(spec=WDSLaion), params="file")
 
     meta = DataChain.from_parquet(Path(webdataset_metadata).as_uri())
 

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -453,8 +453,8 @@ def test_from_storage_check_rows(tmp_dir, test_session):
         )
 
 
-def test_mutate_existing_column(catalog):
-    ds = DataChain.from_values(ids=[1, 2, 3])
+def test_mutate_existing_column(test_session):
+    ds = DataChain.from_values(ids=[1, 2, 3], session=test_session)
 
     with pytest.raises(DataChainColumnError) as excinfo:
         ds.mutate(ids=Column("ids") + 1)

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -213,7 +213,7 @@ def run_step(step):
 
 
 @pytest.mark.e2e
-def test_cli_e2e(tmp_dir, catalog):
+def test_cli_e2e(tmp_dir, catalog_tmpfile):
     """End-to-end CLI Test"""
     for step in E2E_STEPS:
         run_step(step)

--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -243,7 +243,7 @@ def run_step(step):  # noqa: PLR0912
 
 
 @pytest.mark.e2e
-def test_query_e2e(tmp_dir, catalog):
+def test_query_e2e(tmp_dir, catalog_tmpfile):
     """End-to-end CLI Query Test"""
     for step in E2E_STEPS:
         run_step(step)


### PR DESCRIPTION
Here I've switched over from catalog to test_session in a few tests and then from catalog to catalog_tmpfile in some tests that use parallel processing.