### PR TITLE
Refactor `Client.parse_url()`

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -621,10 +621,6 @@ class Catalog:
                 code_ast.body[-1:] = new_expressions
         return code_ast
 
-    def parse_url(self, uri: str, **config: Any) -> tuple[Client, str]:
-        config = config or self.client_config
-        return Client.parse_url(uri, self.cache, **config)
-
     def get_client(self, uri: StorageURI, **config: Any) -> Client:
         """
         Return the client corresponding to the given source `uri`.
@@ -651,17 +647,16 @@ class Catalog:
         partial_path: Optional[str]
 
         client_config = client_config or self.client_config
-        client, path = self.parse_url(source, **client_config)
+        uri, path = Client.parse_url(source)
+        client = Client.get_client(source, self.cache, **client_config)
         stem = os.path.basename(os.path.normpath(path))
         prefix = (
             posixpath.dirname(path)
             if glob.has_magic(stem) or client.fs.isfile(source)
             else path
         )
-        storage_dataset_name = Storage.dataset_name(
-            client.uri, posixpath.join(prefix, "")
-        )
-        source_metastore = self.metastore.clone(client.uri)
+        storage_dataset_name = Storage.dataset_name(uri, posixpath.join(prefix, ""))
+        source_metastore = self.metastore.clone(uri)
 
         columns = [
             Column("path", String),
@@ -675,15 +670,13 @@ class Catalog:
         ]
 
         if skip_indexing:
-            source_metastore.create_storage_if_not_registered(client.uri)
-            storage = source_metastore.get_storage(client.uri)
-            source_metastore.init_partial_id(client.uri)
-            partial_id = source_metastore.get_next_partial_id(client.uri)
+            source_metastore.create_storage_if_not_registered(uri)
+            storage = source_metastore.get_storage(uri)
+            source_metastore.init_partial_id(uri)
+            partial_id = source_metastore.get_next_partial_id(uri)
 
-            source_metastore = self.metastore.clone(
-                uri=client.uri, partial_id=partial_id
-            )
-            source_metastore.init(client.uri)
+            source_metastore = self.metastore.clone(uri=uri, partial_id=partial_id)
+            source_metastore.init(uri)
 
             source_warehouse = self.warehouse.clone()
             dataset = self.create_dataset(
@@ -701,20 +694,16 @@ class Catalog:
             in_progress,
             partial_id,
             partial_path,
-        ) = source_metastore.register_storage_for_indexing(
-            client.uri, force_update, prefix
-        )
+        ) = source_metastore.register_storage_for_indexing(uri, force_update, prefix)
         if in_progress:
             raise PendingIndexingError(f"Pending indexing operation: uri={storage.uri}")
 
         if not need_index:
             assert partial_id is not None
             assert partial_path is not None
-            source_metastore = self.metastore.clone(
-                uri=client.uri, partial_id=partial_id
-            )
+            source_metastore = self.metastore.clone(uri=uri, partial_id=partial_id)
             source_warehouse = self.warehouse.clone()
-            dataset = self.get_dataset(Storage.dataset_name(client.uri, partial_path))
+            dataset = self.get_dataset(Storage.dataset_name(uri, partial_path))
             lst = Listing(storage, source_metastore, source_warehouse, client, dataset)
             logger.debug(
                 "Using cached listing %s. Valid till: %s",
@@ -731,11 +720,11 @@ class Catalog:
 
             return lst, path
 
-        source_metastore.init_partial_id(client.uri)
-        partial_id = source_metastore.get_next_partial_id(client.uri)
+        source_metastore.init_partial_id(uri)
+        partial_id = source_metastore.get_next_partial_id(uri)
 
-        source_metastore.init(client.uri)
-        source_metastore = self.metastore.clone(uri=client.uri, partial_id=partial_id)
+        source_metastore.init(uri)
+        source_metastore = self.metastore.clone(uri=uri, partial_id=partial_id)
 
         source_warehouse = self.warehouse.clone()
 
@@ -1370,7 +1359,7 @@ class Catalog:
 
     def signed_url(self, source: str, path: str, client_config=None) -> str:
         client_config = client_config or self.client_config
-        client, _ = self.parse_url(source, **client_config)
+        client = Client.get_client(source, self.cache, **client_config)
         return client.url(path)
 
     def export_dataset_table(

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -116,7 +116,7 @@ class Client(ABC):
         return DATA_SOURCE_URI_PATTERN.match(name) is not None
 
     @staticmethod
-    def parse_url(
+    def parse_url_old(
         source: str,
         cache: DataChainCache,
         **kwargs,
@@ -125,6 +125,18 @@ class Client(ABC):
         storage_url, rel_path = cls.split_url(source)
         client = cls.from_name(storage_url, cache, kwargs)
         return client, rel_path
+
+    @staticmethod
+    def parse_url(source: str) -> tuple[StorageURI, str]:
+        cls = Client.get_implementation(source)
+        storage_name, rel_path = cls.split_url(source)
+        return cls.get_uri(storage_name), rel_path
+
+    @staticmethod
+    def get_client(source: str, cache: DataChainCache, **kwargs) -> "Client":
+        cls = Client.get_implementation(source)
+        storage_url, _ = cls.split_url(source)
+        return cls.from_name(storage_url, cache, kwargs)
 
     @classmethod
     def create_fs(cls, **kwargs) -> "AbstractFileSystem":

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -116,17 +116,6 @@ class Client(ABC):
         return DATA_SOURCE_URI_PATTERN.match(name) is not None
 
     @staticmethod
-    def parse_url_old(
-        source: str,
-        cache: DataChainCache,
-        **kwargs,
-    ) -> tuple["Client", str]:
-        cls = Client.get_implementation(source)
-        storage_url, rel_path = cls.split_url(source)
-        client = cls.from_name(storage_url, cache, kwargs)
-        return client, rel_path
-
-    @staticmethod
     def parse_url(source: str) -> tuple[StorageURI, str]:
         cls = Client.get_implementation(source)
         storage_name, rel_path = cls.split_url(source)

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -408,7 +408,11 @@ class DataChain(DatasetQuery):
                     in_memory=in_memory,
                 )
                 .gen(
-                    list_bucket(list_uri, client_config=session.catalog.client_config),
+                    list_bucket(
+                        list_uri,
+                        session.catalog.cache,
+                        client_config=session.catalog.client_config,
+                    ),
                     output={f"{object_name}": File},
                 )
                 .save(list_dataset_name, listing=True)

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -20,7 +20,7 @@ LISTING_TTL = 4 * 60 * 60  # cached listing lasts 4 hours
 LISTING_PREFIX = "lst__"  # listing datasets start with this name
 
 
-def list_bucket(uri: str, client_config=None) -> Callable:
+def list_bucket(uri: str, cache, client_config=None) -> Callable:
     """
     Function that returns another generator function that yields File objects
     from bucket where each File represents one bucket entry.
@@ -28,10 +28,11 @@ def list_bucket(uri: str, client_config=None) -> Callable:
 
     def list_func() -> Iterator[File]:
         config = client_config or {}
-        client, path = Client.parse_url(uri, None, **config)  # type: ignore[arg-type]
+        client = Client.get_client(uri, cache, **config)  # type: ignore[arg-type]
+        storage_uri, path = Client.parse_url(uri)
         for entries in iter_over_async(client.scandir(path.rstrip("/")), get_loop()):
             for entry in entries:
-                yield entry.to_file(client.uri)
+                yield entry.to_file(storage_uri)
 
     return list_func
 
@@ -77,16 +78,17 @@ def parse_listing_uri(uri: str, cache, client_config) -> tuple[str, str, str]:
     """
     Parsing uri and returns listing dataset name, listing uri and listing path
     """
-    client, path = Client.parse_url(uri, cache, **client_config)
+    client = Client.get_client(uri, cache, **client_config)
+    storage_uri, path = Client.parse_url(uri)
 
     # clean path without globs
     lst_uri_path = (
         posixpath.dirname(path) if uses_glob(path) or client.fs.isfile(uri) else path
     )
 
-    lst_uri = f"{client.uri}/{lst_uri_path.lstrip('/')}"
+    lst_uri = f"{storage_uri}/{lst_uri_path.lstrip('/')}"
     ds_name = (
-        f"{LISTING_PREFIX}{client.uri}/{posixpath.join(lst_uri_path, '').lstrip('/')}"
+        f"{LISTING_PREFIX}{storage_uri}/{posixpath.join(lst_uri_path, '').lstrip('/')}"
     )
 
     return ds_name, lst_uri, path

--- a/src/datachain/lib/listing_info.py
+++ b/src/datachain/lib/listing_info.py
@@ -13,8 +13,8 @@ class ListingInfo(DatasetInfo):
 
     @property
     def storage_uri(self) -> str:
-        client, _ = Client.parse_url(self.uri, None)  # type: ignore[arg-type]
-        return client.uri
+        uri, _ = Client.parse_url(self.uri)
+        return uri
 
     @property
     def expires(self) -> Optional[datetime]:

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -37,6 +37,7 @@ from tqdm import tqdm
 
 from datachain.asyn import ASYNC_WORKERS, AsyncMapper, OrderedMapper
 from datachain.catalog import QUERY_SCRIPT_CANCELED_EXIT_CODE, get_catalog
+from datachain.client import Client
 from datachain.data_storage.schema import (
     PARTITION_COLUMN_ID,
     partition_col_names,
@@ -194,7 +195,7 @@ class IndexingStep(StartingStep):
 
     def apply(self):
         self.catalog.index([self.path], **self.kwargs)
-        uri, path = self.parse_path()
+        uri, path = Client.parse_url(self.path)
         _partial_id, partial_path = self.catalog.metastore.get_valid_partial_id(
             uri, path
         )
@@ -215,11 +216,6 @@ class IndexingStep(StartingStep):
         storage = self.catalog.metastore.get_storage(uri)
 
         return step_result(q, dataset_rows.c, dependencies=[storage.uri])
-
-    def parse_path(self):
-        client_config = self.kwargs.get("client_config") or {}
-        client, path = self.catalog.parse_url(self.path, **client_config)
-        return client.uri, path
 
 
 def generator_then_call(generator, func: Callable):

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -6,11 +6,12 @@ from tests.data import ENTRIES
 
 def test_listing_generator(cloud_test_catalog, cloud_type):
     ctc = cloud_test_catalog
+    catalog = ctc.catalog
 
     uri = f"{ctc.src_uri}/cats"
 
     dc = DataChain.from_records(DataChain.DEFAULT_FILE_RECORD).gen(
-        file=list_bucket(uri, client_config=ctc.catalog.client_config)
+        file=list_bucket(uri, catalog.cache, client_config=catalog.client_config)
     )
     assert dc.count() == 2
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -261,7 +261,7 @@ def test_listings(test_session, tmp_dir):
     df.to_parquet(tmp_dir / "df.parquet")
 
     uri = tmp_dir.as_uri()
-    client, _ = Client.parse_url(uri, test_session.catalog.cache)
+    client = Client.get_client(uri, test_session.catalog.cache)
 
     DataChain.from_storage(uri, session=test_session)
 
@@ -292,7 +292,7 @@ def test_listings_reindex(test_session, tmp_dir):
     df.to_parquet(tmp_dir / "df.parquet")
 
     uri = tmp_dir.as_uri()
-    client, _ = Client.parse_url(uri, test_session.catalog.cache)
+    client = Client.get_client(uri, test_session.catalog.cache)
 
     DataChain.from_storage(uri, session=test_session)
     assert len(list(DataChain.listings(session=test_session).collect("listing"))) == 1


### PR DESCRIPTION
Refactoring `Client.parse_url()` into two methods:
1. `def parse_url(source: str) -> tuple[StorageURI, str]:` -> just splits `source` into storage uri and relative path and doesn't return `Client` instance any more. 
2. `def get_client(source: str, cache: DataChainCache, **kwargs) -> "Client":` -> returns `Client` instance

This is done because in most of the places we were using old `.parse_url()` to split URL and didn't care about `Client` instance, but because `Client` instance was returned, some additional args like `cache` were needed. 

Now we can use simpler merhod `.parse_url()` where we just need storage uri and path and `.get_client()` where actual `Client` instance is needed