### PR TITLE
query: remove compat for executing last query expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "shtab>=1.3.4,<2",
   "sqlalchemy>=2",
   "multiprocess==0.70.16",
-  "dill==0.3.8",
   "cloudpickle",
   "orjson>=3.10.5",
   "pydantic>=2,<3",

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -11,6 +11,7 @@ from datachain.lib.file import (
 from datachain.lib.model_store import ModelStore
 from datachain.lib.udf import Aggregator, Generator, Mapper
 from datachain.lib.utils import AbstractUDF, DataChainError
+from datachain.query import metrics, param
 from datachain.query.session import Session
 
 __all__ = [
@@ -34,4 +35,6 @@ __all__ = [
     "TarVFile",
     "TextFile",
     "is_chain_type",
+    "metrics",
+    "param",
 ]

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1,4 +1,3 @@
-import ast
 import glob
 import io
 import json
@@ -55,7 +54,6 @@ from datachain.error import (
     DatasetNotFoundError,
     PendingIndexingError,
     QueryScriptCancelError,
-    QueryScriptCompileError,
     QueryScriptRunError,
 )
 from datachain.listing import Listing
@@ -587,37 +585,6 @@ class Catalog:
     @classmethod
     def generate_query_dataset_name(cls) -> str:
         return f"{QUERY_DATASET_PREFIX}_{uuid4().hex}"
-
-    def attach_query_wrapper(self, code_ast):
-        if code_ast.body:
-            last_expr = code_ast.body[-1]
-            if isinstance(last_expr, ast.Expr):
-                new_expressions = [
-                    ast.Import(
-                        names=[ast.alias(name="datachain.query.dataset", asname=None)]
-                    ),
-                    ast.Expr(
-                        value=ast.Call(
-                            func=ast.Attribute(
-                                value=ast.Attribute(
-                                    value=ast.Attribute(
-                                        value=ast.Name(id="datachain", ctx=ast.Load()),
-                                        attr="query",
-                                        ctx=ast.Load(),
-                                    ),
-                                    attr="dataset",
-                                    ctx=ast.Load(),
-                                ),
-                                attr="query_wrapper",
-                                ctx=ast.Load(),
-                            ),
-                            args=[last_expr],
-                            keywords=[],
-                        )
-                    ),
-                ]
-                code_ast.body[-1:] = new_expressions
-        return code_ast
 
     def get_client(self, uri: str, **config: Any) -> Client:
         """
@@ -1722,64 +1689,24 @@ class Catalog:
         query_script: str,
         env: Optional[Mapping[str, str]] = None,
         python_executable: str = sys.executable,
-        save: bool = False,
-        capture_output: bool = True,
+        capture_output: bool = False,
         output_hook: Callable[[str], None] = noop,
         params: Optional[dict[str, str]] = None,
         job_id: Optional[str] = None,
-        _execute_last_expression: bool = False,
     ) -> None:
-        """
-        Method to run custom user Python script to run a query and, as result,
-        creates new dataset from the results of a query.
-        Returns tuple of result dataset and script output.
-
-        Constraints on query script:
-            1. datachain.query.DatasetQuery should be used in order to create query
-            for a dataset
-            2. There should not be any .save() call on DatasetQuery since the idea
-            is to create only one dataset as the outcome of the script
-            3. Last statement must be an instance of DatasetQuery
-
-        If save is set to True, we are creating new dataset with results
-        from dataset query. If it's set to False, we will just print results
-        without saving anything
-
-        Example of query script:
-            from datachain.query import DatasetQuery, C
-            DatasetQuery('s3://ldb-public/remote/datasets/mnist-tiny/').filter(
-                C.size > 1000
-            )
-        """
-        if _execute_last_expression:
-            try:
-                code_ast = ast.parse(query_script)
-                code_ast = self.attach_query_wrapper(code_ast)
-                query_script_compiled = ast.unparse(code_ast)
-            except Exception as exc:
-                raise QueryScriptCompileError(
-                    f"Query script failed to compile, reason: {exc}"
-                ) from exc
-        else:
-            query_script_compiled = query_script
-            assert not save
-
+        cmd = [python_executable, "-c", query_script]
         env = dict(env or os.environ)
         env.update(
             {
                 "DATACHAIN_QUERY_PARAMS": json.dumps(params or {}),
-                "PYTHONPATH": os.getcwd(),  # For local imports
-                "DATACHAIN_QUERY_SAVE": "1" if save else "",
-                "PYTHONUNBUFFERED": "1",
                 "DATACHAIN_JOB_ID": job_id or "",
             },
         )
-        popen_kwargs = {}
+        popen_kwargs: dict[str, Any] = {}
         if capture_output:
             popen_kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.STDOUT}
 
-        cmd = [python_executable, "-c", query_script_compiled]
-        with subprocess.Popen(cmd, env=env, **popen_kwargs) as proc:  # type: ignore[call-overload]  # noqa: S603
+        with subprocess.Popen(cmd, env=env, **popen_kwargs) as proc:  # noqa: S603
             if capture_output:
                 args = (proc.stdout, output_hook)
                 thread = Thread(target=_process_stream, args=args, daemon=True)

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -804,7 +804,6 @@ def query(
         catalog.query(
             script_content,
             python_executable=python_executable,
-            capture_output=False,
             params=params,
             job_id=job_id,
         )

--- a/src/datachain/error.py
+++ b/src/datachain/error.py
@@ -32,14 +32,12 @@ class QueryScriptRunError(Exception):
     Attributes:
         message      Explanation of the error
         return_code  Code returned by the subprocess
-        output       STDOUT + STDERR output of the subprocess
     """
 
-    def __init__(self, message: str, return_code: int = 0, output: str = ""):
+    def __init__(self, message: str, return_code: int = 0):
         self.message = message
         self.return_code = return_code
-        self.output = output
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class QueryScriptCancelError(QueryScriptRunError):

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1604,25 +1604,3 @@ class DatasetQuery:
         finally:
             self.cleanup()
         return self.__class__(name=name, version=version, catalog=self.catalog)
-
-
-def query_wrapper(dataset_query: Any) -> Any:
-    """
-    Wrapper function that wraps the last statement of user query script.
-    Last statement MUST be instance of DatasetQuery, otherwise script exits with
-    error code 10
-    """
-    if not isinstance(dataset_query, DatasetQuery):
-        return dataset_query
-
-    catalog = dataset_query.catalog
-    save = bool(os.getenv("DATACHAIN_QUERY_SAVE"))
-
-    is_session_temp_dataset = dataset_query.name and dataset_query.name.startswith(
-        dataset_query.session.get_temp_prefix()
-    )
-
-    if save and (is_session_temp_dataset or not dataset_query.attached):
-        name = catalog.generate_query_dataset_name()
-        dataset_query = dataset_query.save(name)
-    return dataset_query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -492,6 +492,7 @@ def cloud_server(request, tmp_upath_factory, cloud_type, version_aware, tree):
 def datachain_job_id(monkeypatch):
     job_id = uuid.uuid4().hex
     monkeypatch.setenv("DATACHAIN_JOB_ID", job_id)
+    return job_id
 
 
 @pytest.fixture

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1305,3 +1305,11 @@ def test_process_and_open_tar(cloud_test_catalog, cloud_type):
         (b"bark", f"{prefix}animals.tar/dogs/dog3"),
         (b"ruff", f"{prefix}animals.tar/dogs/others/dog4"),
     }
+
+
+def test_datachain_save_with_job(test_session, catalog, datachain_job_id):
+    DataChain.from_values(value=["val1", "val2"], session=test_session).save("my-ds")
+
+    dataset = catalog.get_dataset("my-ds")
+    result_job_id = dataset.get_version(dataset.latest_version).job_id
+    assert result_job_id == datachain_job_id

--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -1,16 +1,12 @@
-import os.path
+import sys
 from textwrap import dedent
-from typing import TYPE_CHECKING
 
-import dill
+import cloudpickle
 import pytest
 
 from datachain.cli import query
 from datachain.data_storage import AbstractDBMetastore, JobQueryType, JobStatus
-from tests.utils import assert_row_names
-
-if TYPE_CHECKING:
-    from datachain.job import Job
+from datachain.job import Job
 
 
 @pytest.fixture
@@ -25,19 +21,20 @@ def catalog_info_filepath(cloud_test_catalog_tmpfile, tmp_path):
     }
     catalog_info_filepath = tmp_path / "catalog-info"
     with open(catalog_info_filepath, "wb") as f:
-        dill.dump(catalog_info, f)
+        cloudpickle.dump(catalog_info, f)
 
     return catalog_info_filepath
 
 
 def setup_catalog(query: str, catalog_info_filepath: str) -> str:
     query_catalog_setup = f"""\
-    import dill
+    import cloudpickle
     from datachain.catalog import Catalog
+    from datachain.query.session import Session
 
     catalog_info_filepath = {str(catalog_info_filepath)!r}
     with open(catalog_info_filepath, "rb") as f:
-        catalog_info = dill.load(f)
+        catalog_info = cloudpickle.load(f)
     (
         id_generator_class,
         id_generator_args,
@@ -62,13 +59,12 @@ def setup_catalog(query: str, catalog_info_filepath: str) -> str:
         warehouse=warehouse,
         **catalog_info["catalog_init_params"],
     )
+    session = Session("test", catalog=catalog)
     """
     return dedent(query_catalog_setup + "\n" + query)
 
 
-def get_latest_job(
-    metastore: AbstractDBMetastore,
-) -> "Job":
+def get_latest_job(metastore: AbstractDBMetastore) -> Job:
     j = metastore._jobs
     query = metastore._jobs_select().order_by(j.c.created_at.desc()).limit(1)
     (row,) = metastore.db.execute(query)
@@ -81,102 +77,36 @@ def test_query_cli(cloud_test_catalog_tmpfile, tmp_path, catalog_info_filepath, 
     catalog = cloud_test_catalog_tmpfile.catalog
     src_uri = cloud_test_catalog_tmpfile.src_uri
 
-    query_script = f"""\
-    from datachain.query import DatasetQuery
-    from datachain import C
-    from datachain.sql.functions.path import name
+    query_script = """\
+    from datachain import DataChain, metrics, param
 
-    catalog.create_dataset_from_sources("animals", ["{src_uri}"], recursive=True)
+    dc = DataChain.from_storage(param("url"), session=session)
 
-    DatasetQuery("animals", catalog=catalog).mutate(
-        name=name(C("file__path"))
-    ).save("my-ds")
+    metrics.set("count", dc.count())
+
+    dc.save("my-ds")
     """
     query_script = setup_catalog(query_script, catalog_info_filepath)
 
     filepath = tmp_path / "query_script.py"
     filepath.write_text(query_script)
 
-    query(catalog, str(filepath))
+    query(catalog, str(filepath), params={"url": src_uri})
 
     out, err = capsys.readouterr()
     assert not out
     assert not err
 
     dataset = catalog.get_dataset("my-ds")
-    assert dataset
     result_job_id = dataset.get_version(dataset.latest_version).job_id
     assert result_job_id
-
-    latest_job = get_latest_job(catalog.metastore)
-    assert latest_job
-
-    assert str(latest_job.id) == str(result_job_id)
-    assert latest_job.name == os.path.basename(filepath)
-    assert latest_job.status == JobStatus.COMPLETE
-    assert latest_job.query_type == JobQueryType.PYTHON
-    assert latest_job.error_message == ""
-    assert latest_job.error_stack == ""
-
-
-@pytest.mark.xdist_group(name="tmpfile")
-def test_query(cloud_test_catalog_tmpfile, tmp_path, catalog_info_filepath):
-    catalog = cloud_test_catalog_tmpfile.catalog
-    src_uri = cloud_test_catalog_tmpfile.src_uri
-    catalog.create_dataset_from_sources("animals", [src_uri], recursive=True)
-
-    query_script = """\
-    from datachain.query import DatasetQuery, C
-    DatasetQuery("animals", catalog=catalog).filter(
-        C("file__path").glob("*dog*")
-    ).save("my-ds")
-    """
-    query_script = setup_catalog(query_script, catalog_info_filepath)
-    catalog.query(query_script)
-
-    dataset = catalog.get_dataset("my-ds")
-    assert dataset.versions_values == [1]
-    assert_row_names(
-        catalog,
-        dataset,
-        1,
-        {
-            "dog1",
-            "dog2",
-            "dog3",
-            "dog4",
-        },
-    )
-
-
-@pytest.mark.parametrize("cloud_type,version_aware", [("file", False)], indirect=True)
-@pytest.mark.xdist_group(name="tmpfile")
-def test_cli_query_params_metrics(
-    cloud_test_catalog_tmpfile, tmp_path, catalog_info_filepath, capsys
-):
-    catalog = cloud_test_catalog_tmpfile.catalog
-    src_uri = cloud_test_catalog_tmpfile.src_uri
-    catalog.create_dataset_from_sources("animals", [src_uri], recursive=True)
-
-    query_script = """\
-    from datachain.query import DatasetQuery, metrics, param
-
-    ds = DatasetQuery(param("name"), catalog=catalog)
-
-    metrics.set("count", ds.count())
-
-    ds.save("my-ds")
-    """
-    query_script = setup_catalog(query_script, catalog_info_filepath)
-
-    filepath = tmp_path / "query_script.py"
-    filepath.write_text(query_script)
-
-    query(catalog, str(filepath), params={"name": "animals"})
-
-    latest_job = get_latest_job(catalog.metastore)
-    assert latest_job
-
-    assert latest_job.status == JobStatus.COMPLETE
-    assert latest_job.params == {"name": "animals"}
-    assert latest_job.metrics == {"count": 7}
+    job = get_latest_job(catalog.metastore)
+    assert job.id == result_job_id
+    assert job.name == "query_script.py"
+    assert job.status == JobStatus.COMPLETE
+    assert job.query == query_script
+    assert job.query_type == JobQueryType.PYTHON
+    assert job.workers == 1
+    assert job.params == {"url": src_uri}
+    assert job.metrics == {"count": 7}
+    assert job.python_version == f"{sys.version_info.major}.{sys.version_info.minor}"

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,0 +1,65 @@
+import io
+import json
+import os.path
+import sys
+from uuid import uuid4
+
+import pytest
+
+from datachain.catalog.catalog import QUERY_SCRIPT_CANCELED_EXIT_CODE
+from datachain.error import QueryScriptCancelError, QueryScriptRunError
+
+
+@pytest.fixture
+def mock_popen(mocker):
+    m = mocker.patch("subprocess.Popen", returncode=0)
+    m.return_value.__enter__.return_value = m
+    return m
+
+
+def test(catalog, mock_popen):
+    catalog.query("pass")
+
+    expected_env = os.environ | {"DATACHAIN_QUERY_PARAMS": "{}", "DATACHAIN_JOB_ID": ""}
+    mock_popen.assert_called_once_with([sys.executable, "-c", "pass"], env=expected_env)
+
+
+def test_args(catalog, mock_popen):
+    params = {"param": "value"}
+    job_id = str(uuid4())
+    env = {"env1": "value1", "env2": "value2"}
+    catalog.query(
+        "pass", env=env, python_executable="mypython", params=params, job_id=job_id
+    )
+
+    expected_env = env | {
+        "DATACHAIN_QUERY_PARAMS": json.dumps(params),
+        "DATACHAIN_JOB_ID": job_id,
+    }
+    mock_popen.assert_called_once_with(["mypython", "-c", "pass"], env=expected_env)
+
+
+def test_capture_output(mocker, catalog, mock_popen):
+    mock_popen.stdout = io.BytesIO(b"Hello, World!\rLorem Ipsum\nDolor Sit Amet\nconse")
+    lines = []
+
+    catalog.query("pass", capture_output=True, output_hook=lines.append)
+    assert lines == ["Hello, World!\r", "Lorem Ipsum\n", "Dolor Sit Amet\n", "conse"]
+
+
+def test_canceled_by_user(catalog, mock_popen):
+    mock_popen.returncode = QUERY_SCRIPT_CANCELED_EXIT_CODE
+
+    with pytest.raises(QueryScriptCancelError) as e:
+        catalog.query("pass")
+    assert e.value.return_code == QUERY_SCRIPT_CANCELED_EXIT_CODE
+    assert "Query script was canceled by user" in str(e.value)
+
+
+def test_non_zero_exitcode(catalog, mock_popen):
+    mock_popen.returncode = 1
+
+    with pytest.raises(QueryScriptRunError) as e:
+        catalog.query("pass")
+    assert e.value.return_code == 1
+    assert "Query script exited with error code 1" in str(e.value)


### PR DESCRIPTION
I have also removed mocked tests that were in `test_catalog.py`, and replaced them with unittest that are more simpler and are reduced in scope.

Also, since the `Catalog.query` API is now a generic script runner, I have dropped functional tests as they are heavy and slow, and don't really tests that much. 
I have replaced some `query` test with tests that check what happens if `job_id` is set, etc.

I have kept one test though, for CLI `query` command. I was not sure what to do of it, so I have kept it, but can remove it as I don't have find much return from it.