### PR TITLE
Replace `UniqueId` with `File`

### DIFF
--- a/src/datachain/cache.py
+++ b/src/datachain/cache.py
@@ -1,4 +1,3 @@
-import json
 import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
@@ -28,20 +27,6 @@ class UniqueId:
     is_latest: bool = True
     location: Optional[str] = None
     last_modified: datetime = TIME_ZERO
-
-    def get_parsed_location(self) -> Optional[dict]:
-        if not self.location:
-            return None
-
-        loc_stack = (
-            json.loads(self.location)
-            if isinstance(self.location, str)
-            else self.location
-        )
-        if len(loc_stack) > 1:
-            raise NotImplementedError("Nested v-objects are not supported yet.")
-
-        return loc_stack[0]
 
     def get_hash(self) -> str:
         return self.to_file().get_hash()

--- a/src/datachain/cache.py
+++ b/src/datachain/cache.py
@@ -1,49 +1,15 @@
 import os
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-import attrs
 from dvc_data.hashfile.db.local import LocalHashFileDB
 from dvc_objects.fs.local import LocalFileSystem
 from fsspec.callbacks import Callback, TqdmCallback
-
-from datachain.utils import TIME_ZERO
 
 from .progress import Tqdm
 
 if TYPE_CHECKING:
     from datachain.client import Client
     from datachain.lib.file import File
-    from datachain.storage import StorageURI
-
-
-@attrs.frozen
-class UniqueId:
-    storage: "StorageURI"
-    path: str
-    size: int
-    etag: str
-    version: str = ""
-    is_latest: bool = True
-    location: Optional[str] = None
-    last_modified: datetime = TIME_ZERO
-
-    def get_hash(self) -> str:
-        return self.to_file().get_hash()
-
-    def to_file(self) -> "File":
-        from datachain.lib.file import File
-
-        return File(
-            source=self.storage,
-            path=self.path,
-            size=self.size,
-            version=self.version,
-            etag=self.etag,
-            is_latest=self.is_latest,
-            last_modified=self.last_modified,
-            location=self.location,
-        )
 
 
 def try_scandir(path):

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1485,7 +1485,7 @@ class Catalog:
         config = config or self.client_config
         client = self.get_client(file_signals["source"], **config)
         return client.open_object(
-            File._from_row(file_signals).get_uid(),
+            File._from_row(file_signals),
             use_cache=use_cache,
         )
 

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -34,7 +34,7 @@ import yaml
 from sqlalchemy import Column
 from tqdm import tqdm
 
-from datachain.cache import DataChainCache, UniqueId
+from datachain.cache import DataChainCache
 from datachain.client import Client
 from datachain.config import get_remote_config, read_config
 from datachain.dataset import (
@@ -619,13 +619,13 @@ class Catalog:
                 code_ast.body[-1:] = new_expressions
         return code_ast
 
-    def get_client(self, uri: StorageURI, **config: Any) -> Client:
+    def get_client(self, uri: str, **config: Any) -> Client:
         """
         Return the client corresponding to the given source `uri`.
         """
         config = config or self.client_config
         cls = Client.get_implementation(uri)
-        return cls.from_source(uri, self.cache, **config)
+        return cls.from_source(StorageURI(uri), self.cache, **config)
 
     def enlist_source(
         self,
@@ -1431,7 +1431,7 @@ class Catalog:
 
     def get_file_signals(
         self, dataset_name: str, dataset_version: int, row: RowDict
-    ) -> Optional[dict]:
+    ) -> Optional[RowDict]:
         """
         Function that returns file signals from dataset row.
         Note that signal names are without prefix, so if there was 'laion__file__source'
@@ -1448,7 +1448,7 @@ class Catalog:
 
         version = self.get_dataset(dataset_name).get_version(dataset_version)
 
-        file_signals_values = {}
+        file_signals_values = RowDict()
 
         schema = SignalSchema.deserialize(version.feature_schema)
         for file_signals in schema.get_signals(File):
@@ -1476,6 +1476,8 @@ class Catalog:
         use_cache: bool = True,
         **config: Any,
     ):
+        from datachain.lib.file import File
+
         file_signals = self.get_file_signals(dataset_name, dataset_version, row)
         if not file_signals:
             raise RuntimeError("Cannot open object without file signals")
@@ -1483,20 +1485,8 @@ class Catalog:
         config = config or self.client_config
         client = self.get_client(file_signals["source"], **config)
         return client.open_object(
-            self._get_row_uid(file_signals),  # type: ignore [arg-type]
+            File._from_row(file_signals).get_uid(),
             use_cache=use_cache,
-        )
-
-    def _get_row_uid(self, row: RowDict) -> UniqueId:
-        return UniqueId(
-            row["source"],
-            row["path"],
-            row["size"],
-            row["etag"],
-            row["version"],
-            row["is_latest"],
-            row["location"],
-            row["last_modified"],
         )
 
     def ls(

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -25,7 +25,7 @@ from fsspec.asyn import get_loop, sync
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from tqdm import tqdm
 
-from datachain.cache import DataChainCache, UniqueId
+from datachain.cache import DataChainCache
 from datachain.client.fileslice import FileWrapper
 from datachain.error import ClientError as DataChainClientError
 from datachain.lib.file import File
@@ -316,7 +316,7 @@ class Client(ABC):
 
     def instantiate_object(
         self,
-        uid: UniqueId,
+        file: "File",
         dst: str,
         progress_bar: tqdm,
         force: bool = False,
@@ -327,10 +327,10 @@ class Client(ABC):
             else:
                 progress_bar.close()
                 raise FileExistsError(f"Path {dst} already exists")
-        self.do_instantiate_object(uid, dst)
+        self.do_instantiate_object(file, dst)
 
-    def do_instantiate_object(self, uid: "UniqueId", dst: str) -> None:
-        src = self.cache.get_path(uid.to_file())
+    def do_instantiate_object(self, file: "File", dst: str) -> None:
+        src = self.cache.get_path(file)
         assert src is not None
 
         try:

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -331,7 +331,7 @@ class Client(ABC):
         self.do_instantiate_object(uid, dst)
 
     def do_instantiate_object(self, uid: "UniqueId", dst: str) -> None:
-        src = self.cache.get_path(uid)
+        src = self.cache.get_path(uid.to_file())
         assert src is not None
 
         try:
@@ -345,7 +345,7 @@ class Client(ABC):
     ) -> BinaryIO:
         """Open a file, including files in tar archives."""
         location = uid.get_parsed_location()
-        if use_cache and (cache_path := self.cache.get_path(uid)):
+        if use_cache and (cache_path := self.cache.get_path(uid.to_file())):
             return open(cache_path, mode="rb")  # noqa: SIM115
         if location and location["vtype"] == "tar":
             return self._open_tar(uid, use_cache=True)
@@ -373,7 +373,7 @@ class Client(ABC):
         sync(get_loop(), functools.partial(self._download, uid, callback=callback))
 
     async def _download(self, uid: UniqueId, *, callback: "Callback" = None) -> None:
-        if self.cache.contains(uid):
+        if self.cache.contains(uid.to_file()):
             # Already in cache, so there's nothing to do.
             return
         await self._put_in_cache(uid, callback=callback)
@@ -398,7 +398,7 @@ class Client(ABC):
                     f"Invalid etag for {uid.storage}/{uid.path}: "
                     f"expected {uid.etag}, got {etag}"
                 )
-        await self.cache.download(uid, self, callback=callback)
+        await self.cache.download(uid.to_file(), self, callback=callback)
 
     def _download_from_tar(self, uid, *, callback: "Callback" = None):
         with self._open_tar(uid, use_cache=False) as f:

--- a/src/datachain/client/local.py
+++ b/src/datachain/client/local.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 
 from fsspec.implementations.local import LocalFileSystem
 
-from datachain.cache import UniqueId
 from datachain.lib.file import File
 from datachain.storage import StorageURI
 
@@ -114,8 +113,8 @@ class FileClient(Client):
             use_symlinks=use_symlinks,
         )
 
-    async def get_current_etag(self, uid: UniqueId) -> str:
-        info = self.fs.info(self.get_full_path(uid.path))
+    async def get_current_etag(self, file: "File") -> str:
+        info = self.fs.info(self.get_full_path(file.path))
         return self.info_to_file(info, "").etag
 
     async def get_size(self, path: str) -> int:

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -49,7 +49,8 @@ class ArrowGenerator(Generator):
 
     def process(self, file: File):
         if file._caching_enabled:
-            path = file.get_local_path(download=True)
+            file.ensure_cached()
+            path = file.get_local_path()
             ds = dataset(path, schema=self.input_schema, **self.kwargs)
         elif self.nrows:
             path = _nrows_file(file, self.nrows)

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -22,7 +22,6 @@ from pydantic import Field, field_validator
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-from datachain.cache import UniqueId
 from datachain.client.fileslice import FileSlice
 from datachain.lib.data_model import DataModel
 from datachain.lib.utils import DataChainError
@@ -262,11 +261,6 @@ class File(DataModel):
         self._catalog = catalog
         self._caching_enabled = caching_enabled
         self._download_cb = download_cb
-
-    def get_uid(self) -> UniqueId:
-        """Returns unique ID for file."""
-        dump = self.model_dump()
-        return UniqueId(*(dump[k] for k in self._unique_id_keys))
 
     def ensure_cached(self) -> None:
         if self._catalog is None:

--- a/src/datachain/listing.py
+++ b/src/datachain/listing.py
@@ -156,12 +156,12 @@ class Listing:
 
     def instantiate_nodes(
         self,
-        all_nodes,
+        all_nodes: Iterable[NodeWithPath],
         output,
         total_files=None,
         force=False,
         shared_progress_bar=None,
-    ):
+    ) -> None:
         progress_bar = shared_progress_bar or tqdm(
             desc=f"Instantiating '{output}'",
             unit=" files",
@@ -175,8 +175,8 @@ class Listing:
             dst = os.path.join(output, *node.path)
             dst_dir = os.path.dirname(dst)
             os.makedirs(dst_dir, exist_ok=True)
-            uid = node.n.as_uid(self.client.uri)
-            self.client.instantiate_object(uid, dst, progress_bar, force)
+            file = node.n.to_file(self.client.uri)
+            self.client.instantiate_object(file, dst, progress_bar, force)
             counter += 1
             if counter > 1000:
                 progress_bar.update(counter)

--- a/src/datachain/node.py
+++ b/src/datachain/node.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import attrs
 
 from datachain.cache import UniqueId
+from datachain.lib.file import File
 from datachain.storage import StorageURI
 from datachain.utils import TIME_ZERO, time_to_str
 
@@ -104,6 +105,20 @@ class Node:
             storage = self.source
         return UniqueId(
             storage=storage,
+            path=self.path,
+            size=self.size,
+            version=self.version or "",
+            etag=self.etag,
+            is_latest=self.is_latest,
+            location=self.location,
+            last_modified=self.last_modified or TIME_ZERO,
+        )
+
+    def to_file(self, source: Optional[StorageURI] = None) -> File:
+        if source is None:
+            source = self.source
+        return File(
+            source=source,
             path=self.path,
             size=self.size,
             version=self.version or "",

--- a/src/datachain/node.py
+++ b/src/datachain/node.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import attrs
 
-from datachain.cache import UniqueId
 from datachain.lib.file import File
 from datachain.storage import StorageURI
 from datachain.utils import TIME_ZERO, time_to_str
@@ -99,20 +98,6 @@ class Node:
         if self.is_dir and self.path:
             return self.path + "/"
         return self.path
-
-    def as_uid(self, storage: Optional[StorageURI] = None) -> UniqueId:
-        if storage is None:
-            storage = self.source
-        return UniqueId(
-            storage=storage,
-            path=self.path,
-            size=self.size,
-            version=self.version or "",
-            etag=self.etag,
-            is_latest=self.is_latest,
-            location=self.location,
-            last_modified=self.last_modified or TIME_ZERO,
-        )
 
     def to_file(self, source: Optional[StorageURI] = None) -> File:
         if source is None:

--- a/src/datachain/nodes_fetcher.py
+++ b/src/datachain/nodes_fetcher.py
@@ -1,12 +1,19 @@
 import logging
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
+from datachain.node import Node
 from datachain.nodes_thread_pool import NodesThreadPool
+
+if TYPE_CHECKING:
+    from datachain.cache import DataChainCache
+    from datachain.client.fsspec import Client
 
 logger = logging.getLogger("datachain")
 
 
 class NodesFetcher(NodesThreadPool):
-    def __init__(self, client, max_threads, cache):
+    def __init__(self, client: "Client", max_threads: int, cache: "DataChainCache"):
         super().__init__(max_threads)
         self.client = client
         self.cache = cache
@@ -15,7 +22,7 @@ class NodesFetcher(NodesThreadPool):
         for task in done:
             task.result()
 
-    def do_task(self, chunk):
+    def do_task(self, chunk: Iterable[Node]) -> None:
         from fsspec import Callback
 
         class _CB(Callback):
@@ -23,8 +30,8 @@ class NodesFetcher(NodesThreadPool):
                 self.increase_counter(inc)
 
         for node in chunk:
-            uid = node.as_uid(self.client.uri)
-            if self.cache.contains(uid):
+            file = node.to_file(self.client.uri)
+            if self.cache.contains(file):
                 self.increase_counter(node.size)
             else:
-                self.client.put_in_cache(uid, callback=_CB())
+                self.client.put_in_cache(file, callback=_CB())

--- a/src/datachain/nodes_thread_pool.py
+++ b/src/datachain/nodes_thread_pool.py
@@ -20,7 +20,7 @@ class NodeChunk:
     def next_downloadable(self):
         node = next(self.nodes, None)
         while node and (
-            not node.is_downloadable or self.cache.contains(node.as_uid(self.storage))
+            not node.is_downloadable or self.cache.contains(node.to_file(self.storage))
         ):
             node = next(self.nodes, None)
         return node

--- a/src/datachain/query/schema.py
+++ b/src/datachain/query/schema.py
@@ -101,8 +101,8 @@ class Object(UDFParameter):
         file = File._from_row(file_signals(row))
         client = catalog.get_client(file.source)
         if cache:
-            client.download(file.get_uid(), callback=cb)
-        with client.open_object(file.get_uid(), use_cache=cache, cb=cb) as f:
+            client.download(file, callback=cb)
+        with client.open_object(file, use_cache=cache, cb=cb) as f:
             return self.reader(f)
 
     async def get_value_async(
@@ -118,11 +118,9 @@ class Object(UDFParameter):
         file = File._from_row(file_signals(row))
         client = catalog.get_client(file.source)
         if cache:
-            await client._download(file.get_uid(), callback=cb)
+            await client._download(file, callback=cb)
         obj = await mapper.to_thread(
-            functools.partial(
-                client.open_object, file.get_uid(), use_cache=cache, cb=cb
-            )
+            functools.partial(client.open_object, file, use_cache=cache, cb=cb)
         )
         with obj:
             return await mapper.to_thread(self.reader, obj)
@@ -146,8 +144,8 @@ class Stream(UDFParameter):
         file = File._from_row(file_signals(row))
         client = catalog.get_client(file.source)
         if cache:
-            client.download(file.get_uid(), callback=cb)
-        return client.open_object(file.get_uid(), use_cache=cache, cb=cb)
+            client.download(file, callback=cb)
+        return client.open_object(file, use_cache=cache, cb=cb)
 
     async def get_value_async(
         self,
@@ -162,11 +160,9 @@ class Stream(UDFParameter):
         file = File._from_row(file_signals(row))
         client = catalog.get_client(file.source)
         if cache:
-            await client._download(file.get_uid(), callback=cb)
+            await client._download(file, callback=cb)
         return await mapper.to_thread(
-            functools.partial(
-                client.open_object, file.get_uid(), use_cache=cache, cb=cb
-            )
+            functools.partial(client.open_object, file, use_cache=cache, cb=cb)
         )
 
 
@@ -196,7 +192,7 @@ class LocalFilename(UDFParameter):
             return None
         file = File._from_row(file_signals(row))
         client = catalog.get_client(file.source)
-        client.download(file.get_uid(), callback=cb)
+        client.download(file, callback=cb)
         return client.cache.get_path(file)
 
     async def get_value_async(
@@ -215,7 +211,7 @@ class LocalFilename(UDFParameter):
             return None
         file = File._from_row(file_signals(row))
         client = catalog.get_client(file.source)
-        await client._download(file.get_uid(), callback=cb)
+        await client._download(file, callback=cb)
         return client.cache.get_path(file)
 
 

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -69,9 +69,8 @@ def test_cache_get_path(catalog: Catalog):
     stream = File(path="test.txt1", source="s3://mybkt")
     stream._set_stream(catalog)
 
-    uid = stream.get_uid()
     data = b"some data is heRe"
-    catalog.cache.store_data(uid, data)
+    catalog.cache.store_data(stream, data)
 
     path = stream.get_local_path()
     assert path is not None

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -7,7 +7,6 @@ from fsspec.implementations.local import LocalFileSystem
 from PIL import Image
 
 from datachain import DataChain
-from datachain.cache import UniqueId
 from datachain.catalog import Catalog
 from datachain.data_storage.sqlite import SQLiteWarehouse
 from datachain.lib.file import File, ImageFile, TextFile, resolve
@@ -20,28 +19,6 @@ def create_file(source: str):
         source=source,
         etag="ed779276108738fdb2179ccabf9680d9",
     )
-
-
-def test_uid_missing_location():
-    name = "my_name"
-    stream = File(path=name)
-    assert stream.get_uid() == UniqueId(
-        "",
-        name,
-        size=0,
-        version="",
-        etag="",
-        is_latest=True,
-        location=None,
-    )
-
-
-def test_uid_location():
-    name = "na_me"
-    loc = {"e": 42}
-
-    stream = File(path=name, location=loc)
-    assert stream.get_uid() == UniqueId("", name, 0, "", "", True, loc)
 
 
 def test_file_stem():

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -400,4 +400,5 @@ def test_get_local_path(tmp_path, catalog):
     file._set_stream(catalog)
 
     assert file.get_local_path() is None
-    assert file.get_local_path(download=True) is not None
+    file.ensure_cached()
+    assert file.get_local_path() is not None

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,6 +1,7 @@
 import pytest
 
-from datachain.cache import DataChainCache, UniqueId
+from datachain.cache import DataChainCache
+from datachain.lib.file import File
 
 
 @pytest.fixture
@@ -9,7 +10,7 @@ def cache(tmp_path):
 
 
 def test_simple(cache):
-    uid = UniqueId("s3://foo", "data/bar", etag="xyz", size=3, location=None)
+    uid = File(source="s3://foo", path="data/bar", etag="xyz", size=3, location=None)
     data = b"foo"
     assert not cache.contains(uid)
 
@@ -31,7 +32,9 @@ def test_get_total_size(cache):
     ]
     expected_total = sum(len(d) for _, d in file_info)
     for name, data in file_info:
-        uid = UniqueId("s3://foo", f"data/{name}", etag="xyz", size=3, location=None)
+        uid = File(
+            source="s3://foo", path=f"data/{name}", etag="xyz", size=3, location=None
+        )
         cache.store_data(uid, data)
     total = cache.get_total_size()
     assert total == expected_total
@@ -42,7 +45,9 @@ def test_get_total_size(cache):
 
 
 def test_remove(cache):
-    uid = UniqueId("s3://bkt42", "dir1/dir2/file84", etag="abc", size=3, location=None)
+    uid = File(
+        source="s3://bkt42", path="dir1/dir2/file84", etag="abc", size=3, location=None
+    )
     cache.store_data(uid, b"some random string 679")
 
     assert cache.contains(uid)


### PR DESCRIPTION
* Use `File` instead of `UniqueId` everywhere, replace `Node.as_uid()` with `Node.to_file()`
  * Add `File._from_row()` replacing `Catalog._get_row_uid()`
  * Transfer `get_hash()` method from `UniqueId` to `File`
* Remove `UniqueId` class and `File.get_uid()`.
* Remove legacy tar handling code
* Split off `File.ensure_cached()` from `File.get_local_path()`

Fixes #36