### PR TITLE
update pytest-servers to 0.5.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ tests = [
   "pytest-sugar>=0.9.6",
   "pytest-cov>=4.1.0",
   "pytest-mock>=3.12.0",
-  "pytest-servers[all]>=0.5.5",
+  "pytest-servers[all]>=0.5.7",
   "pytest-benchmark[histogram]",
   "pytest-xdist>=3.3.1",
   "virtualenv",


### PR DESCRIPTION
pytest-servers was running on an old (now incompatible) version of Azurite.

Failures shown:

 - https://github.com/iterative/datachain/actions/runs/10911782719
 - https://github.com/iterative/datachain/actions/runs/10911782712