### PR TITLE
Split DatasetQuery from DataChain

### DIFF
--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -770,7 +770,7 @@ def show(
     show_records(records, collapse_columns=not no_collapse)
     if schema and dataset_version.feature_schema:
         print("\nSchema:")
-        dc = DataChain(name=name, version=version, catalog=catalog)
+        dc = DataChain._create(name=name, version=version, catalog=catalog)
         dc.print_schema()
 
 

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import shtab
 
-from datachain import utils
+from datachain import Session, utils
 from datachain.cli_utils import BooleanOptionalAction, CommaSeparatedArgs, KeyValueArgs
 from datachain.lib.dc import DataChain
 from datachain.telemetry import telemetry
@@ -770,7 +770,8 @@ def show(
     show_records(records, collapse_columns=not no_collapse)
     if schema and dataset_version.feature_schema:
         print("\nSchema:")
-        dc = DataChain._create(name=name, version=version, catalog=catalog)
+        session = Session.get(catalog=catalog)
+        dc = DataChain.from_dataset(name=name, version=version, session=session)
         dc.print_schema()
 
 

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -286,12 +286,12 @@ class DataChain:
 
     @property
     def name(self) -> Optional[str]:
-        """Name of the chain."""
+        """Name of the underlying dataset, if there is one."""
         return self._query.name
 
     @property
     def version(self) -> Optional[int]:
-        """Version of the chain."""
+        """Version of the underlying dataset, if there is one."""
         return self._query.version
 
     def __or__(self, other: "Self") -> "Self":

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -238,7 +238,7 @@ class DataChain(DatasetQuery):
         "size": 0,
     }
 
-    def __init__(self, *args, settings: Optional[dict] = None, **kwargs):
+    def __init__(self, *args, settings: Optional[dict] = None, **kwargs) -> None:
         """This method needs to be redefined as a part of Dataset and DataChain
         decoupling.
         """
@@ -911,11 +911,7 @@ class DataChain(DatasetQuery):
 
         new_schema = self.signals_schema.resolve(*args)
         columns = [C(col) for col in new_schema.db_signals()]
-        res = super_func(*columns, **kwargs)
-        if isinstance(res, DataChain):
-            res.signals_schema = new_schema
-
-        return res
+        return super_func(*columns, **kwargs)
 
     @detach
     @resolve_columns

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1313,7 +1313,11 @@ class DataChain:
         return ds
 
     def union(self, other: "Self") -> "Self":
-        """Return the set union of the two datasets."""
+        """Return the set union of the two datasets.
+
+        Parameters:
+            other: chain whose rows will be added to `self`.
+        """
         return self.clone(query=self._query.union(other._query))
 
     def subtract(  # type: ignore[override]
@@ -1995,11 +1999,25 @@ class DataChain:
         return self.clone(query=self._query.filter(*args))
 
     def limit(self, n: int) -> "Self":
-        """Return the first n rows of the chain."""
+        """Return the first `n` rows of the chain.
+
+        If the chain is unordered, which rows are returned is undefined.
+        If the chain has less than `n` rows, the whole chain is returned.
+
+        Parameters:
+            n (int): Number of rows to return.
+        """
         return self.clone(query=self._query.limit(n))
 
     def offset(self, offset: int) -> "Self":
-        """Return the results starting with the offset row."""
+        """Return the results starting with the offset row.
+
+        If the chain is unordered, which rows are skipped in undefined.
+        If the chain has less than `offset` rows, the result is an empty chain.
+
+        Parameters:
+            offset (int): Number of rows to skip.
+        """
         return self.clone(query=self._query.offset(offset))
 
     def count(self) -> int:
@@ -2014,9 +2032,11 @@ class DataChain:
         """Split a chain into smaller chunks for e.g. parallelization.
 
         Example:
-            >>> chain = DataChain.from_storage(...)
-            >>> chunk_1 = query._chunk(0, 2)
-            >>> chunk_2 = query._chunk(1, 2)
+            ```py
+            chain = DataChain.from_storage(...)
+            chunk_1 = query._chunk(0, 2)
+            chunk_2 = query._chunk(1, 2)
+            ```
 
         Note:
             Bear in mind that `index` is 0-indexed but `total` isn't.

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -1,7 +1,7 @@
 import posixpath
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar
 
 from fsspec.asyn import get_loop
 from sqlalchemy.sql.expression import true
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 LISTING_TTL = 4 * 60 * 60  # cached listing lasts 4 hours
 LISTING_PREFIX = "lst__"  # listing datasets start with this name
+
+D = TypeVar("D", bound="DataChain")
 
 
 def list_bucket(uri: str, cache, client_config=None) -> Callable:
@@ -38,11 +40,11 @@ def list_bucket(uri: str, cache, client_config=None) -> Callable:
 
 
 def ls(
-    dc: "DataChain",
+    dc: D,
     path: str,
     recursive: Optional[bool] = True,
     object_name="file",
-):
+) -> D:
     """
     Return files by some path from DataChain instance which contains bucket listing.
     Path can have globs.

--- a/src/datachain/lib/pytorch.py
+++ b/src/datachain/lib/pytorch.py
@@ -9,6 +9,7 @@ from torch.utils.data import IterableDataset, get_worker_info
 from torchvision.transforms import v2
 from tqdm import tqdm
 
+from datachain import Session
 from datachain.catalog import Catalog, get_catalog
 from datachain.lib.dc import DataChain
 from datachain.lib.text import convert_text
@@ -87,9 +88,10 @@ class PytorchDataset(IterableDataset):
     def __iter__(self) -> Iterator[Any]:
         if self.catalog is None:
             self.catalog = self._get_catalog()
+        session = Session.get(catalog=self.catalog)
         total_rank, total_workers = self.get_rank_and_workers()
-        ds = DataChain._create(
-            name=self.name, version=self.version, catalog=self.catalog
+        ds = DataChain.from_dataset(
+            name=self.name, version=self.version, session=session
         )
         ds = ds.remove_file_signals()
 

--- a/src/datachain/lib/pytorch.py
+++ b/src/datachain/lib/pytorch.py
@@ -88,7 +88,9 @@ class PytorchDataset(IterableDataset):
         if self.catalog is None:
             self.catalog = self._get_catalog()
         total_rank, total_workers = self.get_rank_and_workers()
-        ds = DataChain(name=self.name, version=self.version, catalog=self.catalog)
+        ds = DataChain._create(
+            name=self.name, version=self.version, catalog=self.catalog
+        )
         ds = ds.remove_file_signals()
 
         if self.num_samples > 0:

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1037,7 +1037,7 @@ class DatasetQuery:
         session: Optional[Session] = None,
         indexing_column_types: Optional[dict[str, Any]] = None,
         in_memory: bool = False,
-    ):
+    ) -> None:
         self.session = Session.get(session, catalog=catalog, in_memory=in_memory)
         self.catalog = catalog or self.session.catalog
         self.steps: list[Step] = []

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -50,7 +50,7 @@ def _get_listing_datasets(session):
 @pytest.mark.parametrize("anon", [True, False])
 def test_catalog_anon(tmp_dir, catalog, anon):
     chain = DataChain.from_storage(tmp_dir.as_uri(), anon=anon)
-    assert chain.catalog.client_config.get("anon", False) is anon
+    assert chain.session.catalog.client_config.get("anon", False) is anon
 
 
 def test_from_storage(cloud_test_catalog):
@@ -896,9 +896,9 @@ def test_avoid_recalculation_after_save(cloud_test_catalog):
     )
     ds2 = ds.save("ds1")
 
-    assert ds2.steps == []
-    assert ds2.dependencies == set()
-    assert isinstance(ds2.starting_step, QueryStep)
+    assert ds2._query.steps == []
+    assert ds2._query.dependencies == set()
+    assert isinstance(ds2._query.starting_step, QueryStep)
     ds2.save("ds2")
     assert calls == 1  # UDF should be called only once
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1317,10 +1317,6 @@ def test_extend_features(test_session):
         f1=features, num=range(len(features)), session=test_session
     )
 
-    res = dc._extend_to_data_model("select", "num")
-    assert isinstance(res, DataChain)
-    assert res.signals_schema.values == {"num": int}
-
     res = dc._extend_to_data_model("sum", "num")
     assert res == sum(range(len(features)))
 

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -274,7 +274,7 @@ def test_merge_on_expression(test_session):
         return func.substr(c, func.length(c) - 3)
 
     dc = DataChain.from_values(team=team, session=test_session)
-    right_dc = dc.clone(new_table=True)
+    right_dc = dc.clone()
 
     # cross join on "ball" from sport
     merged = dc.merge(right_dc, on=_get_expr(dc), right_on=_get_expr(right_dc))


### PR DESCRIPTION
This removes the inheritance of DataChain from DatasetQuery and instead makes the latter an attribute of the former, as suggested in #41.

The de facto public properties and methods `name`, `version`, `session`, `union()`, `count()`, `exec()` and `chunk()` have been explicitly added to `DataChain`.

