### PR TITLE
Introduce DatasetVersionNotFoundError in errors

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -53,6 +53,7 @@ from datachain.error import (
     DataChainError,
     DatasetInvalidVersionError,
     DatasetNotFoundError,
+    DatasetVersionNotFoundError,
     PendingIndexingError,
     QueryScriptCancelError,
     QueryScriptCompileError,
@@ -1218,7 +1219,9 @@ class Catalog:
 
         dataset_version = dataset.get_version(version)
         if not dataset_version:
-            raise ValueError(f"Dataset {dataset.name} does not have version {version}")
+            raise DatasetVersionNotFoundError(
+                f"Dataset {dataset.name} does not have version {version}"
+            )
 
         if not dataset_version.is_final_status():
             raise ValueError("Cannot register dataset version in non final status")

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1584,7 +1584,7 @@ class Catalog:
 
         try:
             remote_dataset_version = remote_dataset.get_version(version)
-        except (ValueError, StopIteration) as exc:
+        except (DatasetVersionNotFoundError, StopIteration) as exc:
             raise DataChainError(
                 f"Dataset {remote_dataset_name} doesn't have version {version}"
                 " on server"

--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -12,6 +12,7 @@ from typing import (
 from urllib.parse import urlparse
 
 from datachain.client import Client
+from datachain.error import DatasetVersionNotFoundError
 from datachain.sql.types import NAME_TYPES_MAPPING, SQLType
 
 if TYPE_CHECKING:
@@ -417,7 +418,9 @@ class DatasetRecord:
 
     def get_version(self, version: int) -> DatasetVersion:
         if not self.has_version(version):
-            raise ValueError(f"Dataset {self.name} does not have version {version}")
+            raise DatasetVersionNotFoundError(
+                f"Dataset {self.name} does not have version {version}"
+            )
         return next(
             v
             for v in self.versions  # type: ignore [union-attr]
@@ -435,7 +438,9 @@ class DatasetRecord:
         Get identifier in the form my-dataset@v3
         """
         if not self.has_version(version):
-            raise ValueError(f"Dataset {self.name} doesn't have a version {version}")
+            raise DatasetVersionNotFoundError(
+                f"Dataset {self.name} doesn't have a version {version}"
+            )
         return f"{self.name}@v{version}"
 
     def uri(self, version: int) -> str:

--- a/src/datachain/error.py
+++ b/src/datachain/error.py
@@ -10,6 +10,10 @@ class DatasetNotFoundError(NotFoundError):
     pass
 
 
+class DatasetVersionNotFoundError(NotFoundError):
+    pass
+
+
 class DatasetInvalidVersionError(Exception):
     pass
 

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -8,7 +8,11 @@ import sqlalchemy
 from dateutil.parser import isoparse
 
 from datachain.dataset import DatasetDependencyType, DatasetStatus
-from datachain.error import DatasetInvalidVersionError, DatasetNotFoundError
+from datachain.error import (
+    DatasetInvalidVersionError,
+    DatasetNotFoundError,
+    DatasetVersionNotFoundError,
+)
 from datachain.query import C, DatasetQuery, Object, Stream
 from datachain.sql import functions
 from datachain.sql.functions import path as pathfunc
@@ -127,7 +131,7 @@ def test_save_multiple_versions(cloud_test_catalog, animal_dataset):
     assert DatasetQuery(name=ds_name, version=2, catalog=catalog).count() == 3
     assert DatasetQuery(name=ds_name, version=3, catalog=catalog).count() == 3
 
-    with pytest.raises(ValueError):
+    with pytest.raises(DatasetVersionNotFoundError):
         DatasetQuery(name=ds_name, version=4, catalog=catalog).count()
 
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -8,7 +8,11 @@ import sqlalchemy as sa
 from datachain.client.local import FileClient
 from datachain.data_storage.sqlite import SQLiteWarehouse
 from datachain.dataset import DatasetDependencyType, DatasetStatus
-from datachain.error import DatasetInvalidVersionError, DatasetNotFoundError
+from datachain.error import (
+    DatasetInvalidVersionError,
+    DatasetNotFoundError,
+    DatasetVersionNotFoundError,
+)
 from datachain.lib.dc import DataChain
 from datachain.lib.file import File
 from datachain.lib.listing import parse_listing_uri
@@ -452,7 +456,7 @@ def test_registering_dataset_invalid_source_version(
 ):
     catalog = cloud_test_catalog.catalog
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(DatasetVersionNotFoundError) as exc_info:
         catalog.register_dataset(
             dogs_dataset,
             5,

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from datachain.dataset import DatasetStatus
-from datachain.error import DataChainError, DatasetVersionNotFoundError
+from datachain.error import DataChainError
 from datachain.utils import JSONSerialize
 from tests.data import ENTRIES
 from tests.utils import assert_row_names, skip_if_not_sqlite
@@ -229,7 +229,7 @@ def test_pull_dataset_wrong_version(
     )
     catalog = cloud_test_catalog.catalog
 
-    with pytest.raises(DatasetVersionNotFoundError) as exc_info:
+    with pytest.raises(DataChainError) as exc_info:
         catalog.pull_dataset("ds://dogs@v5", no_cp=True, remote_config=remote_config)
     assert str(exc_info.value) == "Dataset dogs doesn't have version 5 on server"
 

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from datachain.dataset import DatasetStatus
-from datachain.error import DataChainError
+from datachain.error import DataChainError, DatasetVersionNotFoundError
 from datachain.utils import JSONSerialize
 from tests.data import ENTRIES
 from tests.utils import assert_row_names, skip_if_not_sqlite
@@ -229,7 +229,7 @@ def test_pull_dataset_wrong_version(
     )
     catalog = cloud_test_catalog.catalog
 
-    with pytest.raises(DataChainError) as exc_info:
+    with pytest.raises(DatasetVersionNotFoundError) as exc_info:
         catalog.pull_dataset("ds://dogs@v5", no_cp=True, remote_config=remote_config)
     assert str(exc_info.value) == "Dataset dogs doesn't have version 5 on server"
 


### PR DESCRIPTION
Currently we are getting some errors that is raised as ValueError in
studio. Capturing all ValueError doesn't seem like a good idea.
So, the exception is specified more properly.
