### PR TITLE
fix(tests): use unique dataset name to isolate from other examples

### DIFF
--- a/examples/multimodal/wds_filtered.py
+++ b/examples/multimodal/wds_filtered.py
@@ -5,7 +5,7 @@ from datachain.lib.webdataset_laion import WDSLaion
 from datachain.sql import literal
 from datachain.sql.functions import array, greatest, least, string
 
-name = "wds"
+name = "wds_filtered"
 try:
     wds = DataChain.from_dataset(name=name)
 except datachain.error.DatasetNotFoundError:


### PR DESCRIPTION
Fixes https://github.com/iterative/datachain/issues/462

I think this is happening because of caching (e.g. we run one of the `wds` tests now before the other - order changed - and both have `save("wds")`, or some other caching is happening somewhere.

We probably should try to completely isolate tests by removing `.datachain` between them. It might slow down the whole thing though. @mattseddon was it intentional - that we are reusing the same `.datachain`? (is it true at all?)