### PR TITLE
assert each example has some output instead of stdout and stderr

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -6,34 +6,42 @@ from typing import Optional
 
 import pytest
 
-get_started_examples = [
-    filename
-    for filename in glob.glob("examples/get_started/**/*.py", recursive=True)
-    # torch-loader will not finish within an hour on Linux runner
-    if "torch" not in filename or os.environ.get("RUNNER_OS") != "Linux"
-]
+get_started_examples = sorted(
+    [
+        filename
+        for filename in glob.glob("examples/get_started/**/*.py", recursive=True)
+        # torch-loader will not finish within an hour on Linux runner
+        if "torch" not in filename or os.environ.get("RUNNER_OS") != "Linux"
+    ]
+)
 
-llm_and_nlp_examples = [
-    filename
-    for filename in glob.glob("examples/llm_and_nlp/**/*.py", recursive=True)
-    # no anthropic token
-    if "claude" not in filename
-]
+llm_and_nlp_examples = sorted(
+    [
+        filename
+        for filename in glob.glob("examples/llm_and_nlp/**/*.py", recursive=True)
+        # no anthropic token
+        if "claude" not in filename
+    ]
+)
 
-multimodal_examples = [
-    filename
-    for filename in glob.glob("examples/multimodal/**/*.py", recursive=True)
-    # no OpenAI token
-    if "openai" not in filename
-]
+multimodal_examples = sorted(
+    [
+        filename
+        for filename in glob.glob("examples/multimodal/**/*.py", recursive=True)
+        # no OpenAI token
+        if "openai" not in filename
+    ]
+)
 
-computer_vision_examples = [
-    filename
-    for filename in glob.glob("examples/computer_vision/**/*.py", recursive=True)
-    # fashion product images tutorial out of scope
-    # and hf download painfully slow
-    if "image_desc" not in filename and "fashion_product_images" not in filename
-]
+computer_vision_examples = sorted(
+    [
+        filename
+        for filename in glob.glob("examples/computer_vision/**/*.py", recursive=True)
+        # fashion product images tutorial out of scope
+        # and hf download painfully slow
+        if "image_desc" not in filename and "fashion_product_images" not in filename
+    ]
+)
 
 
 def smoke_test(example: str, env: Optional[dict] = None):

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -57,8 +57,8 @@ def smoke_test(example: str, env: Optional[dict] = None):
         print(e.stderr.decode("utf-8"))
         pytest.fail("subprocess returned a non-zero exit code")
 
-    assert completed_process.stdout
-    assert completed_process.stderr
+    example_has_some_output = bool(completed_process.stdout or completed_process.stderr)
+    assert example_has_some_output
 
 
 @pytest.mark.examples


### PR DESCRIPTION
Closes https://github.com/iterative/datachain/issues/462

This PR removes a dud assertion that each example should have some `stderr` output and replaces it with the assertion that each example will have some user-facing output (either stdout or stderr, doesn't matter which). It also removes the reliance on `glob` to order the examples for us.

More discussion can be found in #464