### PR TITLE
only use free runners for examples

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,13 +119,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         pyv: ['3.9', '3.12']
         group: ['get_started', 'llm_and_nlp or computer_vision', 'multimodal']
-        exclude:
-          - {os: ubuntu-latest, pyv: '3.9', group: 'multimodal'}
-          - {os: ubuntu-latest, pyv: '3.12', group: 'multimodal'}
-        include:
-          - {os: ubuntu-latest-4-cores, pyv: "3.9", group: multimodal}
-          - {os: ubuntu-latest-4-cores, pyv: "3.12", group: multimodal}
-
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Checking whether or not we can drop `ubuntu-latest-4-cores` usage after #409