### PR TITLE
use official github action for uv and `uv build`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,15 +23,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
-      - name: Upgrade nox and uv
-        run: |
-          python -m pip install --upgrade 'nox[uv]'
-          nox --version
-          uv --version
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-suffix: benchmarks
+          cache-dependency-glob: pyproject.toml
 
-      - run: uv pip install dvc[gs] --system
-      - run: dvc --cd tests/benchmarks/datasets pull
+      - name: Install nox and dvc
+        run: uv pip install dvc[gs] nox --system
+
+      - name: Pull dataset
+        run: dvc --cd tests/benchmarks/datasets pull
       - name: Run benchmarks
         run: nox -s bench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
-      - name: Upgrade nox and uv
-        run: |
-          python -m pip install --upgrade 'nox[uv]'
-          nox --version
-          uv --version
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
 
+      - name: Install nox
+        run: uv pip install nox --system
       - name: Build package
         run: nox -s build
 

--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -82,12 +82,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyv }}
-          cache: 'pip'
 
-      - name: Install uv
-        run: |
-          python -m pip install --upgrade uv
-          uv --version
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-suffix: studio
+          cache-dependency-glob: |
+            backend/datachain_server/pyproject.toml
+            backend/datachain/pyproject.toml
 
       - name: Install dependencies
         run: uv pip install --system ./backend/datachain_server[tests] ./backend/datachain[tests]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-          cache: 'pip'
 
-      - name: Upgrade nox and uv
-        run: |
-          python -m pip install --upgrade 'nox[uv]'
-          nox --version
-          uv --version
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-suffix: lint
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install nox
+        run: uv pip install nox --system
 
       - name: Cache mypy
         uses: actions/cache@v4
@@ -77,13 +80,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyv }}
-          cache: 'pip'
 
-      - name: Upgrade nox and uv
-        run: |
-          python -m pip install --upgrade 'nox[uv]'
-          nox --version
-          uv --version
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-suffix: tests-${{ matrix.pyv }}
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install nox
+        run: uv pip install nox --system
 
       - name: Skip flaky azure, gs remotes on macOS
         if: runner.os == 'macOS'
@@ -134,13 +140,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyv }}
-          cache: 'pip'
 
-      - name: Upgrade nox and uv
-        run: |
-          python -m pip install --upgrade 'nox[uv]'
-          nox --version
-          uv --version
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-suffix: examples-${{ matrix.pyv }}
+          cache-dependency-glob: pyproject.toml
+
+      - name: Install nox
+        run: uv pip install nox --system
 
       - name: Run examples
         run: nox -s examples -p ${{ matrix.pyv }} -- -m "${{ matrix.group }}"

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,8 +57,8 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def build(session: nox.Session) -> None:
-    session.install("build", "twine", "uv")
-    session.run("python", "-m", "build", "--installer", "uv")
+    session.install("twine", "uv")
+    session.run("uv", "build")
     dists = glob.glob("dist/*")
     session.run("twine", "check", *dists, silent=True)
 


### PR DESCRIPTION
There is now an official action for `uv`, with support for caching.

See https://github.com/astral-sh/setup-uv.

`uv` also has a "build" frontend, so we can use `uv build` to build package instead of `python-build`.