### PR TITLE
drop file.location

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -62,7 +62,7 @@ from datachain.listing import Listing
 from datachain.node import DirType, Node, NodeWithPath
 from datachain.nodes_thread_pool import NodesThreadPool
 from datachain.remote.studio import StudioClient
-from datachain.sql.types import JSON, Boolean, DateTime, Int64, SQLType, String
+from datachain.sql.types import Boolean, DateTime, Int64, SQLType, String
 from datachain.storage import Storage, StorageStatus, StorageURI
 from datachain.utils import (
     DataChainDir,
@@ -663,7 +663,6 @@ class Catalog:
             Column("is_latest", Boolean),
             Column("last_modified", DateTime(timezone=True)),
             Column("size", Int64),
-            Column("location", JSON),
             Column("source", String),
         ]
 

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -345,7 +345,6 @@ class Client(ABC):
         """Open a file, including files in tar archives."""
         if use_cache and (cache_path := self.cache.get_path(file)):
             return open(cache_path, mode="rb")  # noqa: SIM115
-        assert not file.location
         return FileWrapper(self.fs.open(self.get_full_path(file.path)), cb)  # type: ignore[return-value]
 
     def download(self, file: File, *, callback: Callback = DEFAULT_CALLBACK) -> None:
@@ -361,7 +360,6 @@ class Client(ABC):
         sync(get_loop(), functools.partial(self._put_in_cache, file, callback=callback))
 
     async def _put_in_cache(self, file: File, *, callback: "Callback" = None) -> None:
-        assert not file.location
         if file.etag:
             etag = await self.get_current_etag(file)
             if file.etag != etag:

--- a/src/datachain/data_storage/schema.py
+++ b/src/datachain/data_storage/schema.py
@@ -10,7 +10,7 @@ from typing import (
 
 import sqlalchemy as sa
 from sqlalchemy.sql import func as f
-from sqlalchemy.sql.expression import false, null, true
+from sqlalchemy.sql.expression import false, true
 
 from datachain.sql.functions import path
 from datachain.sql.types import Int, SQLType, UInt64
@@ -84,7 +84,6 @@ class DirExpansion:
             q.c.source,
             q.c.path,
             q.c.version,
-            q.c.location,
         )
 
     @staticmethod
@@ -96,7 +95,6 @@ class DirExpansion:
                 q.c.source,
                 q.c.path,
                 q.c.version,
-                f.max(q.c.location).label("location"),
             )
             .select_from(q)
             .group_by(q.c.source, q.c.path, q.c.is_dir, q.c.version)
@@ -114,7 +112,6 @@ class DirExpansion:
                 q.c.source,
                 parent.label("path"),
                 sa.literal("").label("version"),
-                null().label("location"),
             ).where(parent != "")
         )
         return cls.apply_group_by(q)

--- a/src/datachain/listing.py
+++ b/src/datachain/listing.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql import func
 from tqdm import tqdm
 
 from datachain.lib.file import File
-from datachain.node import DirType, Node, NodeWithPath
+from datachain.node import Node, NodeWithPath
 from datachain.sql.functions import path as pathfunc
 from datachain.utils import suffix_to_number
 
@@ -102,10 +102,6 @@ class Listing:
         return self.warehouse.get_node_by_path(self.dataset_rows, path)
 
     def ls_path(self, node, fields):
-        if node.location or node.dir_type == DirType.TAR_ARCHIVE:
-            return self.warehouse.select_node_fields_by_parent_path_tar(
-                self.dataset_rows, node.path, fields
-            )
         return self.warehouse.select_node_fields_by_parent_path(
             self.dataset_rows, node.path, fields
         )
@@ -233,16 +229,10 @@ class Listing:
         return self.warehouse.size(self.dataset_rows, node, count_files)
 
     def subtree_files(self, node: Node, sort=None):
-        if node.dir_type == DirType.TAR_ARCHIVE or node.location:
-            include_subobjects = True
-        else:
-            include_subobjects = False
-
         return self.warehouse.get_subtree_files(
             self.dataset_rows,
             node,
             sort=sort,
-            include_subobjects=include_subobjects,
         )
 
     def get_dirs_by_parent_path(

--- a/src/datachain/node.py
+++ b/src/datachain/node.py
@@ -54,7 +54,6 @@ class Node:
     is_latest: bool = True
     last_modified: Optional[datetime] = None
     size: int = 0
-    location: Optional[str] = None
     source: StorageURI = StorageURI("")
     dir_type: int = DirType.FILE
 
@@ -109,7 +108,6 @@ class Node:
             version=self.version or "",
             etag=self.etag,
             is_latest=self.is_latest,
-            location=self.location,
             last_modified=self.last_modified or TIME_ZERO,
         )
 
@@ -128,7 +126,6 @@ class Node:
             size=_dval("size"),
             last_modified=_dval("last_modified"),
             version=_dval("version"),
-            location=_dval("location"),
             dir_type=DirType.FILE,
         )
 

--- a/src/datachain/query/schema.py
+++ b/src/datachain/query/schema.py
@@ -1,5 +1,4 @@
 import functools
-import json
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from fnmatch import fnmatch
@@ -10,7 +9,7 @@ import sqlalchemy as sa
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 
 from datachain.lib.file import File
-from datachain.sql.types import JSON, Boolean, DateTime, Int64, SQLType, String
+from datachain.sql.types import Boolean, DateTime, Int64, SQLType, String
 
 if TYPE_CHECKING:
     from datachain.catalog import Catalog
@@ -233,7 +232,6 @@ class DatasetRow:
         "source": String,
         "path": String,
         "size": Int64,
-        "location": JSON,
         "is_latest": Boolean,
         "last_modified": DateTime,
         "version": String,
@@ -245,7 +243,6 @@ class DatasetRow:
         path: str,
         source: str = "",
         size: int = 0,
-        location: Optional[dict[str, Any]] = None,
         is_latest: bool = True,
         last_modified: Optional[datetime] = None,
         version: str = "",
@@ -262,16 +259,12 @@ class DatasetRow:
         str,
         int,
     ]:
-        if location:
-            location = json.dumps([location])  # type: ignore [assignment]
-
         last_modified = last_modified or datetime.now(timezone.utc)
 
         return (  # type: ignore [return-value]
             source,
             path,
             size,
-            location,
             is_latest,
             last_modified,
             version,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -621,7 +621,6 @@ def dataset_rows():
     return [
         {
             "id": i,
-            "location": "",
             "source": "s3://my-bucket",
             "dir_type": 0,
             "parent": "input/text_emd_1m",

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -476,7 +476,6 @@ def test_from_storage_check_rows(tmp_dir, test_session):
             etag=stat.st_mtime.hex(),
             is_latest=True,
             last_modified=datetime.fromtimestamp(mtime, tz=tz),
-            location=None,
         )
 
 

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -386,7 +386,7 @@ def test_mutate(cloud_test_catalog, save, animal_dataset):
     else:
         result = q.db_results(row_factory=lambda c, v: dict(zip(c, v)))
     assert len(result) == 4
-    assert len(result[0]) == 15
+    assert len(result[0]) == 14
     cols = {"size10x", "size1000x", "s2", "s3", "s4"}
     new_data = [[v for k, v in r.items() if k in cols] for r in result]
     assert new_data == [

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -32,4 +32,3 @@ def test_listing_generator(cloud_test_catalog, cloud_type):
             assert cat_file.path == cat_entry.path
         assert cat_file.size == cat_entry.size
         assert cat_file.is_latest == cat_entry.is_latest
-        assert cat_file.location is None

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -53,7 +53,6 @@ def dog_entries_parquet_lz4(dog_entries) -> bytes:
 
         adapted["sys__id"] = 1
         adapted["sys__rand"] = 1
-        adapted["file__location"] = b""
         adapted["file__source"] = b"s3://dogs"
         return adapted
 
@@ -76,7 +75,6 @@ def schema():
         "file__is_latest": {"type": "Boolean"},
         "file__last_modified": {"type": "DateTime"},
         "file__size": {"type": "Int64"},
-        "file__location": {"type": "String"},
         "file__source": {"type": "String"},
     }
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -199,7 +199,6 @@ def test_from_records_empty_chain_without_schema(test_session):
         "etag",
         "is_latest",
         "last_modified",
-        "location",
     }
     assert ds.count() == 0
 

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import Mock
 
 import pytest
@@ -200,34 +199,6 @@ def test_cache_get_path_without_cache():
     stream = File(path="test.txt1", source="s3://mybkt")
     with pytest.raises(RuntimeError):
         stream.get_local_path()
-
-
-def test_json_from_string():
-    d = {"e": 12}
-
-    file = File(path="something", location=d)
-    assert file.location == d
-
-    file = File(path="something", location=None)
-    assert file.location is None
-
-    file = File(path="something", location="")
-    assert file.location is None
-
-    file = File(path="something", location=json.dumps(d))
-    assert file.location == d
-
-    with pytest.raises(ValueError):
-        File(path="something", location="{not a json}")
-
-
-def test_file_info_jsons():
-    file = File(path="something", location="")
-    assert file.location is None
-
-    d = {"e": 12}
-    file = File(path="something", location=json.dumps(d))
-    assert file.location == d
 
 
 def test_get_path_local(catalog):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -10,7 +10,7 @@ def cache(tmp_path):
 
 
 def test_simple(cache):
-    uid = File(source="s3://foo", path="data/bar", etag="xyz", size=3, location=None)
+    uid = File(source="s3://foo", path="data/bar", etag="xyz", size=3)
     data = b"foo"
     assert not cache.contains(uid)
 
@@ -32,9 +32,7 @@ def test_get_total_size(cache):
     ]
     expected_total = sum(len(d) for _, d in file_info)
     for name, data in file_info:
-        uid = File(
-            source="s3://foo", path=f"data/{name}", etag="xyz", size=3, location=None
-        )
+        uid = File(source="s3://foo", path=f"data/{name}", etag="xyz", size=3)
         cache.store_data(uid, data)
     total = cache.get_total_size()
     assert total == expected_total
@@ -45,9 +43,7 @@ def test_get_total_size(cache):
 
 
 def test_remove(cache):
-    uid = File(
-        source="s3://bkt42", path="dir1/dir2/file84", etag="abc", size=3, location=None
-    )
+    uid = File(source="s3://bkt42", path="dir1/dir2/file84", etag="abc", size=3)
     cache.store_data(uid, b"some random string 679")
 
     assert cache.contains(uid)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -32,7 +32,6 @@ def test_dataset_table_compilation():
             Column("is_latest", Boolean),
             Column("last_modified", DateTime(timezone=True)),
             Column("size", Int64, nullable=False, index=True),
-            Column("location", JSON),
             Column("source", String, nullable=False),
             Column("score", Float, nullable=False),
             Column("meta_info", JSON),
@@ -52,7 +51,6 @@ def test_dataset_table_compilation():
         "\tis_latest BOOLEAN, \n"
         "\tlast_modified DATETIME, \n"
         "\tsize INTEGER NOT NULL, \n"
-        "\tlocation JSON, \n"
         "\tsource VARCHAR NOT NULL, \n"
         "\tscore FLOAT NOT NULL, \n"
         "\tmeta_info JSON, \n"


### PR DESCRIPTION
Drops `File.location` field after https://github.com/iterative/datachain/pull/446. See https://github.com/iterative/datachain/pull/446/files#r1780264304.