### PR TITLE
Don't allow mappers to skip rows

### DIFF
--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -154,7 +154,6 @@ class UDFAdapter:
         return [
             {"sys__id": row_id} | dict(zip(self.signal_names, signals))
             for row_id, signals in zip(row_ids, results)
-            if signals is not None  # skip rows with no output
         ]
 
 


### PR DESCRIPTION
AFAICT that obscure feature was introduced in https://github.com/iterative/dvcx/pull/863. It's undocumented (and even contradicts the docs) and untested, so I assume it's unused and broken.