### PR TITLE
Making anon access to buckets default

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -554,7 +554,9 @@ class Catalog:
         self.metastore = metastore
         self._warehouse = warehouse
         self.cache = DataChainCache(datachain_dir.cache, datachain_dir.tmp)
-        self.client_config = client_config if client_config is not None else {}
+        self.client_config = (
+            client_config if client_config is not None else {"anon": True}
+        )
         self._init_params = {
             "cache_dir": cache_dir,
             "tmp_dir": tmp_dir,

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -392,6 +392,7 @@ class DataChain:
         object_name: str = "file",
         update: bool = False,
         anon: bool = False,
+        client_config: Optional[dict[str, Any]] = None,
     ) -> "Self":
         """Get data from a storage as a list of file with all file attributes.
         It returns the chain itself as usual.
@@ -412,7 +413,10 @@ class DataChain:
         """
         file_type = get_file_type(type)
 
-        client_config = {"anon": True} if anon else None
+        if anon:
+            if client_config is None:
+                client_config = {}
+            client_config["anon"] = True
 
         session = Session.get(session, client_config=client_config, in_memory=in_memory)
 

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -30,7 +30,7 @@ def list_bucket(uri: str, cache, client_config=None) -> Callable:
     """
 
     def list_func() -> Iterator[File]:
-        config = client_config or {}
+        config = client_config if client_config is not None else {"anon": True}
         client = Client.get_client(uri, cache, **config)  # type: ignore[arg-type]
         _, path = Client.parse_url(uri)
         for entries in iter_over_async(client.scandir(path.rstrip("/")), get_loop()):
@@ -80,7 +80,7 @@ def parse_listing_uri(uri: str, cache, client_config) -> tuple[str, str, str]:
     """
     Parsing uri and returns listing dataset name, listing uri and listing path
     """
-    client_config = client_config or {}
+    client_config = client_config if client_config is not None else {"anon": True}
     client = Client.get_client(uri, cache, **client_config)
     storage_uri, path = Client.parse_url(uri)
     telemetry.log_param("client", client.PREFIX)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -47,10 +47,21 @@ def _get_listing_datasets(session):
     )
 
 
-@pytest.mark.parametrize("anon", [True, False])
-def test_catalog_anon(tmp_dir, catalog, anon):
-    chain = DataChain.from_storage(tmp_dir.as_uri(), anon=anon)
-    assert chain.session.catalog.client_config.get("anon", False) is anon
+@pytest.mark.parametrize(
+    "client_config,anon,expected",
+    (
+        ({"anon": True}, False, True),
+        ({}, False, False),
+        ({}, True, True),
+        (None, False, True),
+        (None, True, True),
+    ),
+)
+def test_catalog_anon(tmp_dir, catalog, client_config, anon, expected):
+    chain = DataChain.from_storage(
+        tmp_dir.as_uri(), anon=anon, client_config=client_config
+    )
+    assert chain.session.catalog.client_config.get("anon", False) is expected
 
 
 def test_from_storage(cloud_test_catalog):


### PR DESCRIPTION
This makes anon access default for buckets (s3, gcs, etc.) when no credentials/custom configuration is provided. As especially on Google Cloud Storage, not specifying any credentials (and also not specifying anonymous access) causes a lookup for default credentials, which includes attempting to access a Google Cloud Metadata Server, which on Studio takes a very long time (20+ seconds on my local Studio and 10+ seconds on the production Studio) and leads to warnings such as: 

```
WARNING google.auth.compute_engine._metadata Compute Engine Metadata server unavailable on attempt 5 of 5. Reason: HTTPConnectionPool(host='metadata.google.internal', port=80): Max retries exceeded with url: /computeMetadata/v1/instance/service-accounts/default/?recursive=true (Caused by NameResolutionError("<urllib3.connection.HTTPConnection object at 0x16206bda0>: Failed to resolve 'metadata.google.internal' ([Errno 8] nodename nor servname provided, or not known)"))
```

Note that this does not change the behavior if credentials are provided in `client_config`. This improves image preview loading times on my local Studio from 20+ seconds to less than one second for an uncached image.

This has been tested locally, with my local Studio, and fixes iterative/studio#10743