### PR TITLE
Make datachain queries atomic when exception occurs

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -988,6 +988,14 @@ class Catalog:
         schema = {
             c.name: c.type.to_dict() for c in columns if isinstance(c.type, SQLType)
         }
+
+        job_id = job_id or os.getenv("DATACHAIN_JOB_ID")
+        if not job_id:
+            from datachain.query.session import Session
+
+            session = Session.get(catalog=self)
+            job_id = session.name
+
         dataset = self.metastore.create_dataset_version(
             dataset,
             version,

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -51,7 +51,6 @@ if TYPE_CHECKING:
     from datachain.data_storage import AbstractIDGenerator, schema
     from datachain.data_storage.db_engine import DatabaseEngine
 
-
 logger = logging.getLogger("datachain")
 
 
@@ -384,6 +383,11 @@ class AbstractMetastore(ABC, Serializable):
         dataset_status: DatasetStatus,
     ) -> None:
         """Set the status of the given job and dataset."""
+
+    @abstractmethod
+    def get_job_dataset_versions(self, job_id: str) -> list[tuple[str, int]]:
+        """Returns dataset names and versions for the job."""
+        raise NotImplementedError
 
 
 class AbstractDBMetastore(AbstractMetastore):
@@ -1519,3 +1523,18 @@ class AbstractDBMetastore(AbstractMetastore):
                 .values(status=dataset_status)
             )
             self.db.execute(query, conn=conn)  # type: ignore[attr-defined]
+
+    def get_job_dataset_versions(self, job_id: str) -> list[tuple[str, int]]:
+        """Returns dataset names and versions for the job."""
+        dv = self._datasets_versions
+        ds = self._datasets
+
+        join_condition = dv.c.dataset_id == ds.c.id
+
+        query = (
+            self._datasets_versions_select(ds.c.name, dv.c.version)
+            .select_from(dv.join(ds, join_condition))
+            .where(dv.c.job_id == job_id)
+        )
+
+        return list(self.db.execute(query))

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -1,0 +1,24 @@
+# Set logger to debug level
+import logging
+
+from pydantic import BaseModel
+
+from datachain.lib.dc import C, DataChain
+
+logging.basicConfig(level=logging.INFO)
+
+
+class Embedding(BaseModel):
+    value: float
+
+
+ds_name = "feature_class_error"
+ds = (
+    DataChain.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    .filter(C("file.path").glob("*cat*.jpg"))
+    .limit(5)
+    .map(emd=lambda file: Embedding(value=512), output=Embedding)
+)
+ds.select("file.path", "emd.value").show(limit=5, flatten=True)
+ds.save(ds_name)
+raise Exception("This is a test exception")

--- a/tests/test_atomicity.py
+++ b/tests/test_atomicity.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+tests_dir = os.path.dirname(os.path.abspath(__file__))
+
+python_exc = sys.executable or "python3"
+
+E2E_STEP_TIMEOUT_SEC = 90
+
+
+@pytest.mark.e2e
+@pytest.mark.xdist_group(name="tmpfile")
+def test_atomicity_feature_file(tmp_dir, catalog_tmpfile):
+    command = (
+        python_exc,
+        os.path.join(tests_dir, "scripts", "feature_class_exception.py"),
+    )
+    if sys.platform == "win32":
+        # Windows has a different mechanism of creating a process group.
+        popen_args = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+        # This is STATUS_CONTROL_C_EXIT which is equivalent to 0xC000013A
+    else:
+        popen_args = {"start_new_session": True}
+
+    process = subprocess.Popen(  # noqa: S603
+        command,
+        shell=False,
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "DATACHAIN__ID_GENERATOR": catalog_tmpfile.id_generator.serialize(),
+            "DATACHAIN__METASTORE": catalog_tmpfile.metastore.serialize(),
+            "DATACHAIN__WAREHOUSE": catalog_tmpfile.warehouse.serialize(),
+        },
+        **popen_args,
+    )
+
+    process.communicate(timeout=E2E_STEP_TIMEOUT_SEC)
+
+    assert process.returncode == 1
+
+    # No datasets should be left in the catalog
+    assert list(catalog_tmpfile.list_datasets_versions()) == []


### PR DESCRIPTION
With this change, whenever any error or exception is raised when running
the script, this will revert all datachain version and datasets created
during the script.

Studio PR: https://github.com/iterative/studio/pull/10740
Studio Issue: https://github.com/iterative/studio/issues/9875
