### PR TITLE
UDF refactoring

### DIFF
--- a/src/datachain/lib/convert/values_to_tuples.py
+++ b/src/datachain/lib/convert/values_to_tuples.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from datachain.lib.data_model import (
     DataType,
     DataTypeNames,
-    DataValuesType,
+    DataValue,
     is_chain_type,
 )
 from datachain.lib.utils import DataChainParamsError
@@ -20,7 +20,7 @@ class ValuesToTupleError(DataChainParamsError):
 def values_to_tuples(  # noqa: C901, PLR0912
     ds_name: str = "",
     output: Union[None, DataType, Sequence[str], dict[str, DataType]] = None,
-    **fr_map: Sequence[DataValuesType],
+    **fr_map: Sequence[DataValue],
 ) -> tuple[Any, Any, Any]:
     if output:
         if not isinstance(output, (Sequence, str, dict)):

--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -18,7 +18,7 @@ StandardType = Union[
 ]
 DataType = Union[type[BaseModel], StandardType]
 DataTypeNames = "BaseModel, int, str, float, bool, list, dict, bytes, datetime"
-DataValuesType = Union[BaseModel, int, str, float, bool, list, dict, bytes, datetime]
+DataValue = Union[BaseModel, int, str, float, bool, list, dict, bytes, datetime]
 
 
 class DataModel(BaseModel):

--- a/src/datachain/query/batch.py
+++ b/src/datachain/query/batch.py
@@ -11,8 +11,6 @@ from datachain.data_storage.warehouse import SELECT_BATCH_SIZE
 if TYPE_CHECKING:
     from sqlalchemy import Select
 
-    from datachain.dataset import RowDict
-
 
 @dataclass
 class RowsOutputBatch:
@@ -20,14 +18,6 @@ class RowsOutputBatch:
 
 
 RowsOutput = Union[Sequence, RowsOutputBatch]
-
-
-@dataclass
-class UDFInputBatch:
-    rows: Sequence["RowDict"]
-
-
-UDFInput = Union["RowDict", UDFInputBatch]
 
 
 class BatchingStrategy(ABC):

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -392,7 +392,7 @@ class UDFStep(Step, ABC):
 
     def populate_udf_table(self, udf_table: "Table", query: Select) -> None:
         use_partitioning = self.partition_by is not None
-        batching = self.udf.properties.get_batching(use_partitioning)
+        batching = self.udf.get_batching(use_partitioning)
         workers = self.workers
         if (
             not workers

--- a/src/datachain/query/dispatch.py
+++ b/src/datachain/query/dispatch.py
@@ -114,7 +114,6 @@ class UDFDispatcher:
     catalog: Optional[Catalog] = None
     task_queue: Optional[multiprocess.Queue] = None
     done_queue: Optional[multiprocess.Queue] = None
-    _batch_size: Optional[int] = None
 
     def __init__(
         self,
@@ -153,17 +152,6 @@ class UDFDispatcher:
         self.task_queue = None
         self.done_queue = None
         self.ctx = get_context("spawn")
-
-    @property
-    def batch_size(self):
-        if self._batch_size is None:
-            if hasattr(self.udf, "properties") and hasattr(
-                self.udf.properties, "batch"
-            ):
-                self._batch_size = self.udf.properties.batch
-            else:
-                self._batch_size = 1
-        return self._batch_size
 
     def _create_worker(self) -> "UDFWorker":
         if not self.catalog:


### PR DESCRIPTION
Simplify the logic in `udf.run()` by cleanly separating the 4 different code flows. Part of #40.