### PR TITLE
Add a way to persist dataset even if exception is thrown

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -72,6 +72,7 @@ from datachain.utils import (
 from .datasource import DataSource
 
 if TYPE_CHECKING:
+    from datachain import Session
     from datachain.data_storage import (
         AbstractIDGenerator,
         AbstractMetastore,
@@ -916,6 +917,7 @@ class Catalog:
         create_rows: Optional[bool] = True,
         validate_version: Optional[bool] = True,
         listing: Optional[bool] = False,
+        session: Optional["Session"] = None,
     ) -> "DatasetRecord":
         """
         Creates new dataset of a specific version.
@@ -963,6 +965,7 @@ class Catalog:
             query_script=query_script,
             create_rows_table=create_rows,
             columns=columns,
+            session=session,
         )
 
     def create_new_dataset_version(
@@ -979,6 +982,7 @@ class Catalog:
         script_output="",
         create_rows_table=True,
         job_id: Optional[str] = None,
+        session: Optional["Session"] = None,
     ) -> DatasetRecord:
         from datachain.query.session import Session
 
@@ -1011,7 +1015,7 @@ class Catalog:
             self.warehouse.create_dataset_rows_table(table_name, columns=columns)
             self.update_dataset_version_with_warehouse_info(dataset, version)
 
-        session = Session.get_current_context()
+        session = Session.get(session=session, catalog=self)
         session.add_created_versions(dataset, version)
 
         return dataset
@@ -1176,6 +1180,7 @@ class Catalog:
         version: int,
         target_dataset: DatasetRecord,
         target_version: Optional[int] = None,
+        session: Optional["Session"] = None,
     ) -> DatasetRecord:
         """
         Registers dataset version of one dataset as dataset version of another
@@ -1219,7 +1224,7 @@ class Catalog:
             job_id=dataset_version.job_id,
         )
 
-        session = Session.get_current_context()
+        session = Session.get(session=session, catalog=self)
         session.add_created_versions(target_dataset, target_version)
 
         # to avoid re-creating rows table, we are just renaming it for a new version

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -980,6 +980,8 @@ class Catalog:
         create_rows_table=True,
         job_id: Optional[str] = None,
     ) -> DatasetRecord:
+        from datachain.query.session import Session
+
         """
         Creates dataset version if it doesn't exist.
         If create_rows is False, dataset rows table will not be created
@@ -988,13 +990,6 @@ class Catalog:
         schema = {
             c.name: c.type.to_dict() for c in columns if isinstance(c.type, SQLType)
         }
-
-        job_id = job_id or os.getenv("DATACHAIN_JOB_ID")
-        if not job_id:
-            from datachain.query.session import Session
-
-            session = Session.get(catalog=self)
-            job_id = session.job_id
 
         dataset = self.metastore.create_dataset_version(
             dataset,
@@ -1015,6 +1010,9 @@ class Catalog:
             table_name = self.warehouse.dataset_table_name(dataset.name, version)
             self.warehouse.create_dataset_rows_table(table_name, columns=columns)
             self.update_dataset_version_with_warehouse_info(dataset, version)
+
+        session = Session.get_current_context()
+        session.add_created_versions(dataset, version)
 
         return dataset
 
@@ -1184,6 +1182,8 @@ class Catalog:
         one (it can be new version of existing one).
         It also removes original dataset version
         """
+        from datachain.query.session import Session
+
         target_version = target_version or target_dataset.next_version
 
         if not target_dataset.is_valid_next_version(target_version):
@@ -1218,6 +1218,10 @@ class Catalog:
             preview=dataset_version.preview,
             job_id=dataset_version.job_id,
         )
+
+        session = Session.get_current_context()
+        session.add_created_versions(target_dataset, target_version)
+
         # to avoid re-creating rows table, we are just renaming it for a new version
         # of target dataset
         self.warehouse.rename_dataset_table(

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1016,7 +1016,7 @@ class Catalog:
             self.update_dataset_version_with_warehouse_info(dataset, version)
 
         session = Session.get(session=session, catalog=self)
-        session.add_created_versions(dataset, version)
+        session.add_dataset_version(dataset, version)
 
         return dataset
 
@@ -1225,7 +1225,7 @@ class Catalog:
         )
 
         session = Session.get(session=session, catalog=self)
-        session.add_created_versions(target_dataset, target_version)
+        session.add_dataset_version(target_dataset, target_version)
 
         # to avoid re-creating rows table, we are just renaming it for a new version
         # of target dataset

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1992,8 +1992,9 @@ class DataChain:
                 if signal_schema
                 else None
             ),
-            session=session,
         )
+
+        session.add_dataset_version(dsr, dsr.latest_version)
 
         if isinstance(to_insert, dict):
             to_insert = [to_insert]

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1976,6 +1976,7 @@ class DataChain:
                 if signal_schema
                 else None
             ),
+            session=session,
         )
 
         if isinstance(to_insert, dict):

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1587,10 +1587,11 @@ class DatasetQuery:
                 version=version,
                 feature_schema=feature_schema,
                 columns=columns,
-                session=self.session,
                 **kwargs,
             )
             version = version or dataset.latest_version
+
+            self.session.add_dataset_version(dataset=dataset, version=version)
 
             dr = self.catalog.warehouse.dataset_rows(dataset)
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1587,6 +1587,7 @@ class DatasetQuery:
                 version=version,
                 feature_schema=feature_schema,
                 columns=columns,
+                session=self.session,
                 **kwargs,
             )
             version = version or dataset.latest_version

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -1,8 +1,8 @@
 import atexit
 import logging
-import os
 import re
 import sys
+import threading
 from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from datachain.catalog import Catalog
 
 logger = logging.getLogger("datachain")
+
+# Thread-local storage for the context manager stack
+_local = threading.local()
 
 
 class Session:
@@ -39,7 +42,6 @@ class Session:
     """
 
     GLOBAL_SESSION_CTX: Optional["Session"] = None
-    GLOBAL_SESSION: Optional["Session"] = None
     ORIGINAL_EXCEPT_HOOK = None
 
     DATASET_PREFIX = "session_"
@@ -64,24 +66,46 @@ class Session:
 
         session_uuid = uuid4().hex[: self.SESSION_UUID_LEN]
         self.name = f"{name}_{session_uuid}"
-        self.job_id = os.getenv("DATACHAIN_JOB_ID") or str(uuid4())
         self.is_new_catalog = not catalog
         self.catalog = catalog or get_catalog(
             client_config=client_config, in_memory=in_memory
         )
+        self.versions = []
 
     def __enter__(self):
+        # Initialize the stack if not present
+        if not hasattr(_local, 'context_stack'):
+            _local.context_stack = []
+
+        # Push the current context onto the stack
+        _local.context_stack.append(self)
+
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type:
-            self._cleanup_created_versions(self.name)
+            self._cleanup_created_versions()
 
         self._cleanup_temp_datasets()
         if self.is_new_catalog:
             self.catalog.metastore.close_on_exit()
             self.catalog.warehouse.close_on_exit()
             self.catalog.id_generator.close_on_exit()
+
+        if hasattr(_local, 'context_stack') and _local.context_stack:
+            _local.context_stack.pop()
+
+    @classmethod
+    def get_current_context(cls):
+        # Access the top (most recent) context from the stack
+        if hasattr(_local, 'context_stack') and _local.context_stack:
+            return _local.context_stack[-1]
+
+        # Return global context
+        return Session.get()
+
+    def add_created_versions(self, dataset, version):
+        self.versions.append((dataset, version))
 
     def generate_temp_dataset_name(self) -> str:
         return self.get_temp_prefix() + uuid4().hex[: self.TEMP_TABLE_UUID_LEN]
@@ -98,19 +122,11 @@ class Session:
         except TableMissingError:
             pass
 
-    def _cleanup_created_versions(self, job_id: str) -> None:
-        versions = self.catalog.metastore.get_job_dataset_versions(job_id)
-        if not versions:
+    def _cleanup_created_versions(self) -> None:
+        if not self.versions:
             return
 
-        datasets = {}
-        for dataset_name, version in versions:
-            if dataset_name not in datasets:
-                datasets[dataset_name] = self.catalog.get_dataset(dataset_name)
-            dataset = datasets[dataset_name]
-            logger.info(
-                "Removing dataset version %s@%s due to exception", dataset_name, version
-            )
+        for dataset, version in self.versions:
             self.catalog.remove_dataset_version(dataset, version)
 
     @classmethod
@@ -125,33 +141,29 @@ class Session:
 
         Parameters:
             session (Session): Optional Session(). If not provided a new session will
-                    be created. It's needed mostly for simplie API purposes.
-            catalog (Catalog): Optional catalog. By default a new catalog is created.
+                    be created. It's needed mostly for simple API purposes.
+            catalog (Catalog): Optional catalog. By default, a new catalog is created.
         """
         if session:
             return session
 
-        if cls.GLOBAL_SESSION is None:
+        if cls.GLOBAL_SESSION_CTX is None:
             cls.GLOBAL_SESSION_CTX = Session(
                 cls.GLOBAL_SESSION_NAME,
                 catalog,
                 client_config=client_config,
                 in_memory=in_memory,
             )
-            cls.GLOBAL_SESSION = cls.GLOBAL_SESSION_CTX.__enter__()
 
             atexit.register(cls._global_cleanup)
             cls.ORIGINAL_EXCEPT_HOOK = sys.excepthook
             sys.excepthook = cls.except_hook
 
-        return cls.GLOBAL_SESSION
+        return cls.GLOBAL_SESSION_CTX
 
     @staticmethod
     def except_hook(exc_type, exc_value, exc_traceback):
-        Session._global_cleanup()
-        if Session.GLOBAL_SESSION_CTX is not None:
-            job_id = Session.GLOBAL_SESSION_CTX.job_id
-            Session.GLOBAL_SESSION_CTX._cleanup_created_versions(job_id)
+        Session.GLOBAL_SESSION_CTX.__exit__(exc_type, exc_value, exc_traceback)
 
         if Session.ORIGINAL_EXCEPT_HOOK:
             Session.ORIGINAL_EXCEPT_HOOK(exc_type, exc_value, exc_traceback)
@@ -160,7 +172,6 @@ class Session:
     def cleanup_for_tests(cls):
         if cls.GLOBAL_SESSION_CTX is not None:
             cls.GLOBAL_SESSION_CTX.__exit__(None, None, None)
-            cls.GLOBAL_SESSION = None
             cls.GLOBAL_SESSION_CTX = None
             atexit.unregister(cls._global_cleanup)
 

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -1,4 +1,5 @@
 import atexit
+import gc
 import logging
 import re
 import sys
@@ -174,3 +175,7 @@ class Session:
     def _global_cleanup():
         if Session.GLOBAL_SESSION_CTX is not None:
             Session.GLOBAL_SESSION_CTX.__exit__(None, None, None)
+
+        for obj in gc.get_objects():  # Get all tracked objects
+            if isinstance(obj, Session):  # Cleanup temp dataset for session variables.
+                obj.__exit__(None, None, None)

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -74,7 +74,7 @@ class Session:
 
     def __enter__(self):
         # Initialize the stack if not present
-        if not hasattr(_local, 'context_stack'):
+        if not hasattr(_local, "context_stack"):
             _local.context_stack = []
 
         # Push the current context onto the stack
@@ -92,13 +92,13 @@ class Session:
             self.catalog.warehouse.close_on_exit()
             self.catalog.id_generator.close_on_exit()
 
-        if hasattr(_local, 'context_stack') and _local.context_stack:
+        if hasattr(_local, "context_stack") and _local.context_stack:
             _local.context_stack.pop()
 
     @classmethod
     def get_current_context(cls):
         # Access the top (most recent) context from the stack
-        if hasattr(_local, 'context_stack') and _local.context_stack:
+        if hasattr(_local, "context_stack") and _local.context_stack:
             return _local.context_stack[-1]
 
         # Return global context

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -69,7 +69,7 @@ class Session:
         self.catalog = catalog or get_catalog(
             client_config=client_config, in_memory=in_memory
         )
-        self.versions: list[tuple[DatasetRecord, int]] = []
+        self.dataset_versions: list[tuple[DatasetRecord, int]] = []
 
     def __enter__(self):
         # Push the current context onto the stack
@@ -90,8 +90,8 @@ class Session:
         if Session.SESSION_CONTEXTS:
             Session.SESSION_CONTEXTS.pop()
 
-    def add_created_versions(self, dataset: "DatasetRecord", version: int) -> None:
-        self.versions.append((dataset, version))
+    def add_dataset_version(self, dataset: "DatasetRecord", version: int) -> None:
+        self.dataset_versions.append((dataset, version))
 
     def generate_temp_dataset_name(self) -> str:
         return self.get_temp_prefix() + uuid4().hex[: self.TEMP_TABLE_UUID_LEN]
@@ -109,13 +109,13 @@ class Session:
             pass
 
     def _cleanup_created_versions(self) -> None:
-        if not self.versions:
+        if not self.dataset_versions:
             return
 
-        for dataset, version in self.versions:
+        for dataset, version in self.dataset_versions:
             self.catalog.remove_dataset_version(dataset, version)
 
-        self.versions.clear()
+        self.dataset_versions.clear()
 
     @classmethod
     def get(

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -114,6 +114,8 @@ class Session:
         for dataset, version in self.versions:
             self.catalog.remove_dataset_version(dataset, version)
 
+        self.versions.clear()
+
     @classmethod
     def get(
         cls,
@@ -172,9 +174,3 @@ class Session:
     def _global_cleanup():
         if Session.GLOBAL_SESSION_CTX is not None:
             Session.GLOBAL_SESSION_CTX.__exit__(None, None, None)
-
-    def __del__(self):
-        if hasattr(
-            self, "name"
-        ):  # If the session object is not initialized, it won't have name attribute
-            self.__exit__(None, None, None)

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -4,8 +4,8 @@ from datachain.lib.dc import DataChain
 
 logging.basicConfig(level=logging.INFO)
 
-
 ds_name = "feature_class_error"
 ds = DataChain.from_values(key=["a", "b", "c"])
 ds.save(ds_name)
+
 raise Exception("This is a test exception")

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -31,6 +31,4 @@ except ValueError:
 # We return to global context. So, this will also be reverted.
 DataChain.from_values(key=["a", "b", "c"]).save("global_error_class_v2")
 
-session._cleanup_temp_datasets()
-
 raise Exception("This is a test exception")

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -31,4 +31,6 @@ except ValueError:
 # We return to global context. So, this will also be reverted.
 DataChain.from_values(key=["a", "b", "c"]).save("global_error_class_v2")
 
+session._cleanup_temp_datasets()
+
 raise Exception("This is a test exception")

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -1,11 +1,26 @@
 import logging
 
+from datachain import Session
 from datachain.lib.dc import DataChain
 
 logging.basicConfig(level=logging.INFO)
 
-ds_name = "feature_class_error"
-ds = DataChain.from_values(key=["a", "b", "c"])
-ds.save(ds_name)
+# A datachain created in global context. This will be reverted back due to the global exception.
+DataChain.from_values(key=["a", "b", "c"]).save("global_test_datachain_v1")
+
+with Session("local"):
+    # A datachain created in local context. This will persist since error occur in global context.
+    DataChain.from_values(key=["a", "b", "c"]).save("local_test_datachain")
+
+try:
+    with Session("local_failure"):
+        # A datachain created in local context. This will not persist since error occur in local context.
+        DataChain.from_values(key=["a", "b", "c"]).save("local_test_datachain_v2")
+        raise ValueError("Local failure class")
+except ValueError:
+    pass
+
+# This will persist, however.
+DataChain.from_values(key=["a", "b", "c"]).save("global_error_class_v2")
 
 raise Exception("This is a test exception")

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -5,22 +5,30 @@ from datachain.lib.dc import DataChain
 
 logging.basicConfig(level=logging.INFO)
 
-# A datachain created in global context. This will be reverted back due to the global exception.
+# Dataset with variable session. Will persist.
+session = Session("asVariable")
+dv = DataChain.from_values(key=["a", "b", "c"], session=session)
+dv.save("passed_as_argument")
+
+# A datachain created in global context.
+# This will be reverted back due to the global exception.
 DataChain.from_values(key=["a", "b", "c"]).save("global_test_datachain_v1")
 
 with Session("local"):
-    # A datachain created in local context. This will persist since error occur in global context.
+    # A datachain created in local context.
+    # This will persist since error occur in global context.
     DataChain.from_values(key=["a", "b", "c"]).save("local_test_datachain")
 
 try:
     with Session("local_failure"):
-        # A datachain created in local context. This will not persist since error occur in local context.
+        # A datachain created in local context.
+        # This will not persist since error occur in local context.
         DataChain.from_values(key=["a", "b", "c"]).save("local_test_datachain_v2")
         raise ValueError("Local failure class")
 except ValueError:
     pass
 
-# This will persist, however.
+# We return to global context. So, this will also be reverted.
 DataChain.from_values(key=["a", "b", "c"]).save("global_error_class_v2")
 
 raise Exception("This is a test exception")

--- a/tests/test_atomicity.py
+++ b/tests/test_atomicity.py
@@ -28,7 +28,7 @@ def test_atomicity_feature_file(tmp_dir, catalog_tmpfile):
     else:
         popen_args = {"start_new_session": True}
 
-    existing_dataset = catalog_tmpfile.create_dataset(
+    catalog_tmpfile.create_dataset(
         "existing_dataset",
         query_script="script",
         columns=[sa.Column("similarity", Float32)],
@@ -52,11 +52,13 @@ def test_atomicity_feature_file(tmp_dir, catalog_tmpfile):
 
     assert process.returncode == 1
 
-    # Local context datasets should be created in the catalog, but old should not be removed.
+    # Local context datasets should be created in the catalog,
+    # but old should not be removed.
     dataset_versions = list(catalog_tmpfile.list_datasets_versions())
-    assert len(dataset_versions) == 2
+    assert len(dataset_versions) == 3
 
     assert sorted([d[0].name for d in dataset_versions]) == [
         "existing_dataset",
         "local_test_datachain",
+        "passed_as_argument",
     ]

--- a/tests/test_atomicity.py
+++ b/tests/test_atomicity.py
@@ -52,7 +52,9 @@ def test_atomicity_feature_file(tmp_dir, catalog_tmpfile):
 
     assert process.returncode == 1
 
-    # No datasets should be created in the catalog, but old should not be removed.
+    # Local context datasets should be created in the catalog, but old should not be removed.
     dataset_versions = list(catalog_tmpfile.list_datasets_versions())
-    assert len(dataset_versions) == 1
-    assert dataset_versions[0][0].name == existing_dataset.name
+    assert len(dataset_versions) == 2
+
+    assert sorted([d[0].name for d in dataset_versions]) == ["existing_dataset", "local_test_datachain"]
+

--- a/tests/test_atomicity.py
+++ b/tests/test_atomicity.py
@@ -56,5 +56,7 @@ def test_atomicity_feature_file(tmp_dir, catalog_tmpfile):
     dataset_versions = list(catalog_tmpfile.list_datasets_versions())
     assert len(dataset_versions) == 2
 
-    assert sorted([d[0].name for d in dataset_versions]) == ["existing_dataset", "local_test_datachain"]
-
+    assert sorted([d[0].name for d in dataset_versions]) == [
+        "existing_dataset",
+        "local_test_datachain",
+    ]


### PR DESCRIPTION
Refactoring upon the changes at #494 from the comments, this introduces the way to allow a way to persist dataset even if exception is thrown. With this change, the cleanup is now done at the active context. So, we can use the session context as checkpoints now.  Example implementation is as: 

https://github.com/iterative/datachain/blob/029e677e596c84bb8c2ecb56603d164adde03fe8/tests/scripts/feature_class_exception.py#L1-L34

In this file, `local_test_datachain` should only persist since it is the only dataset where the exception doesn't occur in current context. 

Closes #500 