### PR TITLE
drop DatasetRow outdated class

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -56,7 +56,7 @@ from datachain.query.dataset import (
     DatasetQuery,
     PartitionByType,
 )
-from datachain.query.schema import DEFAULT_DELIMITER, Column, DatasetRow
+from datachain.query.schema import DEFAULT_DELIMITER, Column
 from datachain.sql.functions import path as pathfunc
 from datachain.telemetry import telemetry
 from datachain.utils import batched_it, inside_notebook
@@ -1476,12 +1476,6 @@ class DataChain:
         fr_map = {col.lower(): df[col].tolist() for col in df.columns}
 
         for column in fr_map:
-            if column in DatasetRow.schema:
-                raise DatasetPrepareError(
-                    name,
-                    f"import from pandas error - column '{column}' conflicts with"
-                    " default schema",
-                )
             if not column.isidentifier():
                 raise DatasetPrepareError(
                     name,

--- a/src/datachain/query/__init__.py
+++ b/src/datachain/query/__init__.py
@@ -1,12 +1,11 @@
 from .dataset import DatasetQuery
 from .params import param
-from .schema import C, DatasetRow, LocalFilename, Object, Stream
+from .schema import C, LocalFilename, Object, Stream
 from .session import Session
 
 __all__ = [
     "C",
     "DatasetQuery",
-    "DatasetRow",
     "LocalFilename",
     "Object",
     "Session",

--- a/src/datachain/query/schema.py
+++ b/src/datachain/query/schema.py
@@ -1,16 +1,13 @@
 import functools
-import json
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
 from fnmatch import fnmatch
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import attrs
 import sqlalchemy as sa
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 
 from datachain.lib.file import File
-from datachain.sql.types import JSON, Boolean, DateTime, Int64, SQLType, String
 
 if TYPE_CHECKING:
     from datachain.catalog import Catalog
@@ -226,63 +223,6 @@ def normalize_param(param: UDFParamSpec) -> UDFParameter:
     if isinstance(param, UDFParameter):
         return param
     raise TypeError(f"Invalid UDF parameter: {param}")
-
-
-class DatasetRow:
-    schema: ClassVar[dict[str, type[SQLType]]] = {
-        "source": String,
-        "path": String,
-        "size": Int64,
-        "location": JSON,
-        "is_latest": Boolean,
-        "last_modified": DateTime,
-        "version": String,
-        "etag": String,
-    }
-
-    @staticmethod
-    def create(
-        path: str,
-        source: str = "",
-        size: int = 0,
-        location: Optional[dict[str, Any]] = None,
-        is_latest: bool = True,
-        last_modified: Optional[datetime] = None,
-        version: str = "",
-        etag: str = "",
-    ) -> tuple[
-        str,
-        str,
-        int,
-        Optional[str],
-        int,
-        bool,
-        datetime,
-        str,
-        str,
-        int,
-    ]:
-        if location:
-            location = json.dumps([location])  # type: ignore [assignment]
-
-        last_modified = last_modified or datetime.now(timezone.utc)
-
-        return (  # type: ignore [return-value]
-            source,
-            path,
-            size,
-            location,
-            is_latest,
-            last_modified,
-            version,
-            etag,
-        )
-
-    @staticmethod
-    def extend(**columns):
-        cols = {**DatasetRow.schema}
-        cols.update(columns)
-        return cols
 
 
 C = Column

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -75,20 +75,6 @@ def test_pandas_conversion_in_memory():
     assert dc.equals(df)
 
 
-def test_pandas_file_column_conflict(test_session):
-    file_records = {"path": ["aa.txt", "bb.txt", "ccc.jpg", "dd", "e.txt"]}
-    with pytest.raises(DataChainParamsError):
-        DataChain.from_pandas(
-            pd.DataFrame(DF_DATA | file_records), session=test_session
-        )
-
-    file_records = {"etag": [1, 2, 3, 4, 5]}
-    with pytest.raises(DataChainParamsError):
-        DataChain.from_pandas(
-            pd.DataFrame(DF_DATA | file_records), session=test_session
-        )
-
-
 def test_pandas_uppercase_columns(test_session):
     data = {
         "FirstName": ["Alice", "Bob", "Charlie", "David", "Eva"],


### PR DESCRIPTION
Fixes issue with a customer scripts, e.g. we do this now and it fails w/o it:

```python
tcrops = tcrops.rename(columns={'source': 'crop_source'}) # Named "crop_source" to avoid "Source" column duplication
```

I think we don't need this anymore.

Closes https://github.com/iterative/dvcx/issues/1583.