### PR TITLE
remove ordering by sys.id

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1325,8 +1325,6 @@ class Catalog:
         if offset:
             q = q.offset(offset)
 
-        q = q.order_by("sys__id")
-
         return q.to_db_records()
 
     def signed_url(self, source: str, path: str, client_config=None) -> str:

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -215,10 +215,6 @@ class AbstractWarehouse(ABC, Serializable):
         limit = query._limit
         paginated_query = query.limit(page_size)
 
-        if not paginated_query._order_by_clauses:
-            # default order by is order by `sys__id`
-            paginated_query = paginated_query.order_by(query.selected_columns.sys__id)
-
         results = None
         offset = 0
         num_yielded = 0

--- a/src/datachain/query/batch.py
+++ b/src/datachain/query/batch.py
@@ -97,7 +97,6 @@ class Partition(BatchingStrategy):
 
         ordered_query = query.order_by(None).order_by(
             PARTITION_COLUMN_ID,
-            "sys__id",
             *query._order_by_clauses,
         )
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -775,6 +775,39 @@ def test_dataset_preview_custom_columns(cloud_test_catalog, dogs_dataset):
         assert r["binary_col"] == [0, 25]
 
 
+def test_dataset_preview_order(test_session):
+    ids = list(range(10000))
+    order = ids[::-1]
+    catalog = test_session.catalog
+    dataset_name = "test"
+
+    DataChain.from_values(id=ids, order=order, session=test_session).order_by(
+        "order"
+    ).save(dataset_name)
+
+    preview_values = []
+
+    for r in catalog.get_dataset(dataset_name).get_version(1).preview:
+        id = ids.pop()
+        o = order.pop()
+        entry = (id, o)
+        preview_values.append((id, o))
+        assert (r["id"], r["order"]) == entry
+
+    DataChain.from_dataset(dataset_name, session=test_session).save(dataset_name)
+
+    for r in catalog.get_dataset(dataset_name).get_version(2).preview:
+        assert (r["id"], r["order"]) == preview_values.pop(0)
+
+    DataChain.from_dataset(dataset_name, 2, session=test_session).order_by("id").save(
+        dataset_name
+    )
+
+    for r in catalog.get_dataset(dataset_name).get_version(3).preview:
+        assert r["id"] == ids.pop(0)
+        assert r["order"] == order.pop(0)
+
+
 def test_dataset_preview_last_modified(cloud_test_catalog, dogs_dataset):
     catalog = cloud_test_catalog.catalog
 


### PR DESCRIPTION
Related to https://github.com/iterative/datachain/issues/477 and https://github.com/iterative/studio/issues/10635#issuecomment-2381829809 & https://github.com/iterative/studio/issues/10635#issuecomment-2406225017

All the context for this change is in https://github.com/iterative/datachain/issues/477 but the tl;dr is:

This behaviour is currently undocumented, untested and misunderstood. There is no way to support this behaviour with BigQuery and we have to find another way around datasets appearing ordered. One suggestion is to save the order along with the dataset information in the metastore (perhaps save the appropriate select statement as this would be extendable in the future).