### PR TITLE
Add studio auth to datachain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "psutil",
   "huggingface_hub",
   "iterative-telemetry>=0.0.9",
-  "platformdirs"
+  "platformdirs",
+  "dvc-studio-client>=0.21,<1"
 ]
 
 [project.optional-dependencies]

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -15,6 +15,7 @@ import shtab
 from datachain import Session, utils
 from datachain.cli_utils import BooleanOptionalAction, CommaSeparatedArgs, KeyValueArgs
 from datachain.lib.dc import DataChain
+from datachain.studio import process_studio_cli_args
 from datachain.telemetry import telemetry
 
 if TYPE_CHECKING:
@@ -94,6 +95,94 @@ def add_show_args(parser: ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="Do not collapse the columns",
+    )
+
+
+def add_studio_parser(subparsers, parent_parser) -> None:
+    studio_help = "Commands to authenticate Datachain with Iterative Studio"
+    studio_description = (
+        "Authenticate Datachain with Studio and set the token."
+        " Once this token has been properly configured,\n"
+        " Datachain will utilize it for seamlessly sharing datasets\n"
+        " and using Studio features from CLI"
+    )
+
+    studio_parser = subparsers.add_parser(
+        "studio",
+        parents=[parent_parser],
+        description=studio_description,
+        help=studio_help,
+    )
+    studio_subparser = studio_parser.add_subparsers(
+        dest="cmd",
+        help="Use `Datachain studio CMD --help` to display command-specific help.",
+        required=True,
+    )
+
+    studio_login_help = "Authenticate Datachain with Studio host"
+    studio_login_description = (
+        "By default, this command authenticates the Datachain with Studio\n"
+        " using default scopes and assigns a random name as the token name."
+    )
+    login_parser = studio_subparser.add_parser(
+        "login",
+        parents=[parent_parser],
+        description=studio_login_description,
+        help=studio_login_help,
+    )
+
+    login_parser.add_argument(
+        "-H",
+        "--hostname",
+        action="store",
+        default=None,
+        help="The hostname of the Studio instance to authenticate with.",
+    )
+    login_parser.add_argument(
+        "-s",
+        "--scopes",
+        action="store",
+        default=None,
+        help="The scopes for the authentication token. ",
+    )
+
+    login_parser.add_argument(
+        "-n",
+        "--name",
+        action="store",
+        default=None,
+        help="The name of the authentication token. It will be used to\n"
+        "identify token shown in Studio profile.",
+    )
+
+    login_parser.add_argument(
+        "--no-open",
+        action="store_true",
+        default=False,
+        help="Use authentication flow based on user code.\n"
+        "You will be presented with user code to enter in browser.\n"
+        "Datachain will also use this if it cannot launch browser on your behalf.",
+    )
+
+    studio_logout_help = "Logout user from Studio"
+    studio_logout_description = (
+        "This removes the studio token from your global config.\n"
+    )
+
+    studio_subparser.add_parser(
+        "logout",
+        parents=[parent_parser],
+        description=studio_logout_description,
+        help=studio_logout_help,
+    )
+
+    studio_token_help = "View the token datachain uses to contact Studio"  # noqa: S105 # nosec B105
+
+    studio_subparser.add_parser(
+        "token",
+        parents=[parent_parser],
+        description=studio_token_help,
+        help=studio_token_help,
     )
 
 
@@ -224,6 +313,8 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--edatachain-file",
         help="Use a different filename for the resulting .edatachain file",
     )
+
+    add_studio_parser(subp, parent_parser)
 
     parse_pull = subp.add_parser(
         "pull",
@@ -1000,6 +1091,8 @@ def main(argv: Optional[list[str]] = None) -> int:  # noqa: C901, PLR0912, PLR09
             clear_cache(catalog)
         elif args.command == "gc":
             garbage_collect(catalog)
+        elif args.command == "studio":
+            process_studio_cli_args(args)
         else:
             print(f"invalid command: {args.command}", file=sys.stderr)
             return 1

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -101,10 +101,10 @@ def add_show_args(parser: ArgumentParser) -> None:
 def add_studio_parser(subparsers, parent_parser) -> None:
     studio_help = "Commands to authenticate Datachain with Iterative Studio"
     studio_description = (
-        "Authenticate Datachain with Studio and set the token."
-        " Once this token has been properly configured,\n"
-        " Datachain will utilize it for seamlessly sharing datasets\n"
-        " and using Studio features from CLI"
+        "Authenticate Datachain with Studio and set the token. "
+        "Once this token has been properly configured,\n"
+        "Datachain will utilize it for seamlessly sharing datasets\n"
+        "and using Studio features from CLI"
     )
 
     studio_parser = subparsers.add_parser(
@@ -122,7 +122,7 @@ def add_studio_parser(subparsers, parent_parser) -> None:
     studio_login_help = "Authenticate Datachain with Studio host"
     studio_login_description = (
         "By default, this command authenticates the Datachain with Studio\n"
-        " using default scopes and assigns a random name as the token name."
+        "using default scopes and assigns a random name as the token name."
     )
     login_parser = studio_subparser.add_parser(
         "login",
@@ -165,9 +165,7 @@ def add_studio_parser(subparsers, parent_parser) -> None:
     )
 
     studio_logout_help = "Logout user from Studio"
-    studio_logout_description = (
-        "This removes the studio token from your global config.\n"
-    )
+    studio_logout_description = "This removes the studio token from your global config."
 
     studio_subparser.add_parser(
         "logout",

--- a/src/datachain/config.py
+++ b/src/datachain/config.py
@@ -22,6 +22,8 @@ class Config:
     ):
         self.level = level
 
+        self.init()
+
     @classmethod
     def get_dir(cls, level: Optional[str]) -> str:
         if level == "system":
@@ -31,13 +33,12 @@ class Config:
 
         return DataChainDir.find().root
 
-    @staticmethod
-    def init(datachain_dir: Optional[str] = None):
-        d = DataChainDir(datachain_dir)
+    def init(self):
+        d = DataChainDir(self.get_dir(self.level))
         d.init()
 
         with open(d.config, "w"):
-            return Config(d.root)
+            return self
 
     def load_one(self, level: Optional[str] = None) -> TOMLDocument:
         config_path = DataChainDir(self.get_dir(level)).config
@@ -60,7 +61,7 @@ class Config:
 
         return merged_conf
 
-    def read(self) -> Optional[TOMLDocument]:
+    def read(self) -> TOMLDocument:
         if self.level is None:
             return self.load_config_to_level()
         return self.load_one(self.level)
@@ -72,10 +73,11 @@ class Config:
 
         self.write(config)
 
-    def write(self, config: TOMLDocument):
-        config_file = DataChainDir(self.get_dir(self.level)).config
+    def config_file(self):
+        return DataChainDir(self.get_dir(self.level)).config
 
-        with open(config_file, "w") as f:
+    def write(self, config: TOMLDocument):
+        with open(self.config_file(), "w") as f:
             dump(config, f)
 
     def get_remote_config(self, remote: str = "") -> Mapping[str, str]:

--- a/src/datachain/config.py
+++ b/src/datachain/config.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from contextlib import contextmanager
-from typing import Optional
+from typing import Optional, Union
 
 from tomlkit import TOMLDocument, dump, load
 
@@ -36,9 +36,6 @@ class Config:
     def init(self):
         d = DataChainDir(self.get_dir(self.level))
         d.init()
-
-        with open(d.config, "w"):
-            return self
 
     def load_one(self, level: Optional[str] = None) -> TOMLDocument:
         config_path = DataChainDir(self.get_dir(level)).config
@@ -125,10 +122,10 @@ class Config:
         return remote_conf
 
 
-def merge(into, update):
+def merge(into: Union[TOMLDocument, dict], update: Union[TOMLDocument, dict]):
     """Merges second dict into first recursively"""
     for key, val in update.items():
         if isinstance(into.get(key), dict) and isinstance(val, dict):
-            merge(into[key], val)
+            merge(into[key], val)  # type: ignore[arg-type]
         else:
             into[key] = val

--- a/src/datachain/config.py
+++ b/src/datachain/config.py
@@ -39,14 +39,14 @@ class Config:
         with open(d.config, "w"):
             return Config(d.root)
 
-    def load_one(self, level: Optional[str] = None) -> Optional[TOMLDocument]:
+    def load_one(self, level: Optional[str] = None) -> TOMLDocument:
         config_path = DataChainDir(self.get_dir(level)).config
 
         try:
             with open(config_path, encoding="utf-8") as f:
                 return load(f)
         except FileNotFoundError:
-            return None
+            return TOMLDocument()
 
     def load_config_to_level(self) -> TOMLDocument:
         merged_conf = TOMLDocument()
@@ -81,7 +81,7 @@ class Config:
     def get_remote_config(self, remote: str = "") -> Mapping[str, str]:
         config = self.read()
 
-        if config is None:
+        if not config:
             return {"type": "local"}
         if not remote:
             try:

--- a/src/datachain/config.py
+++ b/src/datachain/config.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 from contextlib import contextmanager
+from enum import Enum
 from typing import Optional, Union
 
 from tomlkit import TOMLDocument, dump, load
@@ -7,37 +8,42 @@ from tomlkit import TOMLDocument, dump, load
 from datachain.utils import DataChainDir, global_config_dir, system_config_dir
 
 
+# Define an enum with value system, global and local
+class ConfigLevel(Enum):
+    SYSTEM = "system"
+    GLOBAL = "global"
+    LOCAL = "local"
+
+
 class Config:
-    SYSTEM_LEVELS = ("system", "global")
-    LOCAL_LEVELS = ("local",)
+    SYSTEM_LEVELS = (ConfigLevel.SYSTEM, ConfigLevel.GLOBAL)
+    LOCAL_LEVELS = (ConfigLevel.LOCAL,)
 
     # In the order of precedence
     LEVELS = SYSTEM_LEVELS + LOCAL_LEVELS
 
-    CONFIG = "config"
-
     def __init__(
         self,
-        level: Optional[str] = None,
+        level: Optional[ConfigLevel] = None,
     ):
         self.level = level
 
         self.init()
 
     @classmethod
-    def get_dir(cls, level: Optional[str]) -> str:
-        if level == "system":
+    def get_dir(cls, level: Optional[ConfigLevel]) -> str:
+        if level == ConfigLevel.SYSTEM:
             return system_config_dir()
-        if level == "global":
+        if level == ConfigLevel.GLOBAL:
             return global_config_dir()
 
-        return DataChainDir.find().root
+        return str(DataChainDir.find().root)
 
     def init(self):
         d = DataChainDir(self.get_dir(self.level))
         d.init()
 
-    def load_one(self, level: Optional[str] = None) -> TOMLDocument:
+    def load_one(self, level: Optional[ConfigLevel] = None) -> TOMLDocument:
         config_path = DataChainDir(self.get_dir(level)).config
 
         try:

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -31,7 +31,7 @@ def login(args: "Namespace"):
     name = args.name
     hostname = (
         args.hostname
-        or os.environ.get("DATACHAIN_STUDIO_HOSTNAME")
+        or os.environ.get("DVC_STUDIO_HOSTNAME")
         or config.get("url")
         or STUDIO_URL
     )

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -1,0 +1,97 @@
+import os
+from typing import TYPE_CHECKING
+
+from datachain.config import Config
+from datachain.error import DataChainError
+from datachain.utils import STUDIO_URL
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+POST_LOGIN_MESSAGE = (
+    "Once you've logged in, return here "
+    "and you'll be ready to start using Datachain with Studio."
+)
+
+
+def process_studio_cli_args(args: "Namespace"):
+    if args.cmd == "login":
+        return login(args)
+    if args.cmd == "logout":
+        return logout()
+    if args.cmd == "token":
+        return token()
+    raise DataChainError(f"Unknown command '{args.cmd}'.")
+
+
+def login(args: "Namespace"):
+    from dvc_studio_client.auth import StudioAuthError, get_access_token
+
+    config = Config().read().get("studio", {})
+    name = args.name
+    hostname = (
+        args.hostname
+        or os.environ.get("DATACHAIN_STUDIO_HOSTNAME")
+        or config.get("url")
+        or STUDIO_URL
+    )
+    scopes = args.scopes
+
+    if config.get("url", hostname) == hostname and "token" in config:
+        raise DataChainError(
+            "Token already exists. "
+            "To login with a different token, "
+            "logout using `datachain studio logout`."
+        )
+
+    open_browser = not args.no_open
+    try:
+        _, access_token = get_access_token(
+            token_name=name,
+            hostname=hostname,
+            scopes=scopes,
+            open_browser=open_browser,
+            client_name="Datachain",
+            post_login_message=POST_LOGIN_MESSAGE,
+        )
+    except StudioAuthError as exc:
+        raise DataChainError(f"Failed to authenticate with Studio: {exc}") from exc
+
+    config_path = save_config(hostname, access_token)
+    print(f"Authentication complete. Saved token to {config_path}.")
+    return 0
+
+
+def logout():
+    with Config("global").edit() as conf:
+        token = conf.get("studio", {}).get("token")
+        if not token:
+            raise DataChainError(
+                "Not logged in to Studio. Log in with 'datachain studio login'."
+            )
+
+        del conf["studio"]["token"]
+
+    print("Logged out from Studio. (you can log back in with 'datachain studio login')")
+
+
+def token():
+    config = Config().read().get("studio", {})
+    token = config.get("token")
+    if not token:
+        raise DataChainError(
+            "Not logged in to Studio. Log in with 'datachain studio login'."
+        )
+
+    print(token)
+
+
+def save_config(hostname, token):
+    config = Config("global")
+    with config.edit() as conf:
+        studio_conf = conf.get("studio", {})
+        studio_conf["url"] = hostname
+        studio_conf["token"] = token
+        conf["studio"] = studio_conf
+
+    return config.config_file()

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -1,7 +1,7 @@
 import os
 from typing import TYPE_CHECKING
 
-from datachain.config import Config
+from datachain.config import Config, ConfigLevel
 from datachain.error import DataChainError
 from datachain.utils import STUDIO_URL
 
@@ -63,7 +63,7 @@ def login(args: "Namespace"):
 
 
 def logout():
-    with Config("global").edit() as conf:
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
         token = conf.get("studio", {}).get("token")
         if not token:
             raise DataChainError(
@@ -87,7 +87,7 @@ def token():
 
 
 def save_config(hostname, token):
-    config = Config("global")
+    config = Config(ConfigLevel.GLOBAL)
     with config.edit() as conf:
         studio_conf = conf.get("studio", {})
         studio_conf["url"] = hostname

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -107,15 +107,15 @@ class DataChainDir:
 
 
 def system_config_dir():
-    return os.getenv(
-        DataChainDir.ENV_DATACHAIN_SYSTEM_CONFIG_DIR
-    ) or platformdirs.site_config_dir(APPNAME, APPAUTHOR)
+    return os.getenv(ENV_DATACHAIN_SYSTEM_CONFIG_DIR) or platformdirs.site_config_dir(
+        APPNAME, APPAUTHOR
+    )
 
 
 def global_config_dir():
-    return os.getenv(
-        DataChainDir.ENV_DATACHAIN_GLOBAL_CONFIG_DIR
-    ) or platformdirs.user_config_dir(APPNAME, APPAUTHOR)
+    return os.getenv(ENV_DATACHAIN_GLOBAL_CONFIG_DIR) or platformdirs.user_config_dir(
+        APPNAME, APPAUTHOR
+    )
 
 
 def human_time_to_int(time: str) -> Optional[int]:

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -42,7 +42,6 @@ class DataChainDir:
     TMP = "tmp"
     DB = "db"
     CONFIG = "config"
-    CONFIG = "config"
     ENV_VAR = "DATACHAIN_DIR"
     ENV_VAR_DATACHAIN_ROOT = "DATACHAIN_ROOT_DIR"
 
@@ -52,7 +51,6 @@ class DataChainDir:
         cache: Optional[str] = None,
         tmp: Optional[str] = None,
         db: Optional[str] = None,
-        config: Optional[str] = None,
         config: Optional[str] = None,
     ) -> None:
         self.root = osp.abspath(root) if root is not None else self.default_root()

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -42,6 +42,7 @@ class DataChainDir:
     TMP = "tmp"
     DB = "db"
     CONFIG = "config"
+    CONFIG = "config"
     ENV_VAR = "DATACHAIN_DIR"
     ENV_VAR_DATACHAIN_ROOT = "DATACHAIN_ROOT_DIR"
 
@@ -51,6 +52,7 @@ class DataChainDir:
         cache: Optional[str] = None,
         tmp: Optional[str] = None,
         db: Optional[str] = None,
+        config: Optional[str] = None,
         config: Optional[str] = None,
     ) -> None:
         self.root = osp.abspath(root) if root is not None else self.default_root()
@@ -66,12 +68,18 @@ class DataChainDir:
             if config is not None
             else osp.join(self.root, self.CONFIG)
         )
+        self.config = (
+            osp.abspath(config)
+            if config is not None
+            else osp.join(self.root, self.CONFIG)
+        )
 
     def init(self):
         os.makedirs(self.root, exist_ok=True)
         os.makedirs(self.cache, exist_ok=True)
         os.makedirs(self.tmp, exist_ok=True)
         os.makedirs(osp.split(self.db)[0], exist_ok=True)
+        os.makedirs(osp.split(self.config)[0], exist_ok=True)
         os.makedirs(osp.split(self.config)[0], exist_ok=True)
 
     @classmethod
@@ -99,15 +107,15 @@ class DataChainDir:
 
 
 def system_config_dir():
-    return os.getenv(ENV_DATACHAIN_SYSTEM_CONFIG_DIR) or platformdirs.site_config_dir(
-        APPNAME, APPAUTHOR
-    )
+    return os.getenv(
+        DataChainDir.ENV_DATACHAIN_SYSTEM_CONFIG_DIR
+    ) or platformdirs.site_config_dir(APPNAME, APPAUTHOR)
 
 
 def global_config_dir():
-    return os.getenv(ENV_DATACHAIN_GLOBAL_CONFIG_DIR) or platformdirs.user_config_dir(
-        APPNAME, APPAUTHOR
-    )
+    return os.getenv(
+        DataChainDir.ENV_DATACHAIN_GLOBAL_CONFIG_DIR
+    ) or platformdirs.user_config_dir(APPNAME, APPAUTHOR)
 
 
 def human_time_to_int(time: str) -> Optional[int]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,11 @@ from datachain.data_storage.sqlite import (
 from datachain.dataset import DatasetRecord
 from datachain.lib.dc import DataChain
 from datachain.query.session import Session
-from datachain.utils import DataChainDir
+from datachain.utils import (
+    ENV_DATACHAIN_GLOBAL_CONFIG_DIR,
+    ENV_DATACHAIN_SYSTEM_CONFIG_DIR,
+    DataChainDir,
+)
 
 from .utils import DEFAULT_TREE, instantiate_tree
 
@@ -37,6 +41,20 @@ collect_ignore = ["setup.py"]
 @pytest.fixture(scope="session", autouse=True)
 def add_test_env():
     os.environ["DATACHAIN_TEST"] = "true"
+
+
+@pytest.fixture(autouse=True)
+def global_config_dir(monkeypatch, tmp_path_factory):
+    global_dir = str(tmp_path_factory.mktemp("studio-login-global"))
+    monkeypatch.setenv(ENV_DATACHAIN_GLOBAL_CONFIG_DIR, global_dir)
+    yield global_dir
+
+
+@pytest.fixture(autouse=True)
+def system_config_dir(monkeypatch, tmp_path_factory):
+    system_dir = str(tmp_path_factory.mktemp("studio-login-system"))
+    monkeypatch.setenv(ENV_DATACHAIN_SYSTEM_CONFIG_DIR, system_dir)
+    yield system_dir
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1,0 +1,92 @@
+import pytest
+from dvc_studio_client.auth import AuthorizationExpiredError
+
+from datachain.cli import main
+from datachain.config import Config
+from datachain.studio import POST_LOGIN_MESSAGE
+from datachain.utils import ENV_DATACHAIN_GLOBAL_CONFIG_DIR, STUDIO_URL
+
+
+@pytest.fixture(autouse=True)
+def global_config_dir(monkeypatch, tmp_path_factory):
+    monkeypatch.setenv(
+        ENV_DATACHAIN_GLOBAL_CONFIG_DIR, str(tmp_path_factory.mktemp("studio-login"))
+    )
+
+
+def test_studio_login_token_check_failed(mocker):
+    mocker.patch(
+        "dvc_studio_client.auth.get_access_token",
+        side_effect=AuthorizationExpiredError,
+    )
+    assert main(["studio", "login"]) == 1
+
+
+def test_studio_login_success(mocker):
+    mocker.patch(
+        "dvc_studio_client.auth.get_access_token",
+        return_value=("token_name", "isat_access_token"),
+    )
+
+    assert main(["studio", "login"]) == 0
+
+    config = Config().read()
+    assert config["studio"]["token"] == "isat_access_token"  # noqa: S105 # nosec B105
+    assert config["studio"]["url"] == STUDIO_URL
+
+
+def test_studio_login_arguments(mocker):
+    mock = mocker.patch(
+        "dvc_studio_client.auth.get_access_token",
+        return_value=("token_name", "isat_access_token"),
+    )
+
+    assert (
+        main(
+            [
+                "studio",
+                "login",
+                "--name",
+                "token_name",
+                "--hostname",
+                "https://example.com",
+                "--scopes",
+                "experiments",
+                "--no-open",
+            ]
+        )
+        == 0
+    )
+
+    mock.assert_called_with(
+        token_name="token_name",  #  noqa: S106
+        hostname="https://example.com",
+        scopes="experiments",
+        client_name="Datachain",
+        open_browser=False,
+        post_login_message=POST_LOGIN_MESSAGE,
+    )
+
+
+def test_studio_logout():
+    with Config("global").edit() as conf:
+        conf["studio"] = {"token": "isat_access_token"}
+
+    assert main(["studio", "logout"]) == 0
+    config = Config("global").read()
+    assert "token" not in config["studio"]
+
+    assert main(["studio", "logout"]) == 1
+
+
+def test_studio_token(capsys):
+    with Config("global").edit() as conf:
+        conf["studio"] = {"token": "isat_access_token"}
+
+    assert main(["studio", "token"]) == 0
+    assert capsys.readouterr().out == "isat_access_token\n"
+
+    with Config("global").edit() as conf:
+        del conf["studio"]["token"]
+
+    assert main(["studio", "token"]) == 1

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1,17 +1,9 @@
-import pytest
 from dvc_studio_client.auth import AuthorizationExpiredError
 
 from datachain.cli import main
-from datachain.config import Config
+from datachain.config import Config, ConfigLevel
 from datachain.studio import POST_LOGIN_MESSAGE
-from datachain.utils import ENV_DATACHAIN_GLOBAL_CONFIG_DIR, STUDIO_URL
-
-
-@pytest.fixture(autouse=True)
-def global_config_dir(monkeypatch, tmp_path_factory):
-    monkeypatch.setenv(
-        ENV_DATACHAIN_GLOBAL_CONFIG_DIR, str(tmp_path_factory.mktemp("studio-login"))
-    )
+from datachain.utils import STUDIO_URL
 
 
 def test_studio_login_token_check_failed(mocker):
@@ -69,24 +61,24 @@ def test_studio_login_arguments(mocker):
 
 
 def test_studio_logout():
-    with Config("global").edit() as conf:
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token"}
 
     assert main(["studio", "logout"]) == 0
-    config = Config("global").read()
+    config = Config(ConfigLevel.GLOBAL).read()
     assert "token" not in config["studio"]
 
     assert main(["studio", "logout"]) == 1
 
 
 def test_studio_token(capsys):
-    with Config("global").edit() as conf:
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token"}
 
     assert main(["studio", "token"]) == 0
     assert capsys.readouterr().out == "isat_access_token\n"
 
-    with Config("global").edit() as conf:
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
         del conf["studio"]["token"]
 
     assert main(["studio", "token"]) == 1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from tomlkit import TOMLDocument, dump
 
@@ -49,14 +51,15 @@ def create_local_config(current_dir):
         "local-conf": "exists",
     }
 
-    with open(DataChainDir(current_dir + "/.datachain").config, "w") as f:
+    with open(DataChainDir(os.path.join(current_dir, ".datachain")).config, "w") as f:
         dump(conf, f)
 
 
 def test_get_dir(global_config_dir, system_config_dir, current_dir):
     assert Config.get_dir(ConfigLevel.GLOBAL) == global_config_dir
     assert Config.get_dir(ConfigLevel.SYSTEM) == system_config_dir
-    assert Config.get_dir(ConfigLevel.LOCAL) == current_dir + "/.datachain"
+
+    assert Config.get_dir(ConfigLevel.LOCAL) == os.path.join(current_dir, ".datachain")
 
 
 def test_read_config(global_config_dir, system_config_dir, current_dir):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,171 @@
+import pytest
+from tomlkit import TOMLDocument, dump
+
+from datachain.config import Config, ConfigLevel
+from datachain.utils import DataChainDir
+
+
+@pytest.fixture(autouse=True)
+def current_dir(monkeypatch, tmp_dir):
+    monkeypatch.chdir(tmp_dir)
+    yield str(tmp_dir)
+
+
+def create_global_config(global_config_dir):
+    conf = TOMLDocument()
+    conf["level"] = "global"
+    conf["global"] = True
+    conf["studio"] = {
+        "url": "https://studio.dvc.ai",
+        "token": "global-token",
+        "global-conf": "exists",
+    }
+
+    with open(DataChainDir(global_config_dir).config, "w") as f:
+        dump(conf, f)
+
+
+def create_system_config(system_config_dir):
+    conf = TOMLDocument()
+    conf["level"] = "system"
+    conf["system"] = True
+    conf["studio"] = {
+        "url": "https://studio.dvc.ai",
+        "token": "system-token",
+        "system-conf": "exists",
+    }
+
+    with open(DataChainDir(system_config_dir).config, "w") as f:
+        dump(conf, f)
+
+
+def create_local_config(current_dir):
+    conf = TOMLDocument()
+    conf["level"] = "local"
+    conf["local"] = True
+    conf["studio"] = {
+        "url": "https://studio.dvc.ai",
+        "token": "local-token",
+        "local-conf": "exists",
+    }
+
+    with open(DataChainDir(current_dir + "/.datachain").config, "w") as f:
+        dump(conf, f)
+
+
+def test_get_dir(global_config_dir, system_config_dir, current_dir):
+    assert Config.get_dir(ConfigLevel.GLOBAL) == global_config_dir
+    assert Config.get_dir(ConfigLevel.SYSTEM) == system_config_dir
+    assert Config.get_dir(ConfigLevel.LOCAL) == current_dir + "/.datachain"
+
+
+def test_read_config(global_config_dir, system_config_dir, current_dir):
+    config = Config()
+
+    # Test for empty config
+    assert config.read() == TOMLDocument()
+
+    # Add system config
+    create_system_config(system_config_dir)
+    assert config.read() == {
+        "level": "system",
+        "system": True,
+        "studio": {
+            "url": "https://studio.dvc.ai",
+            "token": "system-token",
+            "system-conf": "exists",
+        },
+    }
+
+    # Add global config
+    create_global_config(global_config_dir)
+    # Both system and global config are merged.
+
+    assert config.read() == {
+        "level": "global",
+        "global": True,
+        "system": True,
+        "studio": {
+            "url": "https://studio.dvc.ai",
+            "token": "global-token",
+            "global-conf": "exists",
+            "system-conf": "exists",
+        },
+    }
+
+    # Add local config
+    create_local_config(current_dir)
+
+    # All configs are merged
+    assert config.read() == {
+        "level": "local",
+        "global": True,
+        "system": True,
+        "local": True,
+        "studio": {
+            "url": "https://studio.dvc.ai",
+            "token": "local-token",
+            "global-conf": "exists",
+            "system-conf": "exists",
+            "local-conf": "exists",
+        },
+    }
+
+    # Get the config for a single level only
+    assert Config(ConfigLevel.GLOBAL).read() == {
+        "level": "global",
+        "global": True,
+        "studio": {
+            "url": "https://studio.dvc.ai",
+            "token": "global-token",
+            "global-conf": "exists",
+        },
+    }
+
+
+def test_edit_config_local_level(current_dir):
+    # Assert the local config is empty first
+    assert Config().read() == {}
+
+    create_local_config(current_dir)
+
+    # Edit the local config
+    with Config().edit() as config:
+        config["new_key"] = "new_value"
+        config["studio"]["token"] = "new-token"  # noqa: S105 # nosec B105
+
+    # Assert the local config is updated
+    assert Config().read() == {
+        "level": "local",
+        "local": True,
+        "new_key": "new_value",
+        "studio": {
+            "url": "https://studio.dvc.ai",
+            "token": "new-token",
+            "local-conf": "exists",
+        },
+    }
+
+
+def test_edit_config_global_level(global_config_dir):
+    # Assert the global config is empty first
+    assert Config(ConfigLevel.GLOBAL).read() == {}
+
+    create_global_config(global_config_dir)
+
+    # Edit the global config
+    with Config(ConfigLevel.GLOBAL).edit() as config:
+        config["new_key"] = "new_value"
+        config["studio"]["token"] = "new-token"  # noqa: S105 # nosec B105
+
+    # Assert the global config is updated
+    assert Config(ConfigLevel.GLOBAL).read() == {
+        "level": "global",
+        "global": True,
+        "new_key": "new_value",
+        "studio": {
+            "url": "https://studio.dvc.ai",
+            "token": "new-token",
+            "global-conf": "exists",
+        },
+    }


### PR DESCRIPTION
Adds a new auth command to datachain that authorizes the datachain with
studio.

Commands added are:
- `datachain studio login`
- `datachain studio logout`
- `datachain studio token`

## Studio command
```sh
Authenticate Datachain with Studio and set the token. Once this token has been properly configured, Datachain will utilize it for seamlessly sharing
datasets and using Studio features from CLI

positional arguments:
  {login,logout,token}  Use `Datachain studio CMD --help` to display command-specific help.
    login               Authenticate Datachain with Studio host
    logout              Logout user from Studio
    token               View the token datachain uses to contact Studio

options:
  -h, --help            show this help message and exit
  --aws-endpoint-url AWS_ENDPOINT_URL
                        AWS endpoint URL
  --anon                AWS anon (aka awscli's --no-sign-request)
  --ttl TTL             Time-to-live of data source cache. Negative equals forever.
  -u, --update          Update cache
  -v, --verbose         Verbose
  -q, --quiet           Be quiet
  --debug-sql           Show All SQL Queries (very verbose output, for debugging only)
  --pdb                 Drop into the pdb debugger on fatal exception
```

## Login

To login, you can call `datachain studio login` which will open the Studio with a device code prefilled in your browser. Once the user authorizes the code, the token is saved to global config.
```sh
usage: datachain studio login [-h] [-q | -v] [-H HOSTNAME] [-s SCOPES] [-n NAME] [-d]

By default, this command authorize datachain with Studio with
 default scopes and a random  name as token name.

options:
  -h, --help            show this help message and exit
  -q, --quiet           Be quiet.
  -v, --verbose         Be verbose.
  -H HOSTNAME, --hostname HOSTNAME
                        The hostname of the Studio instance to authenticate with.
  -s SCOPES, --scopes SCOPES
                        The scopes for the authentication token.
  -n NAME, --name NAME  The name of the authentication token. It will be used to identify token shown in Studio profile.
  -d, --use-device-code
                        Use authentication flow based on user code. You will be presented with user code to enter in browser. Datachain will also use this if it
                        cannot launch browser on your behalf.
```

### Example usages:

#### Normal flow
On running the command `datachain studio login` , following screen is presented in CLI:
```sh
datachain studio login
A web browser has been opened at
https://studio.iterative.ai/auth/device-login.
Please continue the login in the web browser.
If no web browser is available or if the web browser fails to open,
use device code flow with `datachain studio login --use-device-code`.
```

A webbrowser is opened with the device code in Studio.
<img width="632" alt="image" src="https://github.com/iterative/dvc/assets/16842655/8662d52b-9523-4db4-9742-02808d7e3ec4">
Once user authorizes the token in the screen above, the token is saved to the user's global config.
Additional message as below will be shown in the CLI and will exit.
```sh
Authentication successful. The token will be available as risen-geum in Studio profile.
```

#### Device login flow
In case, you are running this in remote machine or where you are unable to open web browser, the following screen is presented.
```
Please open the following url in your browser.
https://studio.iterative.ai/auth/device-login
And enter the user code below 06D21JBK to authorize.
```
Every other flow is same.

## Logout
```sh
usage: datachain studio logout [-h] [-q | -v]

This command helps to log out user from  Studio.

options:
  -h, --help     show this help message and exit
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
```

## Token
```sh
usage: datachain studio token [-h] [-q | -v]

View the token datachain uses to contact Studio

options:
  -h, --help     show this help message and exit
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
```

Related to https://github.com/iterative/studio/issues/10774

Based on #513 
