### PR TITLE
Adding FSSpec Export for CSV and Parquet

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1895,10 +1895,14 @@ class DataChain:
         """Save chain to parquet file with SignalSchema metadata.
 
         Parameters:
-            path : Path or a file-like binary object to save the file.
+            path : Path or a file-like binary object to save the file. This supports
+                local paths as well as remote paths, such as s3:// or hf:// with fsspec.
             partition_cols : Column names by which to partition the dataset.
             chunk_size : The chunk size of results to read and convert to columnar
                 data, to avoid running out of memory.
+            fs_kwargs : Optional kwargs to pass to the fsspec filesystem, used only for
+                write, for fsspec-type URLs, such as s3:// or hf:// when
+                provided as the destination path.
         """
         import pyarrow as pa
         import pyarrow.parquet as pq
@@ -1988,8 +1992,12 @@ class DataChain:
         """Save chain to a csv (comma-separated values) file.
 
         Parameters:
-            path : Path to save the file.
+            path : Path to save the file. This supports local paths as well as
+                remote paths, such as s3:// or hf:// with fsspec.
             delimiter : Delimiter to use for the resulting file.
+            fs_kwargs : Optional kwargs to pass to the fsspec filesystem, used only for
+                write, for fsspec-type URLs, such as s3:// or hf:// when
+                provided as the destination path.
         """
         import csv
 

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1,6 +1,8 @@
 import copy
 import os
+import os.path
 import re
+import sys
 from collections.abc import Iterator, Sequence
 from functools import wraps
 from typing import (
@@ -1920,6 +1922,8 @@ class DataChain:
                 from urllib.parse import urlparse
 
                 path = urlparse(path).path
+                if sys.platform == "win32":
+                    path = os.path.normpath(path.lstrip("/"))
 
             fsspec_fs = client.create_fs(**fs_kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -559,6 +559,26 @@ def cloud_test_catalog(
 
 
 @pytest.fixture
+def cloud_test_catalog_upload(cloud_test_catalog):
+    """This returns a version of the cloud_test_catalog that is suitable for uploading
+    files, and will perform the necessary cleanup of any uploaded files."""
+    from datachain.client.fsspec import Client
+
+    src = cloud_test_catalog.src_uri
+    client = Client.get_implementation(src)
+    fsspec_fs = client.create_fs(**cloud_test_catalog.client_config)
+    original_paths = set(fsspec_fs.ls(src))
+
+    yield cloud_test_catalog
+
+    # Cleanup any written files
+    new_paths = set(fsspec_fs.ls(src))
+    cleanup_paths = new_paths - original_paths
+    for p in cleanup_paths:
+        fsspec_fs.rm(p, recursive=True)
+
+
+@pytest.fixture
 def cloud_test_catalog_tmpfile(
     cloud_server,
     cloud_server_credentials,

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1386,6 +1386,13 @@ def test_to_from_csv_remote(cloud_test_catalog):
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     assert df1.equals(df)
 
+    # Cleanup any written files
+    from datachain.client.fsspec import Client
+
+    client = Client.get_implementation(path)
+    fsspec_fs = client.create_fs(**ctc.client_config)
+    fsspec_fs.rm(path, recursive=True)
+
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 @pytest.mark.parametrize("kwargs", ({}, {"compression": "gzip"}))
@@ -1401,6 +1408,13 @@ def test_to_from_parquet_remote(cloud_test_catalog, chunk_size, kwargs):
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
 
     assert df1.equals(df)
+
+    # Cleanup any written files
+    from datachain.client.fsspec import Client
+
+    client = Client.get_implementation(path)
+    fsspec_fs = client.create_fs(**ctc.client_config)
+    fsspec_fs.rm(path, recursive=True)
 
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1374,8 +1374,8 @@ def test_group_by_signals(cloud_test_catalog, partition_by, signal_name):
     )
 
 
-def test_to_from_csv_remote(cloud_test_catalog):
-    ctc = cloud_test_catalog
+def test_to_from_csv_remote(cloud_test_catalog_upload):
+    ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/test.csv"
 
     df = pd.DataFrame(DF_DATA)
@@ -1386,18 +1386,11 @@ def test_to_from_csv_remote(cloud_test_catalog):
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     assert df1.equals(df)
 
-    # Cleanup any written files
-    from datachain.client.fsspec import Client
-
-    client = Client.get_implementation(path)
-    fsspec_fs = client.create_fs(**ctc.client_config)
-    fsspec_fs.rm(path, recursive=True)
-
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 @pytest.mark.parametrize("kwargs", ({}, {"compression": "gzip"}))
-def test_to_from_parquet_remote(cloud_test_catalog, chunk_size, kwargs):
-    ctc = cloud_test_catalog
+def test_to_from_parquet_remote(cloud_test_catalog_upload, chunk_size, kwargs):
+    ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/test.parquet"
 
     df = pd.DataFrame(DF_DATA)
@@ -1409,17 +1402,10 @@ def test_to_from_parquet_remote(cloud_test_catalog, chunk_size, kwargs):
 
     assert df1.equals(df)
 
-    # Cleanup any written files
-    from datachain.client.fsspec import Client
-
-    client = Client.get_implementation(path)
-    fsspec_fs = client.create_fs(**ctc.client_config)
-    fsspec_fs.rm(path, recursive=True)
-
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
-def test_to_from_parquet_partitioned_remote(cloud_test_catalog, chunk_size):
-    ctc = cloud_test_catalog
+def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload, chunk_size):
+    ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/parquets"
 
     df = pd.DataFrame(DF_DATA)
@@ -1430,10 +1416,3 @@ def test_to_from_parquet_partitioned_remote(cloud_test_catalog, chunk_size):
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     df1 = df1.sort_values("first_name").reset_index(drop=True)
     assert df1.equals(df)
-
-    # Cleanup any written files
-    from datachain.client.fsspec import Client
-
-    client = Client.get_implementation(path)
-    fsspec_fs = client.create_fs(**ctc.client_config)
-    fsspec_fs.rm(path, recursive=True)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -38,6 +38,12 @@ from tests.utils import (
     text_embedding,
 )
 
+DF_DATA = {
+    "first_name": ["Alice", "Bob", "Charlie", "David", "Eva"],
+    "age": [25, 30, 35, 40, 45],
+    "city": ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix"],
+}
+
 
 def _get_listing_datasets(session):
     return sorted(
@@ -1366,3 +1372,54 @@ def test_group_by_signals(cloud_test_catalog, partition_by, signal_name):
         ],
         "file_info__path",
     )
+
+
+def test_to_from_csv_remote(cloud_test_catalog):
+    ctc = cloud_test_catalog
+    path = f"{ctc.src_uri}/test.csv"
+
+    df = pd.DataFrame(DF_DATA)
+    dc_to = DataChain.from_pandas(df, session=ctc.session)
+    dc_to.to_csv(path)
+
+    dc_from = DataChain.from_csv(path, session=ctc.session)
+    df1 = dc_from.select("first_name", "age", "city").to_pandas()
+    assert df1.equals(df)
+
+
+@pytest.mark.parametrize("chunk_size", (1000, 2))
+@pytest.mark.parametrize("kwargs", ({}, {"compression": "gzip"}))
+def test_to_from_parquet_remote(cloud_test_catalog, chunk_size, kwargs):
+    ctc = cloud_test_catalog
+    path = f"{ctc.src_uri}/test.parquet"
+
+    df = pd.DataFrame(DF_DATA)
+    dc_to = DataChain.from_pandas(df, session=ctc.session)
+    dc_to.to_parquet(path, chunk_size=chunk_size, **kwargs)
+
+    dc_from = DataChain.from_parquet(path, session=ctc.session)
+    df1 = dc_from.select("first_name", "age", "city").to_pandas()
+
+    assert df1.equals(df)
+
+
+@pytest.mark.parametrize("chunk_size", (1000, 2))
+def test_to_from_parquet_partitioned_remote(cloud_test_catalog, chunk_size):
+    ctc = cloud_test_catalog
+    path = f"{ctc.src_uri}/parquets"
+
+    df = pd.DataFrame(DF_DATA)
+    dc_to = DataChain.from_pandas(df, session=ctc.session)
+    dc_to.to_parquet(path, partition_cols=["first_name"], chunk_size=chunk_size)
+
+    dc_from = DataChain.from_parquet(path, session=ctc.session)
+    df1 = dc_from.select("first_name", "age", "city").to_pandas()
+    df1 = df1.sort_values("first_name").reset_index(drop=True)
+    assert df1.equals(df)
+
+    # Cleanup any written files
+    from datachain.client.fsspec import Client
+
+    client = Client.get_implementation(path)
+    fsspec_fs = client.create_fs(**ctc.client_config)
+    fsspec_fs.rm(path, recursive=True)


### PR DESCRIPTION
This adds the ability to export / upload to FSSpec filesystems in `to_csv` and `to_parquet` - such as exporting directly to S3 or Hugging Face. This is done by passing the relevant url path to the export functions, such as:
`chain.to_parquet("s3://dtulga-datachain-test/test.parquet")`
`chain.to_csv("hf://datasets/dtulga/datachain-test/test.csv")`

This has been tested manually with S3 and Hugging Face, as seen here: https://huggingface.co/datasets/dtulga/datachain-test/tree/main This is part of #236 and #370