### PR TITLE
Implement ls-datasets for studio client

### DIFF
--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -213,7 +213,7 @@ def add_studio_parser(subparsers, parent_parser) -> None:
     )
 
     ls_dataset_parser = studio_subparser.add_parser(
-        "ls-datasets",
+        "datasets",
         parents=[parent_parser],
         description=studio_ls_dataset_description,
         help=studio_ls_dataset_help,

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -206,6 +206,25 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         help=studio_token_help,
     )
 
+    studio_ls_dataset_help = "List the available datasets from Studio"
+    studio_ls_dataset_description = (
+        "This command lists all the datasets available in Studio.\n"
+        "It will show the dataset name and the number of versions available."
+    )
+
+    ls_dataset_parser = studio_subparser.add_parser(
+        "ls-datasets",
+        parents=[parent_parser],
+        description=studio_ls_dataset_description,
+        help=studio_ls_dataset_help,
+    )
+    ls_dataset_parser.add_argument(
+        "--team",
+        action="store",
+        default=None,
+        help="The team to list datasets for. By default, it will use team from config.",
+    )
+
 
 def get_parser() -> ArgumentParser:  # noqa: PLR0915
     try:
@@ -749,16 +768,13 @@ def format_ls_entry(entry: str) -> str:
 
 
 def ls_remote(
-    url: str,
-    username: str,
-    token: str,
     paths: Iterable[str],
     long: bool = False,
 ):
     from datachain.node import long_line_str
     from datachain.remote.studio import StudioClient
 
-    client = StudioClient(url, username, token)
+    client = StudioClient()
     first = True
     for path, response in client.ls(paths):
         if not first:
@@ -798,9 +814,6 @@ def ls(
         ls_local(sources, long=long, **kwargs)
     else:
         ls_remote(
-            config["url"],
-            config["username"],
-            config["token"],
             sources,
             long=long,
         )

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -112,8 +112,10 @@ def list_datasets(args: "Namespace"):
         print("No datasets found.")
         return
     for d in response.data:
+        name = d.get("name")
         for v in d.get("versions", []):
-            print(f"{d.get("name")} (v{v.get("version")})")
+            version = v.get("version")
+            print(f"{name} (v{version})")
 
 
 def save_config(hostname, token):

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -23,7 +23,7 @@ def process_studio_cli_args(args: "Namespace"):
         return logout()
     if args.cmd == "token":
         return token()
-    if args.cmd == "ls-datasets":
+    if args.cmd == "datasets":
         return list_datasets(args)
     if args.cmd == "team":
         return set_team(args)

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -9,8 +9,15 @@ import pytest
 from sqlalchemy import select
 
 from datachain.cli import ls
+from datachain.config import Config, ConfigLevel
 from datachain.lib.dc import DataChain
 from tests.utils import uppercase_scheme
+
+
+@pytest.fixture(autouse=True)
+def studio_config():
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
+        conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
 
 
 def same_lines(lines1, lines2):

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -103,7 +103,7 @@ def test_studio_ls_datasets(capsys, requests_mock):
 
     requests_mock.post(f"{STUDIO_URL}/api/datachain/ls-datasets", json=datasets)
 
-    assert main(["studio", "ls-datasets"]) == 0
+    assert main(["studio", "datasets"]) == 0
     out = capsys.readouterr().out
     assert out.strip() == "dogs (v1)\ndogs (v2)\ncats (v1)"
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -84,6 +84,30 @@ def test_studio_token(capsys):
     assert main(["studio", "token"]) == 1
 
 
+def test_studio_ls_datasets(capsys, requests_mock):
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
+        conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
+
+    datasets = [
+        {
+            "id": 1,
+            "name": "dogs",
+            "versions": [{"version": 1}, {"version": 2}],
+        },
+        {
+            "id": 2,
+            "name": "cats",
+            "versions": [{"version": 1}],
+        },
+    ]
+
+    requests_mock.post(f"{STUDIO_URL}/api/datachain/ls-datasets", json=datasets)
+
+    assert main(["studio", "ls-datasets"]) == 0
+    out = capsys.readouterr().out
+    assert out.strip() == "dogs (v1)\ndogs (v2)\ncats (v1)"
+
+
 def test_studio_team_local():
     assert main(["studio", "team", "team_name"]) == 0
     config = Config(ConfigLevel.LOCAL).read()


### PR DESCRIPTION
This fixes the existing studio client to use the configuration from studio login and provides a way to list the datasets available in Studio.

```sh
$ datachain studio datasets
passed_as_argument (v1)
local_test_datachain (v1)
dql-small (v1)

```

```sh
$ datachain studio datasets --team team_name
passed_as_argument (v1)
local_test_datachain (v1)
dql-small (v1)

```

Relates to https://github.com/iterative/studio/issues/10774