### PR TITLE
Add option to set team in config for studio

### DIFF
--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -174,6 +174,30 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         help=studio_logout_help,
     )
 
+    studio_team_help = "Set the default team for Datachain"
+    studio_team_description = (
+        "Set the default team for Datachain to use when interacting with Studio."
+    )
+
+    team_parser = studio_subparser.add_parser(
+        "team",
+        parents=[parent_parser],
+        description=studio_team_description,
+        help=studio_team_help,
+    )
+    # Add a positional argument for the team name
+    team_parser.add_argument(
+        "team_name",
+        action="store",
+        help="The name of the team to set as the default.",
+    )
+    team_parser.add_argument(
+        "--global",
+        action="store_true",
+        default=False,
+        help="Set the team globally for all Datachain projects.",
+    )
+
     studio_token_help = "View the token datachain uses to contact Studio"  # noqa: S105 # nosec B105
 
     studio_subparser.add_parser(

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -99,11 +99,11 @@ def add_show_args(parser: ArgumentParser) -> None:
 
 
 def add_studio_parser(subparsers, parent_parser) -> None:
-    studio_help = "Commands to authenticate Datachain with Iterative Studio"
+    studio_help = "Commands to authenticate DataChain with Iterative Studio"
     studio_description = (
-        "Authenticate Datachain with Studio and set the token. "
+        "Authenticate DataChain with Studio and set the token. "
         "Once this token has been properly configured,\n"
-        "Datachain will utilize it for seamlessly sharing datasets\n"
+        "DataChain will utilize it for seamlessly sharing datasets\n"
         "and using Studio features from CLI"
     )
 
@@ -115,13 +115,13 @@ def add_studio_parser(subparsers, parent_parser) -> None:
     )
     studio_subparser = studio_parser.add_subparsers(
         dest="cmd",
-        help="Use `Datachain studio CMD --help` to display command-specific help.",
+        help="Use `DataChain studio CMD --help` to display command-specific help.",
         required=True,
     )
 
-    studio_login_help = "Authenticate Datachain with Studio host"
+    studio_login_help = "Authenticate DataChain with Studio host"
     studio_login_description = (
-        "By default, this command authenticates the Datachain with Studio\n"
+        "By default, this command authenticates the DataChain with Studio\n"
         "using default scopes and assigns a random name as the token name."
     )
     login_parser = studio_subparser.add_parser(
@@ -161,7 +161,7 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         default=False,
         help="Use authentication flow based on user code.\n"
         "You will be presented with user code to enter in browser.\n"
-        "Datachain will also use this if it cannot launch browser on your behalf.",
+        "DataChain will also use this if it cannot launch browser on your behalf.",
     )
 
     studio_logout_help = "Logout user from Studio"
@@ -174,9 +174,9 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         help=studio_logout_help,
     )
 
-    studio_team_help = "Set the default team for Datachain"
+    studio_team_help = "Set the default team for DataChain"
     studio_team_description = (
-        "Set the default team for Datachain to use when interacting with Studio."
+        "Set the default team for DataChain to use when interacting with Studio."
     )
 
     team_parser = studio_subparser.add_parser(
@@ -185,7 +185,6 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         description=studio_team_description,
         help=studio_team_help,
     )
-    # Add a positional argument for the team name
     team_parser.add_argument(
         "team_name",
         action="store",
@@ -195,7 +194,7 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         "--global",
         action="store_true",
         default=False,
-        help="Set the team globally for all Datachain projects.",
+        help="Set the team globally for all DataChain projects.",
     )
 
     studio_token_help = "View the token datachain uses to contact Studio"  # noqa: S105 # nosec B105

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -21,7 +21,20 @@ def process_studio_cli_args(args: "Namespace"):
         return logout()
     if args.cmd == "token":
         return token()
+    if args.cmd == "team":
+        return set_team(args)
     raise DataChainError(f"Unknown command '{args.cmd}'.")
+
+
+def set_team(args: "Namespace"):
+    level = ConfigLevel.GLOBAL if args.__dict__.get("global") else ConfigLevel.LOCAL
+    config = Config(level)
+    with config.edit() as conf:
+        studio_conf = conf.get("studio", {})
+        studio_conf["team"] = args.team_name
+        conf["studio"] = studio_conf
+
+    print(f"Set default team to '{args.team_name}' in {config.config_file()}")
 
 
 def login(args: "Namespace"):

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 POST_LOGIN_MESSAGE = (
     "Once you've logged in, return here "
-    "and you'll be ready to start using Datachain with Studio."
+    "and you'll be ready to start using DataChain with Studio."
 )
 
 
@@ -64,7 +64,7 @@ def login(args: "Namespace"):
             hostname=hostname,
             scopes=scopes,
             open_browser=open_browser,
-            client_name="Datachain",
+            client_name="DataChain",
             post_login_message=POST_LOGIN_MESSAGE,
         )
     except StudioAuthError as exc:

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -54,7 +54,7 @@ def test_studio_login_arguments(mocker):
         token_name="token_name",  #  noqa: S106
         hostname="https://example.com",
         scopes="experiments",
-        client_name="Datachain",
+        client_name="DataChain",
         open_browser=False,
         post_login_message=POST_LOGIN_MESSAGE,
     )

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -82,3 +82,15 @@ def test_studio_token(capsys):
         del conf["studio"]["token"]
 
     assert main(["studio", "token"]) == 1
+
+
+def test_studio_team_local():
+    assert main(["studio", "team", "team_name"]) == 0
+    config = Config(ConfigLevel.LOCAL).read()
+    assert config["studio"]["team"] == "team_name"
+
+
+def test_studio_team_global():
+    assert main(["studio", "team", "team_name", "--global"]) == 0
+    config = Config(ConfigLevel.GLOBAL).read()
+    assert config["studio"]["team"] == "team_name"


### PR DESCRIPTION
As part of https://github.com/iterative/studio/issues/10774,
this adds a command as below:

```sh
datachain studio team team_name
Set default team to 'team_name' in <PATH>/.datachain/config
```

```sh
datachain studio team team_name --global
Set default team to 'team_name' in /Users/amritghimire/Library/Application Support/datachain/config
```
