### PR TITLE
Adding JSON / JSON Lines Export Support

### DIFF
--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -455,3 +455,27 @@ def env2bool(var, undefined=False):
     if var is None:
         return undefined
     return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
+
+
+def nested_dict_path_set(
+    data: dict[str, Any], path: Sequence[str], value: Any
+) -> dict[str, Any]:
+    """Sets a value inside a nested dict based on the list of dict keys as a path,
+    and will create sub-dicts as needed to set the value."""
+    sub_data = data
+    for element in path[:-1]:
+        if element not in sub_data:
+            sub_data[element] = {}
+        sub_data = sub_data[element]
+    sub_data[path[len(path) - 1]] = value
+    return data
+
+
+def row_to_nested_dict(
+    headers: Iterable[Sequence[str]], row: Iterable[Any]
+) -> dict[str, Any]:
+    """Converts a row to a nested dict based on the provided headers."""
+    result: dict[str, Any] = {}
+    for h, v in zip(headers, row):
+        nested_dict_path_set(result, h, v)
+    return result

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1505,3 +1505,35 @@ def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload, chunk_siz
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     df1 = df1.sort_values("first_name").reset_index(drop=True)
     assert df1.equals(df)
+
+
+# These deprecation warnings occur in the datamodel-code-generator package.
+@pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
+def test_to_from_json_remote(cloud_test_catalog_upload):
+    ctc = cloud_test_catalog_upload
+    path = f"{ctc.src_uri}/test.json"
+
+    df = pd.DataFrame(DF_DATA)
+    dc_to = DataChain.from_pandas(df, session=ctc.session)
+    dc_to.to_json(path)
+
+    dc_from = DataChain.from_json(path, session=ctc.session)
+    df1 = dc_from.select("json.first_name", "json.age", "json.city").to_pandas()
+    df1 = df1["json"]
+    assert df1.equals(df)
+
+
+# These deprecation warnings occur in the datamodel-code-generator package.
+@pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
+def test_to_from_jsonl_remote(cloud_test_catalog_upload):
+    ctc = cloud_test_catalog_upload
+    path = f"{ctc.src_uri}/test.jsonl"
+
+    df = pd.DataFrame(DF_DATA)
+    dc_to = DataChain.from_pandas(df, session=ctc.session)
+    dc_to.to_jsonl(path)
+
+    dc_from = DataChain.from_jsonl(path, session=ctc.session)
+    df1 = dc_from.select("jsonl.first_name", "jsonl.age", "jsonl.city").to_pandas()
+    df1 = df1["jsonl"]
+    assert df1.equals(df)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1326,7 +1326,8 @@ def test_to_json_features(tmp_dir, test_session):
     with open(path) as f:
         values = json.load(f)
     assert values == [
-        {"f1.nnn": f.nnn, "f1.count": f.count, "num": n} for n, f in enumerate(features)
+        {"f1": {"nnn": f.nnn, "count": f.count}, "num": n}
+        for n, f in enumerate(features)
     ]
 
 
@@ -1337,7 +1338,7 @@ def test_to_json_features_nested(tmp_dir, test_session):
     with open(path) as f:
         values = json.load(f)
     assert values == [
-        {"sign1.label": f"label_{n}", "sign1.fr.nnn": f.nnn, "sign1.fr.count": f.count}
+        {"sign1": {"label": f"label_{n}", "fr": {"nnn": f.nnn, "count": f.count}}}
         for n, f in enumerate(features)
     ]
 
@@ -1396,7 +1397,8 @@ def test_to_jsonl_features(tmp_dir, test_session):
     with open(path) as f:
         values = [json.loads(line) for line in f.read().split("\n")]
     assert values == [
-        {"f1.nnn": f.nnn, "f1.count": f.count, "num": n} for n, f in enumerate(features)
+        {"f1": {"nnn": f.nnn, "count": f.count}, "num": n}
+        for n, f in enumerate(features)
     ]
 
 
@@ -1407,7 +1409,7 @@ def test_to_jsonl_features_nested(tmp_dir, test_session):
     with open(path) as f:
         values = [json.loads(line) for line in f.read().split("\n")]
     assert values == [
-        {"sign1.label": f"label_{n}", "sign1.fr.nnn": f.nnn, "sign1.fr.count": f.count}
+        {"sign1": {"label": f"label_{n}", "fr": {"nnn": f.nnn, "count": f.count}}}
         for n, f in enumerate(features)
     ]
 


### PR DESCRIPTION
This PR adds the functions `to_json` and `to_jsonl` to export to JSON / JSON lines from DataChain. These functions support remote fsspec filesystems / URLs (such as `s3://`), similar to `to_csv` and `to_parquet`, and implement streaming writing as well, to enable writing data larger than memory. This also adds tests for these functions, tests for the existing `from_json` and `from_jsonl` functions, and tests for both of these on remote filesystems (such as S3).

This has been tested locally and fixes #533