### PR TITLE
fix(parsing): normalize nested column names

### DIFF
--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Sequence
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Optional
@@ -13,6 +12,7 @@ from datachain.lib.file import ArrowRow, File
 from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.udf import Generator
+from datachain.lib.utils import normalize_col_names
 
 if TYPE_CHECKING:
     from datasets.features.features import Features
@@ -128,7 +128,7 @@ def schema_to_output(schema: pa.Schema, col_names: Optional[Sequence[str]] = Non
     signal_schema = _get_datachain_schema(schema)
     if signal_schema:
         return signal_schema.values
-    columns = _convert_col_names(col_names)  # type: ignore[arg-type]
+    columns = list(normalize_col_names(col_names).keys())  # type: ignore[arg-type]
     hf_schema = _get_hf_schema(schema)
     if hf_schema:
         return {
@@ -141,19 +141,6 @@ def schema_to_output(schema: pa.Schema, col_names: Optional[Sequence[str]] = Non
             dtype = Optional[dtype]  # type: ignore[assignment]
         output[column] = dtype
     return output
-
-
-def _convert_col_names(col_names: Sequence[str]) -> list[str]:
-    default_column = 0
-    converted_col_names = []
-    for column in col_names:
-        column = column.lower()
-        column = re.sub("[^0-9a-z_]+", "", column)
-        if not column:
-            column = f"c{default_column}"
-            default_column += 1
-        converted_col_names.append(column)
-    return converted_col_names
 
 
 def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa: PLR0911

--- a/src/datachain/lib/utils.py
+++ b/src/datachain/lib/utils.py
@@ -39,8 +39,7 @@ def normalize_col_names(col_names: Sequence[str]) -> dict[str, str]:
 
     for org_column in col_names:
         new_column = org_column.lower()
-        new_column = re.sub("[^0-9a-z_\\s-]+", "_", new_column)
-        new_column = re.sub("[-_\\s]+", "_", new_column)
+        new_column = re.sub("[^0-9a-z]+", "_", new_column)
         new_column = new_column.strip("_")
 
         if (

--- a/src/datachain/lib/utils.py
+++ b/src/datachain/lib/utils.py
@@ -42,24 +42,19 @@ def normalize_col_names(col_names: Sequence[str]) -> dict[str, str]:
         new_column = re.sub("[^0-9a-z]+", "_", new_column)
         new_column = new_column.strip("_")
 
-        if (
-            not new_column
-            or new_column[0].isdigit()
-            or (new_column != org_column and new_column in org_col_names)
-            or new_column in new_col_names
-        ):
-            while True:
-                generated_column = f"c{gen_col_counter}"
-                gen_col_counter += 1
-                if new_column:
-                    generated_column = f"{generated_column}_{new_column}"
-                if (
-                    generated_column not in org_col_names
-                    and generated_column not in new_col_names
-                ):
-                    new_column = generated_column
-                    break
+        generated_column = new_column
 
-        new_col_names[new_column] = org_column
+        while (
+            not generated_column.isidentifier()
+            or generated_column in new_col_names
+            or (generated_column != org_column and generated_column in org_col_names)
+        ):
+            if new_column:
+                generated_column = f"c{gen_col_counter}_{new_column}"
+            else:
+                generated_column = f"c{gen_col_counter}"
+            gen_col_counter += 1
+
+        new_col_names[generated_column] = org_column
 
     return new_col_names

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -168,13 +168,21 @@ def test_parquet_convert_column_names():
             ("dot.notation.col", pa.int32()),
             ("with-dashes", pa.int32()),
             ("with spaces", pa.int32()),
+            ("with-multiple--dashes", pa.int32()),
+            ("with__underscores", pa.int32()),
+            ("__leading__underscores", pa.int32()),
+            ("trailing__underscores__", pa.int32()),
         ]
     )
     assert list(schema_to_output(schema)) == [
         "uppercasecol",
-        "dotnotationcol",
-        "withdashes",
-        "withspaces",
+        "dot_notation_col",
+        "with_dashes",
+        "with_spaces",
+        "with_multiple_dashes",
+        "with_underscores",
+        "leading_underscores",
+        "trailing_underscores",
     ]
 
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -284,7 +284,9 @@ def test_listings(test_session, tmp_dir):
     assert listing.expires
     assert listing.version == 1
     assert listing.num_objects == 1
-    assert listing.size == 2912
+    # Exact number if unreliable here since it depends on the PyArrow version
+    assert listing.size > 1000
+    assert listing.size < 5000
     assert listing.status == 4
 
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -36,6 +36,18 @@ DF_DATA = {
     "city": ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix"],
 }
 
+DF_DATA_NESTED_NOT_NORMALIZED = {
+    "nAmE": [
+        {"first-SELECT": "Alice", "l--as@t": "Smith"},
+        {"l--as@t": "Jones", "first-SELECT": "Bob"},
+        {"first-SELECT": "Charlie", "l--as@t": "Brown"},
+        {"first-SELECT": "David", "l--as@t": "White"},
+        {"first-SELECT": "Eva", "l--as@t": "Black"},
+    ],
+    "AgE": [25, 30, 35, 40, 45],
+    "citY": ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix"],
+}
+
 DF_OTHER_DATA = {
     "last_name": ["Smith", "Jones"],
     "country": ["USA", "Russia"],
@@ -986,6 +998,25 @@ def test_parse_tabular_format(tmp_dir, test_session):
     )
     df1 = dc.select("first_name", "age", "city").to_pandas()
     assert df1.equals(df)
+
+
+def test_parse_nested_json(tmp_dir, test_session):
+    df = pd.DataFrame(DF_DATA_NESTED_NOT_NORMALIZED)
+    path = tmp_dir / "test.jsonl"
+    path.write_text(df.to_json(orient="records", lines=True))
+    dc = DataChain.from_storage(path.as_uri(), session=test_session).parse_tabular(
+        format="json"
+    )
+    # Field names are normalized, values are preserved
+    # E.g. nAmE -> name, l--as@t -> l_as_t, etc
+    df1 = dc.select("name", "age", "city").to_pandas()
+
+    assert df1["name"]["first_select"].to_list() == [
+        d["first-SELECT"] for d in df["nAmE"].to_list()
+    ]
+    assert df1["name"]["l_as_t"].to_list() == [
+        d["l--as@t"] for d in df["nAmE"].to_list()
+    ]
 
 
 def test_parse_tabular_partitions(tmp_dir, test_session):

--- a/tests/unit/lib/test_utils.py
+++ b/tests/unit/lib/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import BaseModel
 
 from datachain.lib.convert.python_to_sql import python_to_sql
+from datachain.lib.utils import normalize_col_names
 from datachain.sql.types import JSON, Array, String
 
 
@@ -56,3 +57,72 @@ def test_convert_type_to_datachain_array(typ, expected):
 def test_convert_type_to_datachain_error(typ):
     with pytest.raises(TypeError):
         python_to_sql(typ)
+
+
+def test_normalize_column_names():
+    res = normalize_col_names(
+        [
+            "UpperCase",
+            "_underscore_start",
+            "double__underscore",
+            "1start_with_number",
+            "не_ascii_start",
+            "  space_start",
+            "space_end  ",
+            "dash-end-",
+            "-dash-start",
+            "--multiple--dash--",
+            "-_ mix_  -dash_ -",
+            "__2digit_after_uderscore",
+            "",
+            "_-_-  _---_ _",
+            "_-_-  _---_ _1",
+        ]
+    )
+    assert list(res.keys()) == [
+        "uppercase",
+        "underscore_start",
+        "double_underscore",
+        "c0_1start_with_number",
+        "ascii_start",
+        "space_start",
+        "space_end",
+        "dash_end",
+        "dash_start",
+        "multiple_dash",
+        "mix_dash",
+        "c1_2digit_after_uderscore",
+        "c2",
+        "c3",
+        "c4_1",
+    ]
+
+
+def test_normalize_column_names_case_repeat():
+    res = normalize_col_names(["UpperCase", "UpPerCase"])
+
+    assert list(res.keys()) == ["uppercase", "c0_uppercase"]
+
+
+def test_normalize_column_names_exists_after_normalize():
+    res = normalize_col_names(["1digit", "c0_1digit"])
+
+    assert list(res.keys()) == ["c1_1digit", "c0_1digit"]
+
+
+def test_normalize_column_names_normalized_repeat():
+    res = normalize_col_names(["column", "_column"])
+
+    assert list(res.keys()) == ["column", "c0_column"]
+
+
+def test_normalize_column_names_normalized_case_repeat():
+    res = normalize_col_names(["CoLuMn", "_column"])
+
+    assert res == {"column": "CoLuMn", "c0_column": "_column"}
+
+
+def test_normalize_column_names_repeat_generated_after_normalize():
+    res = normalize_col_names(["c0_CoLuMn", "_column", "column"])
+
+    assert res == {"c0_column": "c0_CoLuMn", "c1_column": "_column", "column": "column"}


### PR DESCRIPTION
Part of the https://github.com/iterative/datachain/issues/481

Fixes a few issue with nested column names. We had before a [function](https://github.com/iterative/datachain/blob/main/src/datachain/lib/arrow.py#L146-L156) that was normalizing the top level schema names in a single place [here](https://github.com/iterative/datachain/blob/main/src/datachain/lib/arrow.py#L131).

It means that if you have a JSON file to parse with `parse_tabular` (yes, it supports JSONs as well), or any other nested structure where we create Pydantic models for nested fields with [`dict_to_data_model`](https://github.com/iterative/datachain/blob/main/src/datachain/lib/data_model.py#L62-L68) we either had a bunch of non-normalized names except for the top level, or we could end up with a syntax error.

E.g. I had a JSON like this:

```json
{
  "bff_contained_ngram_count_before_dedupe": 0,
  "language_id_whole_page_fasttext": {
    "en": 0.9512948989868164
  },
  "metadata": {
    "Content-Length": "112946",
    "Content-Type": "application/http; msgtype=response",
    "WARC-Block-Digest": "sha1:U462KE2IDQWYDJQDRXIP3UVH465G2I2G",
    "WARC-Concurrent-To": "<urn:uuid:eaf4d817-f140-4a5e-9fa9-64d0dcb32a08>",
    "WARC-Date": "2017-05-27T21:20:09Z",
    "WARC-IP-Address": "198.57.149.47",
    "WARC-Identified-Payload-Type": "text/html",
    "WARC-Payload-Digest": "sha1:KAFZ77S3HPJ7SOABQ4ZMMVT47OCXZR6R",
    "WARC-Record-ID": "<urn:uuid:f8557905-b0dd-47b9-bc60-3106b3c18b4c>",
    "WARC-Target-URI": "http://www.muslimlinkpaper.com/index.php/editors-desk/13-letter-to-the-editor/3054-a-letter-to-president-obama.html",
    "WARC-Truncated": "length",
    "WARC-Type": "response",
    "WARC-Warcinfo-ID": "<urn:uuid:398fb229-e8ed-4f8b-86af-00eb8d6b2594>"
  },
  "previous_word_count": 178,
  "text": "A Letter ...",
  "url": "http://www.muslimlinkpaper.com/index.php/editors-desk/13-letter-to-the-editor/3054-a-letter-to-president-obama.html",
  "warcinfo": "robots: classic\r\nhostname: ip-10-185-224-210.ec2.internal\r\nsoftware: Nutch 1.6 (CC)/CC WarcExport 1.0\r\nisPartOf: CC-MAIN-2017-22\r\noperator: Common Crawl Admin\r\ndescription: Wide crawl of the web for May 2017\r\npublisher: Common Crawl\r\nformat: WARC File Format 1.0\r\nconformsTo: http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf",
  "fasttext_openhermes_reddit_eli5_vs_rw_v2_bigram_200k_train_prob": 0.967424213886261
}
```

Particularly, dealing with a field `WARC-Concurrent-To` is problematic. `sqlalchmey` fails to quote bound params in `INSERT ... VALUES ...` and `-TO` triggers a syntax error, as well as `-SELECT` for example.

With this PR, we are applying the same rules to all column names - top level and nested. It requires making an alias on Pydantic model, but I hope that is fine.

## TODO:

- [x] Add more unit tests for the new name normalization function
- [x] To @0x2b3bfa0 point - make it even more strict (make them valid Python identifiers - e.g. they can't start with numbers) - at least in case when we generate a pydantic model out of them.

