### PR TITLE
fix(tests): hf test can be flakey if runs in parallel

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -19,8 +19,12 @@ llm_and_nlp_examples = sorted(
     [
         filename
         for filename in glob.glob("examples/llm_and_nlp/**/*.py", recursive=True)
-        # no anthropic token
+        # no anthropic token, HF runs against actual API - thus run it only once
         if "claude" not in filename
+        and (
+            "hf-" not in filename
+            or (sys.platform == "darwin" and sys.version_info >= (3, 12))
+        )
     ]
 )
 


### PR DESCRIPTION
Per https://github.com/iterative/datachain/pull/555#discussion_r1827088410

Run HF test only once since it using actual API, token, etc. It can be expensive + it seems it might be running into some race condition (not sure yet, we can observe and do retries if needed if we see that it is still unstable)