### PR TITLE
feat(cli): enhance dataset listing with additional options for studio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "huggingface_hub",
   "iterative-telemetry>=0.0.9",
   "platformdirs",
-  "dvc-studio-client>=0.21,<1"
+  "dvc-studio-client>=0.21,<1",
+  "tabulate"
 ]
 
 [project.optional-dependencies]
@@ -98,7 +99,8 @@ dev = [
   "types-python-dateutil",
   "types-pytz",
   "types-PyYAML",
-  "types-requests"
+  "types-requests",
+  "types-tabulate"
 ]
 examples = [
   "datachain[tests]",

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -844,7 +844,7 @@ def ls(
     long: bool = False,
     studio: bool = False,
     local: bool = False,
-    all: bool = False,
+    all: bool = True,
     team: Optional[str] = None,
     **kwargs,
 ):

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -849,13 +849,7 @@ def ls(
     **kwargs,
 ):
     token = Config().read().get("studio", {}).get("token")
-    if studio and not token:
-        raise DataChainError(
-            "Not logged in to Studio. Log in with 'datachain studio login'."
-        )
-
-    if local or studio:
-        all = False
+    all, local, studio = _determine_flavors(studio, local, all, token)
 
     if all or local:
         ls_local(sources, long=long, **kwargs)
@@ -872,15 +866,7 @@ def datasets(
     team: Optional[str] = None,
 ):
     token = Config().read().get("studio", {}).get("token")
-    if studio and not token:
-        raise DataChainError(
-            "Not logged in to Studio. Log in with 'datachain studio login'."
-        )
-
-    if local or studio:
-        all = False
-
-    all = all and not (local or studio)
+    all, local, studio = _determine_flavors(studio, local, all, token)
 
     local_datasets = set(list_datasets_local(catalog)) if all or local else set()
     studio_datasets = (
@@ -1056,6 +1042,20 @@ def completion(shell: str) -> str:
         get_parser(),
         shell=shell,
     )
+
+
+def _determine_flavors(studio: bool, local: bool, all: bool, token: Optional[str]):
+    if studio and not token:
+        raise DataChainError(
+            "Not logged in to Studio. Log in with 'datachain studio login'."
+        )
+
+    if local or studio:
+        all = False
+
+    all = all and not (local or studio)
+
+    return all, local, studio
 
 
 def main(argv: Optional[list[str]] = None) -> int:  # noqa: C901, PLR0912, PLR0915

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -131,6 +131,12 @@ class StudioClient:
             timeout=self.timeout,
         )
         ok = response.ok
+        if not ok:
+            if response.status_code == 403:
+                message = f"Not authorized for the team {self.team}"
+                raise DataChainError(message)
+            logger.error("Got bad response from Studio")
+
         content = msgpack.unpackb(response.content, ext_hook=self._unpacker_hook)
         response_data = content.get("data")
         if ok and response_data is None:
@@ -177,8 +183,12 @@ class StudioClient:
                 response.content.decode("utf-8"),
             )
             if response.status_code == 403:
-                message = "Not authorized"
+                message = f"Not authorized for the team {self.team}"
             else:
+                logger.error(
+                    "Got bad response from Studio, content is %s",
+                    response.content.decode("utf-8"),
+                )
                 message = data.get("message", "")
         else:
             message = ""
@@ -214,7 +224,7 @@ class StudioClient:
         # to handle cases where a path will be expanded (i.e. globs)
         response: Response[LsData]
         for path in paths:
-            response = self._send_request_msgpack("ls", {"source": path})
+            response = self._send_request_msgpack("datachain/ls", {"source": path})
             yield path, response
 
     def ls_datasets(self) -> Response[LsData]:

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from datachain.catalog.catalog import raise_remote_error
 from datachain.config import Config, ConfigLevel
@@ -24,7 +24,7 @@ def process_studio_cli_args(args: "Namespace"):
     if args.cmd == "token":
         return token()
     if args.cmd == "datasets":
-        return list_datasets(args)
+        return list_datasets(args.team)
     if args.cmd == "team":
         return set_team(args)
     raise DataChainError(f"Unknown command '{args.cmd}'.")
@@ -103,14 +103,16 @@ def token():
     print(token)
 
 
-def list_datasets(args: "Namespace"):
-    client = StudioClient(team=args.team)
+def list_datasets(team: Optional[str] = None):
+    client = StudioClient(team=team)
     response = client.ls_datasets()
     if not response.ok:
         raise_remote_error(response.message)
     if not response.data:
         print("No datasets found.")
         return
+
+    print("Datasets in Studio:")
     for d in response.data:
         name = d.get("name")
         for v in d.get("versions", []):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from upath.implementations.cloud import CloudPath
 from datachain.catalog import Catalog
 from datachain.catalog.loader import get_id_generator, get_metastore, get_warehouse
 from datachain.cli_utils import CommaSeparatedArgs
+from datachain.config import Config, ConfigLevel
 from datachain.data_storage.sqlite import (
     SQLiteDatabaseEngine,
     SQLiteIDGenerator,
@@ -26,6 +27,7 @@ from datachain.query.session import Session
 from datachain.utils import (
     ENV_DATACHAIN_GLOBAL_CONFIG_DIR,
     ENV_DATACHAIN_SYSTEM_CONFIG_DIR,
+    STUDIO_URL,
     DataChainDir,
 )
 
@@ -673,3 +675,24 @@ def dataset_rows():
         }
         for i in range(19)
     ]
+
+
+@pytest.fixture
+def studio_datasets(requests_mock):
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
+        conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
+
+    datasets = [
+        {
+            "id": 1,
+            "name": "dogs",
+            "versions": [{"version": 1}, {"version": 2}],
+        },
+        {
+            "id": 2,
+            "name": "cats",
+            "versions": [{"version": 1}],
+        },
+    ]
+
+    requests_mock.post(f"{STUDIO_URL}/api/datachain/ls-datasets", json=datasets)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -693,6 +693,11 @@ def studio_datasets(requests_mock):
             "name": "cats",
             "versions": [{"version": 1}],
         },
+        {
+            "id": 3,
+            "name": "both",
+            "versions": [{"version": 1}],
+        },
     ]
 
     requests_mock.post(f"{STUDIO_URL}/api/datachain/ls-datasets", json=datasets)

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -16,7 +16,7 @@ from tests.utils import uppercase_scheme
 
 
 @pytest.fixture(autouse=True)
-def studio_config():
+def studio_config(global_config_dir):
     with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
 
@@ -235,20 +235,11 @@ dog3
 """
 
 
-def test_ls_remote_sources(cloud_type, capsys, monkeypatch):
+def test_ls_remote_sources(cloud_type, capsys, monkeypatch, studio_config):
     src = f"{cloud_type}://bucket"
-    token = "35NmrvSlsGVxTYIglxSsBIQHRrMpi6irSSYcAL0flijOytCHc"  # noqa: S105
     with monkeypatch.context() as m:
         m.setattr("requests.post", mock_post)
-        ls(
-            [src, f"{src}/dogs/others", f"{src}/dogs"],
-            config={
-                "type": "http",
-                "url": "http://localhost:8111/api/datachain",
-                "username": "datachain-team",
-                "token": f"isat_{token}",
-            },
-        )
+        ls([src, f"{src}/dogs/others", f"{src}/dogs"])
     captured = capsys.readouterr()
     assert captured.out == ls_remote_sources_output.format(src=src)
 

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -239,7 +239,7 @@ def test_ls_remote_sources(cloud_type, capsys, monkeypatch, studio_config):
     src = f"{cloud_type}://bucket"
     with monkeypatch.context() as m:
         m.setattr("requests.post", mock_post)
-        ls([src, f"{src}/dogs/others", f"{src}/dogs"])
+        ls([src, f"{src}/dogs/others", f"{src}/dogs"], studio=True)
     captured = capsys.readouterr()
     assert captured.out == ls_remote_sources_output.format(src=src)
 

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -15,7 +15,7 @@ from datachain.lib.listing import LISTING_PREFIX
 from tests.utils import uppercase_scheme
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def studio_config(global_config_dir):
     with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token", "team": "team_name"}

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -138,28 +138,28 @@ E2E_STEPS = (
         },
     },
     {
-        "command": ("datachain", "ls-datasets"),
-        "expected": "mnt (v1)\n",
+        "command": ("datachain", "datasets"),
+        "expected": "Datasets locally available:\nmnt (v1)\n",
     },
     {
-        "command": ("datachain", "ls-datasets"),
-        "expected": "mnt (v1)\n",
+        "command": ("datachain", "datasets"),
+        "expected": "Datasets locally available:\nmnt (v1)\n",
     },
     {
         "command": ("datachain", "edit-dataset", "mnt", "--new-name", "mnt-new"),
         "expected": "",
     },
     {
-        "command": ("datachain", "ls-datasets"),
-        "expected": "mnt-new (v1)\n",
+        "command": ("datachain", "datasets"),
+        "expected": "Datasets locally available:\nmnt-new (v1)\n",
     },
     {
         "command": ("datachain", "rm-dataset", "mnt-new", "--version", "1"),
         "expected": "",
     },
     {
-        "command": ("datachain", "ls-datasets"),
-        "expected": "",
+        "command": ("datachain", "datasets"),
+        "expected": "Datasets locally available:\n",
     },
     {
         "command": ("datachain", "gc"),
@@ -200,7 +200,7 @@ def run_step(step, catalog):
             step["expected"].lstrip("\n").split("\n")
         )
     else:
-        assert result.stdout == step["expected"].lstrip("\n")
+        assert result.stdout.strip("\n") == step["expected"].strip("\n")
     if step.get("listing"):
         assert "Listing" in result.stderr
     else:

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -4,6 +4,15 @@ import subprocess
 from textwrap import dedent
 
 import pytest
+import tabulate
+
+
+def _tabulated_datasets(name, version):
+    row = [
+        {"Name": name, "Version": version},
+    ]
+    return tabulate.tabulate(row, headers="keys")
+
 
 MNT_FILE_TREE = {
     "01375.png": 324,
@@ -139,11 +148,11 @@ E2E_STEPS = (
     },
     {
         "command": ("datachain", "datasets"),
-        "expected": "Datasets locally available:\nmnt (v1)\n",
+        "expected": _tabulated_datasets("mnt", 1),
     },
     {
         "command": ("datachain", "datasets"),
-        "expected": "Datasets locally available:\nmnt (v1)\n",
+        "expected": _tabulated_datasets("mnt", 1),
     },
     {
         "command": ("datachain", "edit-dataset", "mnt", "--new-name", "mnt-new"),
@@ -151,7 +160,7 @@ E2E_STEPS = (
     },
     {
         "command": ("datachain", "datasets"),
-        "expected": "Datasets locally available:\nmnt-new (v1)\n",
+        "expected": _tabulated_datasets("mnt-new", 1),
     },
     {
         "command": ("datachain", "rm-dataset", "mnt-new", "--version", "1"),
@@ -159,7 +168,7 @@ E2E_STEPS = (
     },
     {
         "command": ("datachain", "datasets"),
-        "expected": "Datasets locally available:\n",
+        "expected": "",
     },
     {
         "command": ("datachain", "gc"),


### PR DESCRIPTION
With this change, the following variation are available to list datasets
instead of `datachain ls-datasets`:

- `datachain datasets --local`
- `datachain datasets --studio`
```
Name             Version
-------------  ---------
jpg_files              1
all_files              1
jpg_png_files          1
png_files              1
02jpg_files            1
```

- `datachain datasets --all` (Default option)
- `datachain datasets --team TEAM_NAME`
- `datachain datasets`

```
Name                       Version  Studio    Local
-----------------------  ---------  --------  -------
jpg_files                        1  ✔         ✔
hello                            2  ✔         ✖
02jpg_files                      1  ✔         ✔
embeddings-and-metadata          1  ✔         ✖
```

By default, if the user has logged in to Studio using `datachain studio login`,
it will try to fetch the datasets from both local and studio.
If any specific option (local or studio) is passed, only that option is
passed.

The team name is parsed from config (Set by  `datachain studio team <TEAM_NAME>`).

The same feature is added for `datachain ls` function and added the
error handling for each scenarios.

Relates to #10774
