### PR TITLE
pin version of clickhouse to 24.6 (match clickhouse-cloud)

### DIFF
--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -32,7 +32,7 @@ jobs:
           POSTGRES_DB: database
           POSTGRES_HOST_AUTH_METHOD: trust
       clickhouse:
-        image: clickhouse/clickhouse-server:24
+        image: clickhouse/clickhouse-server:24.6
         ports:
           - 8123:8123
           - 9010:9000


### PR DESCRIPTION
Pointed out by @dreadatour - Clickhouse cloud currently uses version 24.6 so we should too.