### PR TITLE
Filter telemetry for dev version

### DIFF
--- a/src/datachain/telemetry.py
+++ b/src/datachain/telemetry.py
@@ -8,6 +8,12 @@ from datachain.utils import env2bool
 
 logger = logging.getLogger(__name__)
 
+# Try to get the version of the datachain package
+try:
+    __version__ = version("datachain")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 
 def is_enabled():
     """
@@ -15,6 +21,9 @@ def is_enabled():
     """
     # Disable telemetry if running in test mode
     if env2bool("DATACHAIN_TEST"):
+        return False
+
+    if "dev" in __version__:
         return False
 
     # Check if telemetry is disabled by environment variable
@@ -26,12 +35,6 @@ def is_enabled():
     logger.debug("Telemetry is enabled.")
     return True
 
-
-# Try to get the version of the datachain package
-try:
-    __version__ = version("datachain")
-except PackageNotFoundError:
-    __version__ = "unknown"
 
 # Initialize telemetry logger
 telemetry = IterativeTelemetryLogger("datachain", __version__, is_enabled)


### PR DESCRIPTION
When running `datachain` in a dev environment, we will get the version
in the format of `0.6.2.dev2+gf6445e2.d20241021`. This will disable the
telemetry for such version.
