### PR TITLE
Fix 'limit' + 'offset' methods for SQLite warehouse

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -747,8 +747,12 @@ class SQLiteWarehouse(AbstractWarehouse):
 
         ids = self.db.execute(select_ids).fetchall()
 
-        select_q = query.with_only_columns(
-            *[c for c in query.selected_columns if c.name != "sys__id"]
+        select_q = (
+            query.with_only_columns(
+                *[c for c in query.selected_columns if c.name != "sys__id"]
+            )
+            .offset(None)
+            .limit(None)
         )
 
         for batch in batched_it(ids, 10_000):

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -459,6 +459,77 @@ def test_order_by_limit(cloud_test_catalog, save, animal_dataset):
     ]
 
 
+@pytest.mark.parametrize("save", [True, False])
+@pytest.mark.parametrize(
+    "cloud_type,version_aware",
+    [("s3", True)],
+    indirect=True,
+)
+def test_limit(cloud_test_catalog, save, animal_dataset):
+    catalog = cloud_test_catalog.catalog
+    q = DatasetQuery(animal_dataset.name, catalog=catalog).limit(2)
+    if save:
+        ds_name = "animals_cats"
+        q.save(ds_name)
+        result = DatasetQuery(name=ds_name, catalog=catalog).db_results()
+        dataset_record = catalog.get_dataset(ds_name)
+        assert dataset_record.status == DatasetStatus.COMPLETE
+    else:
+        result = q.db_results()
+
+    assert len(result) == 2
+    assert [posixpath.basename(r[3]) for r in result] == ["cat1", "cat2"]
+
+
+@pytest.mark.parametrize("save", [True, False])
+@pytest.mark.parametrize(
+    "cloud_type,version_aware",
+    [("s3", True)],
+    indirect=True,
+)
+def test_offset_limit(cloud_test_catalog, save, animal_dataset):
+    catalog = cloud_test_catalog.catalog
+    q = DatasetQuery(animal_dataset.name, catalog=catalog).offset(3).limit(2)
+    if save:
+        ds_name = "animals_cats"
+        q.save(ds_name)
+        result = DatasetQuery(name=ds_name, catalog=catalog).db_results()
+        dataset_record = catalog.get_dataset(ds_name)
+        assert dataset_record.status == DatasetStatus.COMPLETE
+    else:
+        result = q.db_results()
+
+    assert len(result) == 2
+    assert [posixpath.basename(r[3]) for r in result] == ["dog1", "dog2"]
+
+
+@pytest.mark.parametrize("save", [True, False])
+@pytest.mark.parametrize(
+    "cloud_type,version_aware",
+    [("s3", True)],
+    indirect=True,
+)
+def test_mutate_offset_limit(cloud_test_catalog, save, animal_dataset):
+    catalog = cloud_test_catalog.catalog
+    q = (
+        DatasetQuery(animal_dataset.name, catalog=catalog)
+        .mutate(size10x=C("file.size") * 10)
+        .offset(3)
+        .limit(2)
+    )
+    if save:
+        ds_name = "animals_cats"
+        q.save(ds_name)
+        result = DatasetQuery(name=ds_name, catalog=catalog).db_results()
+        dataset_record = catalog.get_dataset(ds_name)
+        assert dataset_record.status == DatasetStatus.COMPLETE
+    else:
+        result = q.db_results()
+
+    assert len(result) == 2
+    assert [posixpath.basename(r[3]) for r in result] == ["dog1", "dog2"]
+
+
 @pytest.mark.parametrize(
     "cloud_type,version_aware",
     [("s3", True)],

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -460,14 +460,13 @@ def test_order_by_limit(cloud_test_catalog, save, animal_dataset):
 
 
 @pytest.mark.parametrize("save", [True, False])
-@pytest.mark.parametrize(
-    "cloud_type,version_aware",
-    [("s3", True)],
-    indirect=True,
-)
 def test_limit(cloud_test_catalog, save, animal_dataset):
     catalog = cloud_test_catalog.catalog
-    q = DatasetQuery(animal_dataset.name, catalog=catalog).limit(2)
+    q = (
+        DatasetQuery(animal_dataset.name, catalog=catalog)
+        .order_by(C("file.path"))
+        .limit(2)
+    )
     if save:
         ds_name = "animals_cats"
         q.save(ds_name)
@@ -482,14 +481,14 @@ def test_limit(cloud_test_catalog, save, animal_dataset):
 
 
 @pytest.mark.parametrize("save", [True, False])
-@pytest.mark.parametrize(
-    "cloud_type,version_aware",
-    [("s3", True)],
-    indirect=True,
-)
 def test_offset_limit(cloud_test_catalog, save, animal_dataset):
     catalog = cloud_test_catalog.catalog
-    q = DatasetQuery(animal_dataset.name, catalog=catalog).offset(3).limit(2)
+    q = (
+        DatasetQuery(animal_dataset.name, catalog=catalog)
+        .order_by(C("file.path"))
+        .offset(3)
+        .limit(2)
+    )
     if save:
         ds_name = "animals_cats"
         q.save(ds_name)
@@ -504,15 +503,11 @@ def test_offset_limit(cloud_test_catalog, save, animal_dataset):
 
 
 @pytest.mark.parametrize("save", [True, False])
-@pytest.mark.parametrize(
-    "cloud_type,version_aware",
-    [("s3", True)],
-    indirect=True,
-)
 def test_mutate_offset_limit(cloud_test_catalog, save, animal_dataset):
     catalog = cloud_test_catalog.catalog
     q = (
         DatasetQuery(animal_dataset.name, catalog=catalog)
+        .order_by(C("file.path"))
         .mutate(size10x=C("file.size") * 10)
         .offset(3)
         .limit(2)


### PR DESCRIPTION
This PR fixes `offset` method for DatasetQuery/DataChain for SQLite warehouse (it works fine in SaaS).

+ added tests (fail before fix: https://github.com/iterative/datachain/actions/runs/11829848002)