### PR TITLE
asyncmapper: shutdown producer on generator close

### DIFF
--- a/src/datachain/asyn.py
+++ b/src/datachain/asyn.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from collections.abc import (
     AsyncIterable,
     Awaitable,
@@ -54,6 +55,7 @@ class AsyncMapper(Generic[InputT, ResultT]):
         self.loop = get_loop() if loop is None else loop
         self.pool = ThreadPoolExecutor(workers)
         self._tasks: set[asyncio.Task] = set()
+        self._shutdown_producer = threading.Event()
 
     def start_task(self, coro: Coroutine) -> asyncio.Task:
         task = self.loop.create_task(coro)
@@ -63,11 +65,29 @@ class AsyncMapper(Generic[InputT, ResultT]):
 
     def _produce(self) -> None:
         for item in self.iterable:
+            if self._shutdown_producer.is_set():
+                return
             fut = asyncio.run_coroutine_threadsafe(self.work_queue.put(item), self.loop)
             fut.result()  # wait until the item is in the queue
 
     async def produce(self) -> None:
         await self.to_thread(self._produce)
+
+    def shutdown_producer(self) -> None:
+        """
+        Signal the producer to stop and drain any remaining items from the work_queue.
+
+        This method sets an internal event, `_shutdown_producer`, which tells the
+        producer that it should stop adding items to the queue. To ensure that the
+        producer notices this signal promptly, we also attempt to drain any items
+        currently in the queue, clearing it so that the event can be checked without
+        delay.
+        """
+        self._shutdown_producer.set()
+        q = self.work_queue
+        while not q.empty():
+            q.get_nowait()
+            q.task_done()
 
     async def worker(self) -> None:
         while (item := await self.work_queue.get()) is not None:
@@ -156,6 +176,7 @@ class AsyncMapper(Generic[InputT, ResultT]):
             if exc := async_run.exception():
                 raise exc
         finally:
+            self.shutdown_producer()
             if not async_run.done():
                 async_run.cancel()
 


### PR DESCRIPTION
Fixes the hanging issue when trying to cancel or close the script.

The test on #521 hangs. This is because we run the producer on a separate `ThreadPoolExecutor` in a _loop_.

https://github.com/iterative/datachain/blob/9fd31553d9003c09e135d8b4a2345ced4ffc5bdd/src/datachain/asyn.py#L64-L70

https://github.com/iterative/datachain/blob/9fd31553d9003c09e135d8b4a2345ced4ffc5bdd/src/datachain/asyn.py#L165-L166

When the interpreter shuts down, `ThreadPoolExecutor` waits for all threads to `join()`. Since `produce()` is still running, `join()` hangs indefinitely.

## Test Failure Analysis

Although the script hangs on other platforms too, you might notice that the CI failed only on the Windows tests on #521.

This is because [`test_query_e2e`](https://github.com/iterative/datachain/blob/ba9c5819f7f3ee578c8c55866463069f0e10d305/tests/test_query_e2e.py#L129-L133) sends multiple `SIGINT` signals (or `CTRL_C` on Windows). On the first `SIGINT`, Python raises a `KeyboardInterrupt` and tries to exit, but it gets blocked by `thread.join()`. On the next `SIGINT`, `join()` raises an exception and exits. 

The latter only happens on non-Windows platform, while Windows would hang indefinitely on `thread.join()` due to:

- https://github.com/python/cpython/issues/74157

Before this PR, on non-Windows platform, it would take 2 `SIGINT` signals to terminate the script.

## Solution

This PR adjusts `produce()` loop to check for a "shutdown" signal, and sets the signal on exit (either on success or failure). 

`produce()` also queues items into the `work_queue`, so that might hang if the queue is full. To solve that, we also drain items from the queue, so that it notices the "shutdown" signal quickly.


 

