### PR TITLE
Fixing np array dumping

### DIFF
--- a/src/datachain/sql/sqlite/types.py
+++ b/src/datachain/sql/sqlite/types.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 
 import orjson
@@ -36,6 +37,15 @@ def convert_array(arr):
 
 
 def adapt_np_array(arr):
+    def _json_serialize(obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return obj
+
+    if np.issubdtype(arr.dtype, np.object_):
+        # orjson cannot parse arrays with object subtype
+        return json.dumps(arr.tolist(), default=_json_serialize)
+
     return orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8")
 
 

--- a/src/datachain/sql/sqlite/types.py
+++ b/src/datachain/sql/sqlite/types.py
@@ -1,4 +1,3 @@
-import json
 import sqlite3
 
 import orjson
@@ -42,11 +41,9 @@ def adapt_np_array(arr):
             return obj.tolist()
         return obj
 
-    if np.issubdtype(arr.dtype, np.object_):
-        # orjson cannot parse arrays with object subtype
-        return json.dumps(arr.tolist(), default=_json_serialize)
-
-    return orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY).decode("utf-8")
+    return orjson.dumps(
+        arr, option=orjson.OPT_SERIALIZE_NUMPY, default=_json_serialize
+    ).decode("utf-8")
 
 
 def adapt_np_generic(val):

--- a/tests/unit/sql/sqlite/test_types.py
+++ b/tests/unit/sql/sqlite/test_types.py
@@ -1,18 +1,19 @@
 import numpy as np
+import pytest
 
 from datachain.sql.sqlite.types import adapt_np_array
 
 
-def test_adapt_np_array():
-    arr = np.array([0.5, 0.6], dtype=float)
-    assert adapt_np_array(arr) == "[0.5,0.6]"
-
-
-def test_adapt_nested_np_array():
-    arr = np.array([[0.5, 0.6], [0.7, 0.8]], dtype=float)
-    assert adapt_np_array(arr) == "[[0.5,0.6],[0.7,0.8]]"
-
-
-def test_adapt_np_array_object_type():
-    arr = np.array([0.5, 0.6], dtype=np.dtypes.ObjectDType)
-    assert adapt_np_array(arr) == "[0.5, 0.6]"
+@pytest.mark.parametrize(
+    "dtype,arr,expected",
+    (
+        (float, [], "[]"),
+        (float, [0.5, 0.6], "[0.5,0.6]"),
+        (float, [[0.5, 0.6], [0.7, 0.8]], "[[0.5,0.6],[0.7,0.8]]"),
+        (np.dtypes.ObjectDType, [], "[]"),
+        (np.dtypes.ObjectDType, [0.5, 0.6], "[0.5,0.6]"),
+        (np.dtypes.ObjectDType, [[0.5, 0.6], [0.7, 0.8]], "[[0.5,0.6],[0.7,0.8]]"),
+    ),
+)
+def test_adapt_np_array(dtype, arr, expected):
+    assert adapt_np_array(np.array(arr, dtype=dtype)) == expected

--- a/tests/unit/sql/sqlite/test_types.py
+++ b/tests/unit/sql/sqlite/test_types.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from datachain.sql.sqlite.types import adapt_np_array
+
+
+def test_adapt_np_array():
+    arr = np.array([0.5, 0.6], dtype=float)
+    assert adapt_np_array(arr) == "[0.5,0.6]"
+
+
+def test_adapt_nested_np_array():
+    arr = np.array([[0.5, 0.6], [0.7, 0.8]], dtype=float)
+    assert adapt_np_array(arr) == "[[0.5,0.6],[0.7,0.8]]"
+
+
+def test_adapt_np_array_object_type():
+    arr = np.array([0.5, 0.6], dtype=np.dtypes.ObjectDType)
+    assert adapt_np_array(arr) == "[0.5, 0.6]"


### PR DESCRIPTION
Fix for dumping np array into SQLite as current json lib doesn't work well with the object type np arrays