### PR TITLE
feat(dc): make expand work if some fields are optional

### DIFF
--- a/src/datachain/lib/hf.py
+++ b/src/datachain/lib/hf.py
@@ -98,7 +98,7 @@ class HFGenerator(Generator):
         with tqdm(desc=desc, unit=" rows") as pbar:
             for row in ds:
                 output_dict = {}
-                if split:
+                if split and "split" in self.output_schema.model_fields:
                     output_dict["split"] = split
                 for name, feat in ds.features.items():
                     anno = self.output_schema.model_fields[name].annotation

--- a/src/datachain/lib/utils.py
+++ b/src/datachain/lib/utils.py
@@ -33,6 +33,7 @@ class DataChainColumnError(DataChainParamsError):
 
 
 def normalize_col_names(col_names: Sequence[str]) -> dict[str, str]:
+    """Returns normalized_name -> original_name dict."""
     gen_col_counter = 0
     new_col_names = {}
     org_col_names = set(col_names)

--- a/tests/unit/lib/test_hf.py
+++ b/tests/unit/lib/test_hf.py
@@ -101,7 +101,7 @@ def test_hf_image(tmp_path):
     img.save(train_dir / "img1.png")
 
     ds = load_dataset("imagefolder", data_dir=tmp_path)
-    schema = get_output_schema(ds["train"].features)
+    schema = {"split": str} | get_output_schema(ds["train"].features)
     assert schema["image"] is HFImage
 
     gen = HFGenerator(ds, dict_to_data_model("", schema))
@@ -122,7 +122,7 @@ def test_hf_audio(tmp_path):
     write(train_dir / "example.wav", samplerate, data.astype(np.int16))
 
     ds = load_dataset("audiofolder", data_dir=tmp_path)
-    schema = get_output_schema(ds["train"].features)
+    schema = {"split": str} | get_output_schema(ds["train"].features)
 
     gen = HFGenerator(ds, dict_to_data_model("", schema))
     gen.setup()


### PR DESCRIPTION
Adds `schema_sample_size` option to `explode` to specify how many samples it should be analyzing do derive schema. This is needed in case some fields are missing in a single sample.

Fixes a few other things to make it work on the existing fixture.