### PR TITLE
Fix inaccurate comment in `split.py`

### DIFF
--- a/src/datachain/toolkit/split.py
+++ b/src/datachain/toolkit/split.py
@@ -58,14 +58,12 @@ def train_test_split(dc: DataChain, weights: list[float]) -> list[DataChain]:
 
     weights_normalized = [weight / sum(weights) for weight in weights]
 
-    resolution = 2**31 - 1  # Maximum positive value for a 32-bit signed integer.
-
     return [
         dc.filter(
-            C("sys__rand") % resolution
-            >= round(sum(weights_normalized[:index]) * resolution),
-            C("sys__rand") % resolution
-            < round(sum(weights_normalized[: index + 1]) * resolution),
+            C("sys__rand") % 2**31
+            >= round(sum(weights_normalized[:index]) * (2**31 - 1)),
+            C("sys__rand") % 2**31
+            < round(sum(weights_normalized[: index + 1]) * (2**31 - 1)),
         )
         for index, _ in enumerate(weights_normalized)
     ]


### PR DESCRIPTION
Continuation of #611, see https://github.com/iterative/datachain/pull/611#discussion_r1850895073.

To do:
* Call `abs` always before comparison, and make sure we're always comparing positive numbers.
* Check that we're using the right data types everywhere [un]signed integers? 64 bits? SQLite doesn't support uint64, but only int64.