### PR TITLE
test_query_e2e: do not interrupt running script multiple times

### DIFF
--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -109,7 +109,7 @@ E2E_STEPS = (
         ),
         "interrupt_after": "UDF Processing Started",
         "expected_in_stderr": "KeyboardInterrupt",
-        "expected_not_in_stderr": "semaphore",
+        "expected_not_in_stderr": "Warning",
     },
     {
         "command": ("datachain", "gc"),


### PR DESCRIPTION
The PR makes three changes:

1) The E2E test is updated only to send the interrupt signal once (done in the first commit).
2) Suppresses `usearch`'s `UserWarning`, and
3) Fixes "leaked semaphore issue" (see #615) due to worker process being SIGKILL'd on `KeyboardInterrupt`. 


This happens because, while running script, sending <kbd>Ctrl</kbd> + <kbd>C</kbd> would also send SIGINT to
the worker processes, but then [it would immediately follow up with a SIKILL][1] [after 0.25s][2].

This allowed very little time for workers to do cleanup, due to which, Python was raising `UserWarning`
for leaked semaphores:

```py
.../lib/python3.12/site-packages/multiprocess/resource_tracker.py:257: UserWarning: resource_tracker: There appear to be 6 leaked semaphore objects to clean >
```

Also see python/cpython#70130.

This patch changes worker processes to be run using `subprocess.Popen`
rather than `subprocess.run`, so that SIGKILL never gets sent.
The responsibility is on worker process to cleanup properly and exit. 

[1]: https://github.com/python/cpython/blob/3c770e3f0978d825c5ebea98fcd654660e7e135f/Lib/subprocess.py#L571-L573
[2]: https://github.com/python/cpython/blob/3c770e3f0978d825c5ebea98fcd654660e7e135f/Lib/subprocess.py#L891
