### PR TITLE
sqlitedb: retain `db_file` in `_connect` method to ensure proper connection on `db.clone()`

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -122,7 +122,9 @@ class SQLiteDatabaseEngine(DatabaseEngine):
         return cls(*cls._connect(db_file=db_file))
 
     @staticmethod
-    def _connect(db_file: Optional[str] = None):
+    def _connect(
+        db_file: Optional[str] = None,
+    ) -> tuple["Engine", "MetaData", sqlite3.Connection, str]:
         try:
             if db_file == ":memory:":
                 # Enable multithreaded usage of the same in-memory db
@@ -130,9 +132,8 @@ class SQLiteDatabaseEngine(DatabaseEngine):
                     _get_in_memory_uri(), uri=True, detect_types=DETECT_TYPES
                 )
             else:
-                db = sqlite3.connect(
-                    db_file or DataChainDir.find().db, detect_types=DETECT_TYPES
-                )
+                db_file = db_file or DataChainDir.find().db
+                db = sqlite3.connect(db_file, detect_types=DETECT_TYPES)
             create_user_defined_sql_functions(db)
             engine = sqlalchemy.create_engine(
                 "sqlite+pysqlite:///", creator=lambda: db, future=True


### PR DESCRIPTION
This fixes an issue where `db._connect()` would fail to preserve the original database file when it wasn’t explicitly specified. The root cause involved external directory changes on `read_meta()` which uses [`datamodel-codegenerator` that briefly changes the current working directory][1].

Since we were not storing original `db_file`, the `db.clone()` would try to open the database file from the new working directory, instead of the original one, which disrupted the database connection to the background thread running for the prefetch.

By saving the `db_file`, `clone()` can now reliably reuse the correct database uri/path, avoiding unintended connections to a different database file.

CI failure: https://github.com/iterative/datachain/actions/runs/11991835481/job/33430946078#step:8:128

[1]: https://github.com/koxudaxi/datamodel-code-generator/blob/230fe9b772f1a8018b31b78361f72acf474566ec/datamodel_code_generator/__init__.py#L486