### PR TITLE
remove JSON columns from dataset lists

### DIFF
--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -772,6 +772,25 @@ def test_dataset_stats(test_session):
     assert dataset_version2.size == 18
 
 
+def test_ls_datasets_no_json(test_session):
+    ids = [1, 2, 3]
+    values = tuple(zip(["a", "b", "c"], [1, 2, 3]))
+
+    DataChain.from_values(
+        ids=ids,
+        file=[File(path=name, size=size) for name, size in values],
+        session=test_session,
+    ).save()
+    datasets = test_session.catalog.ls_datasets()
+    assert datasets
+    for d in datasets:
+        assert d.feature_schema == {}
+        assert d.versions
+        for v in d.versions:
+            assert v.preview is None
+            assert v.feature_schema == {}
+
+
 @pytest.mark.parametrize("cloud_type", ["s3", "azure", "gs"], indirect=True)
 def test_listing_stats(cloud_test_catalog):
     catalog = cloud_test_catalog.catalog


### PR DESCRIPTION
Related to https://github.com/iterative/studio/issues/10849

In Studio we're seeing a slow query alerts for the following query:

<details> 
<summary> SQL </summary>

```SQL
    SELECT
        dqlapp_dataset.id,
        dqlapp_dataset.name,
        dqlapp_dataset.description,
        dqlapp_dataset.labels,
        dqlapp_dataset.status,
        dqlapp_dataset.feature_schema,
        dqlapp_dataset.created_at,
        dqlapp_dataset.finished_at,
        dqlapp_dataset.error_message,
        dqlapp_dataset.error_stack,
        dqlapp_dataset.script_output,
        dqlapp_dataset.sources,
        dqlapp_dataset.query_script,
        dqlapp_dataset.schema,
        dqlapp_dataset.team_id,
        dqlapp_dataset.warehouse_id,
        dqlapp_dataset.created_by_id,
        dqlapp_datasetversion.id AS id_1,
        dqlapp_datasetversion.uuid,
        dqlapp_datasetversion.dataset_id,
        dqlapp_datasetversion.version,
        dqlapp_datasetversion.status AS status_1,
        dqlapp_datasetversion.feature_schema AS feature_schema_1,
        dqlapp_datasetversion.created_at AS created_at_1,
        dqlapp_datasetversion.finished_at AS finished_at_1,
        dqlapp_datasetversion.error_message AS error_message_1,
        dqlapp_datasetversion.error_stack AS error_stack_1,
        dqlapp_datasetversion.script_output AS script_output_1,
        dqlapp_datasetversion.num_objects,
        dqlapp_datasetversion.size,
        dqlapp_datasetversion.preview,
        dqlapp_datasetversion.sources AS sources_1,
        dqlapp_datasetversion.query_script AS query_script_1,
        dqlapp_datasetversion.schema AS schema_1,
        dqlapp_datasetversion.job_id,
        dqlapp_datasetversion.created_by_id AS created_by_id_1  
    FROM
        dqlapp_dataset 
    LEFT OUTER JOIN
        dqlapp_datasetversion 
            ON dqlapp_dataset.id = dqlapp_datasetversion.dataset_id  
    WHERE
        dqlapp_dataset.team_id = $1
```

</details>

This statement is being generated by a `catalog.ls_datasets` call via a GraphQL endpoint. 

`ls_datasets` uses `metastore.list_datasets`. None of the callers of `metastore.list_datasets` use any of the JSON columns from the data. The same is true for `metastore.list_datasets_by_prefix`. 

This PR removes the JSON columns from the underlying query which should help with performance in Studio without affecting anything else.
