### PR TITLE
fix type issues produced by new version of pydantic

### DIFF
--- a/src/datachain/lib/dataset_info.py
+++ b/src/datachain/lib/dataset_info.py
@@ -23,8 +23,8 @@ class DatasetInfo(DataModel):
     finished_at: Optional[datetime] = Field(default=None)
     num_objects: Optional[int] = Field(default=None)
     size: Optional[int] = Field(default=None)
-    params: dict[str, str] = Field(default=dict)
-    metrics: dict[str, Any] = Field(default=dict)
+    params: dict[str, str] = Field(default={})
+    metrics: dict[str, Any] = Field(default={})
     error_message: str = Field(default="")
     error_stack: str = Field(default="")
 

--- a/src/datachain/lib/webdataset_laion.py
+++ b/src/datachain/lib/webdataset_laion.py
@@ -49,11 +49,11 @@ class WDSLaion(WDSBasic):
 class LaionMeta(BaseModel):
     file: File
     index: Optional[int] = Field(default=None)
-    b32_img: list[float] = Field(default=None)
-    b32_txt: list[float] = Field(default=None)
-    l14_img: list[float] = Field(default=None)
-    l14_txt: list[float] = Field(default=None)
-    dedup: list[float] = Field(default=None)
+    b32_img: list[float] = Field(default=[])
+    b32_txt: list[float] = Field(default=[])
+    l14_img: list[float] = Field(default=[])
+    l14_txt: list[float] = Field(default=[])
+    dedup: list[float] = Field(default=[])
 
 
 def process_laion_meta(file: File) -> Iterator[LaionMeta]:

--- a/src/datachain/model/bbox.py
+++ b/src/datachain/model/bbox.py
@@ -17,7 +17,7 @@ class BBox(DataModel):
     """
 
     title: str = Field(default="")
-    coords: list[int] = Field(default=None)
+    coords: list[int] = Field(default=[])
 
     @staticmethod
     def from_list(coords: list[float], title: str = "") -> "BBox":
@@ -60,7 +60,7 @@ class OBBox(DataModel):
     """
 
     title: str = Field(default="")
-    coords: list[int] = Field(default=None)
+    coords: list[int] = Field(default=[])
 
     @staticmethod
     def from_list(coords: list[float], title: str = "") -> "OBBox":

--- a/src/datachain/model/pose.py
+++ b/src/datachain/model/pose.py
@@ -15,8 +15,8 @@ class Pose(DataModel):
     corresponds to a specific body part.
     """
 
-    x: list[int] = Field(default=None)
-    y: list[int] = Field(default=None)
+    x: list[int] = Field(default=[])
+    y: list[int] = Field(default=[])
 
     @staticmethod
     def from_list(points: list[list[float]]) -> "Pose":
@@ -55,9 +55,9 @@ class Pose3D(DataModel):
     where each index corresponds to a specific body part.
     """
 
-    x: list[int] = Field(default=None)
-    y: list[int] = Field(default=None)
-    visible: list[float] = Field(default=None)
+    x: list[int] = Field(default=[])
+    y: list[int] = Field(default=[])
+    visible: list[float] = Field(default=[])
 
     @staticmethod
     def from_list(points: list[list[float]]) -> "Pose3D":

--- a/src/datachain/model/segment.py
+++ b/src/datachain/model/segment.py
@@ -17,8 +17,8 @@ class Segment(DataModel):
     """
 
     title: str = Field(default="")
-    x: list[int] = Field(default=None)
-    y: list[int] = Field(default=None)
+    x: list[int] = Field(default=[])
+    y: list[int] = Field(default=[])
 
     @staticmethod
     def from_list(points: list[list[float]], title: str = "") -> "Segment":


### PR DESCRIPTION
It seems like the newest release of Pydantic expects type-safe defaults to be provided (failure [here](https://github.com/iterative/datachain/actions/runs/12040183868/job/33569570076))