### PR TITLE
add get_dataset_version method to catalog and metastore

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -42,6 +42,7 @@ from datachain.dataset import (
     DatasetRecord,
     DatasetStats,
     DatasetStatus,
+    DatasetVersionRecord,
     RowDict,
     StorageURI,
     create_dataset_uri,
@@ -1100,6 +1101,9 @@ class Catalog:
 
     def get_dataset(self, name: str) -> DatasetRecord:
         return self.metastore.get_dataset(name)
+
+    def get_dataset_version(self, name: str, version: int) -> DatasetVersionRecord:
+        return self.metastore.get_dataset_version(name, version)
 
     def get_remote_dataset(self, name: str) -> DatasetRecord:
         studio_client = StudioClient()

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -1046,8 +1046,7 @@ def show(
     from datachain.query.dataset import DatasetQuery
     from datachain.utils import show_records
 
-    dataset = catalog.get_dataset(name)
-    dataset_version = dataset.get_version(version or dataset.latest_version)
+    dataset_version = catalog.get_version(name, version)
 
     query = (
         DatasetQuery(name=name, version=version, catalog=catalog)

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -699,13 +699,6 @@ class AbstractDBMetastore(AbstractMetastore):
         assert len(versions) == 1
         return versions[0]
 
-    def _parse_datasets(self, rows) -> Iterator["DatasetRecord"]:
-        # grouping rows by dataset id
-        for _, g in groupby(rows, lambda r: r[0]):
-            dataset = self._parse_dataset(list(g))
-            if dataset:
-                yield dataset
-
     def _parse_list_dataset(self, rows) -> Optional[DatasetListRecord]:
         versions = [self.dataset_list_class.parse(*r) for r in rows]
         if not versions:

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -148,6 +148,20 @@ def test_get_dataset(cloud_test_catalog, dogs_dataset):
         catalog.get_dataset("wrong name")
 
 
+def test_get_dataset_version(cloud_test_catalog, dogs_dataset):
+    catalog = cloud_test_catalog.catalog
+
+    dataset = catalog.get_dataset_version(dogs_dataset.name, 1)
+    assert dataset.name == dogs_dataset.name
+    assert dataset.version.version == 1
+
+    with pytest.raises(DatasetVersionNotFoundError):
+        catalog.get_dataset_version("wrong name", 1)
+
+    with pytest.raises(DatasetVersionNotFoundError):
+        catalog.get_dataset_version(dogs_dataset.name, 10000000000000000)
+
+
 # Returns None if the table does not exist
 def get_table_row_count(db, table_name):
     if not db.has_table(table_name):


### PR DESCRIPTION
This PR was an attempt to solve an issue with dataset version previews taking too long to load. The theory was that we could cut down the amount of data being requested from the database by only calling for a single version with the dataset.

The main drawback of this approach is the need to add a further 2 dataclasses (one here and one in Studio). As a result, I have decided to go with #642. We can always come back to this if we need further performance improvements.