### PR TITLE
do not pre-load dataset version preview from string

### DIFF
--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -2,6 +2,7 @@ import builtins
 import json
 from dataclasses import dataclass, fields
 from datetime import datetime
+from functools import cached_property
 from typing import (
     Any,
     NewType,
@@ -10,6 +11,8 @@ from typing import (
     Union,
 )
 from urllib.parse import urlparse
+
+import orjson
 
 from datachain.error import DatasetVersionNotFoundError
 from datachain.sql.types import NAME_TYPES_MAPPING, SQLType
@@ -178,7 +181,7 @@ class DatasetVersion:
     schema: dict[str, Union[SQLType, type[SQLType]]]
     num_objects: Optional[int]
     size: Optional[int]
-    preview: Optional[list[dict]]
+    _preview_data: Optional[Union[str, list[dict]]]
     sources: str = ""
     query_script: str = ""
     job_id: Optional[str] = None
@@ -199,7 +202,7 @@ class DatasetVersion:
         script_output: str,
         num_objects: Optional[int],
         size: Optional[int],
-        preview: Optional[str],
+        preview: Optional[Union[str, list[dict]]],
         schema: dict[str, Union[SQLType, type[SQLType]]],
         sources: str = "",
         query_script: str = "",
@@ -220,7 +223,7 @@ class DatasetVersion:
             schema,
             num_objects,
             size,
-            json.loads(preview) if preview else None,
+            preview,
             sources,
             query_script,
             job_id,
@@ -260,9 +263,17 @@ class DatasetVersion:
             for c_name, c_type in self.schema.items()
         }
 
+    @cached_property
+    def preview(self) -> Optional[list[dict]]:
+        if isinstance(self._preview_data, str):
+            return orjson.loads(self._preview_data)
+        return self._preview_data if self._preview_data else None
+
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "DatasetVersion":
         kwargs = {f.name: d[f.name] for f in fields(cls) if f.name in d}
+        if not hasattr(kwargs, "_preview_data"):
+            kwargs["_preview_data"] = d.get("preview")
         return cls(**kwargs)
 
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -6,7 +7,7 @@ from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
 from sqlalchemy.schema import CreateTable
 
 from datachain.data_storage.schema import DataTable
-from datachain.dataset import DatasetDependency, DatasetDependencyType
+from datachain.dataset import DatasetDependency, DatasetDependencyType, DatasetVersion
 from datachain.sql.types import (
     JSON,
     Array,
@@ -106,3 +107,34 @@ def test_dataset_dependency_dataset_name(dep_name, dep_type, expected):
     )
 
     assert dep.dataset_name == expected
+
+
+@pytest.mark.parametrize(
+    "use_string",
+    [True, False],
+)
+def test_dataset_version_from_dict(use_string):
+    preview = [{"id": 1, "thing": "a"}, {"id": 2, "thing": "b"}]
+
+    preview_data = json.dumps(preview) if use_string else preview
+
+    data = {
+        "id": 1,
+        "uuid": "98928be4-b6e8-4b7b-a7c5-2ce3b33130d8",
+        "dataset_id": 40,
+        "version": 2,
+        "status": 1,
+        "feature_schema": {},
+        "created_at": datetime.fromisoformat("2023-10-01T12:00:00"),
+        "finished_at": None,
+        "error_message": "",
+        "error_stack": "",
+        "script_output": "",
+        "schema": {},
+        "num_objects": 100,
+        "size": 1000000,
+        "preview": preview_data,
+    }
+
+    dataset_version = DatasetVersion.from_dict(data)
+    assert dataset_version.preview == preview


### PR DESCRIPTION
This PR ensures that we don't load a dataset version's preview to a dict from a string until it has been requested. This should mean that we can continue to use the pattern of loading all version for a dataset via `catalog.get_dataset` without taking the performance hit of loading all of the dataset version previews via `json.loads`