### PR TITLE
do not use orjson to parse dataset version preview

### DIFF
--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -12,8 +12,6 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-import orjson
-
 from datachain.error import DatasetVersionNotFoundError
 from datachain.sql.types import NAME_TYPES_MAPPING, SQLType
 
@@ -266,7 +264,7 @@ class DatasetVersion:
     @cached_property
     def preview(self) -> Optional[list[dict]]:
         if isinstance(self._preview_data, str):
-            return orjson.loads(self._preview_data)
+            return json.loads(self._preview_data)
         return self._preview_data if self._preview_data else None
 
     @classmethod


### PR DESCRIPTION
Reverting to using json.loads for the dataset version preview because orjson cannot cope with some custom serialization that we do (demonstrated [here](https://github.com/iterative/studio/actions/runs/12078410076/job/33682779597?pr=11000)).

We can revisit this but for now I don't want to leave Studio in a broken state.