### PR TITLE
Support 'case' operator inside functions

### DIFF
--- a/src/datachain/func/__init__.py
+++ b/src/datachain/func/__init__.py
@@ -1,4 +1,4 @@
-from sqlalchemy import literal
+from sqlalchemy import case, literal
 
 from . import array, path, random, string
 from .aggregate import (
@@ -24,6 +24,7 @@ __all__ = [
     "any_value",
     "array",
     "avg",
+    "case",
     "collect",
     "concat",
     "cosine_distance",

--- a/src/datachain/func/func.py
+++ b/src/datachain/func/func.py
@@ -6,6 +6,7 @@ from sqlalchemy import BindParameter, Case, ColumnElement, desc
 from sqlalchemy.ext.hybrid import Comparator
 
 from datachain.lib.convert.python_to_sql import python_to_sql
+from datachain.lib.convert.sql_to_python import sql_to_python
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
 from datachain.query.schema import Column, ColumnMeta
 
@@ -273,6 +274,9 @@ class Func(Function):
 def get_db_col_type(signals_schema: "SignalSchema", col: ColT) -> "DataType":
     if isinstance(col, Func):
         return col.get_result_type(signals_schema)
+
+    if isinstance(col, ColumnElement) and not hasattr(col, "name"):
+        return sql_to_python(col)
 
     return signals_schema.get_column_type(
         col.name if isinstance(col, ColumnElement) else col


### PR DESCRIPTION
Follow-up for the https://github.com/iterative/datachain/pull/649

This will allow us to run:

```python
from datachain import C, DataChain, func


(
  DataChain.from_values(name=["foo", "bar", "baz"], anxiety=[0.0, 1.0, 0.5], boredom=[0.7, 0.0, 0.05])
  .group_by(
    anxiety=func.sum(func.case((C("anxiety") > 0.1, 1), else_=0)),
    boredom=func.sum(func.case((C("boredom") > 0.1, 1), else_=0)),
  )
  .show()
)
```

Instead of:

```python
from datachain import C, DataChain, func
from sqlalchemy import case


(
  DataChain.from_values(name=["foo", "bar", "baz"], anxiety=[0.0, 1.0, 0.5], boredom=[0.7, 0.0, 0.05])
  .mutate(
    anxiety=case((C("anxiety") > 0.1, 1), else_=0),
    boredom=case((C("boredom") > 0.1, 1), else_=0),
  )
  .group_by(
    anxiety=func.sum("anxiety"),
    boredom=func.sum("boredom"),
  )
  .show()
)
```