### PR TITLE
pytorch dataset: pass cache/prefetch to DataChain instances

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1446,6 +1446,7 @@ class DataChain:
             tokenizer=tokenizer,
             tokenizer_kwargs=tokenizer_kwargs,
             num_samples=num_samples,
+            dc_settings=chain._settings,
         )
 
     def remove_file_signals(self) -> "Self":  # noqa: D102


### PR DESCRIPTION
This should enable prefetching on `to_pytorch` API. We were not passing any `settings` to the `DataChain` instances created inside `to_pytorch`, due to which it was not using `cache` or `prefetch`.

I have refrained from setting `workers`, etc. because I believe that is better left to `PytorchDataLoader` for now. 

I have found this PR to increase performance for `torch-loader.py` example by 20-25% when prefetch and cache is enabled. However, this was done on my machine and was not a scientific measurement.

Closes #631.