### PR TITLE
Allow adding new signal from existing signal field

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -402,9 +402,12 @@ class SignalSchema:
             if ModelStore.is_pydantic(finfo.annotation):
                 SignalSchema._set_file_stream(getattr(obj, field), catalog, cache)
 
-    def get_column_type(self, col_name: str) -> DataType:
+    def get_column_type(self, col_name: str, leaf_only: bool = True) -> DataType:
         for path, _type, has_subtree, _ in self.get_flat_tree():
-            if not has_subtree and DEFAULT_DELIMITER.join(path) == col_name:
+            if (
+                not (leaf_only and has_subtree)
+                and DEFAULT_DELIMITER.join(path) == col_name
+            ):
                 return _type
         raise SignalResolvingError([col_name], "is not found")
 
@@ -492,14 +495,23 @@ class SignalSchema:
                 # renaming existing signal
                 del new_values[value.name]
                 new_values[name] = self.values[value.name]
-            elif isinstance(value, Func):
+                continue
+            if isinstance(value, Column):
+                # adding new signal from existing signal field
+                try:
+                    new_values[name] = self.get_column_type(value.name, leaf_only=False)
+                    continue
+                except SignalResolvingError:
+                    pass
+            if isinstance(value, Func):
                 # adding new signal with function
                 new_values[name] = value.get_result_type(self)
-            elif isinstance(value, ColumnElement):
+                continue
+            if isinstance(value, ColumnElement):
                 # adding new signal
                 new_values[name] = sql_to_python(value)
-            else:
-                new_values[name] = value
+                continue
+            new_values[name] = value
 
         return SignalSchema(new_values)
 

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -703,6 +703,11 @@ def test_mutate_rename():
     assert schema.values == {"new_name": str}
 
 
+def test_mutate_rename_leaf(nested_file_schema):
+    schema = nested_file_schema.mutate({"new_name": Column("my_f__nested_file")})
+    assert schema.values == {**nested_file_schema.values, "new_name": File}
+
+
 def test_mutate_new_signal():
     schema = SignalSchema({"name": str})
     schema = schema.mutate({"age": Column("age", Float)})


### PR DESCRIPTION
See original issue with full example: https://github.com/iterative/datachain/issues/637
Also fix for the https://github.com/iterative/studio/issues/10989

---

Let's say we have a complex model with other models used as signals:

```python
from datachain.model.ultralytics import YoloBBoxes, YoloPoses, YoloSegments

class MyYolo(DataModel):
    bbox: YoloBBoxes
    segm: YoloSegments
    poses: YoloPoses
```

this PR allow us to use these sub-signals in `mutate` (assuming `yolo` is signal with `MyYolo` type):

```python
dc.mutate(my_poses=C("yolo.poses"))
```

then `my_poses` will be a signal with `YoloPoses` type.