### PR TITLE
Use 'setup' in HuggingFace llm example

### DIFF
--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -15,9 +15,11 @@ class DialogEval(DataModel):
 
 # DataChain function to evaluate dialog.
 # DataChain is using types for inputs, results to automatically infer schema.
-def eval_dialog(user_input: str, bot_response: str) -> DialogEval:
-    client = InferenceClient("meta-llama/Llama-3.1-70B-Instruct")
-
+def eval_dialog(
+    client: InferenceClient,
+    user_input: str,
+    bot_response: str,
+) -> DialogEval:
     completion = client.chat_completion(
         messages=[
             {
@@ -44,6 +46,7 @@ def eval_dialog(user_input: str, bot_response: str) -> DialogEval:
         "hf://datasets/infinite-dataset-hub/MobilePlanAssistant/data.csv"
     )
     .settings(parallel=10)
+    .setup(client=lambda: InferenceClient("meta-llama/Llama-3.1-70B-Instruct"))
     .map(response=eval_dialog)
     .to_parquet("hf://datasets/dvcorg/test-datachain-llm-eval/data.parquet")
 )


### PR DESCRIPTION
This might be a fix for example running in CI [failure](https://github.com/iterative/datachain/actions/runs/12021069833/job/33887783578?pr=626).

Error is:
```
429 Client Error: Too Many Requests for url: https://api-inference.huggingface.co/models/meta-llama/Llama-3.1-70B-Instruct/v1/chat/completions (Request ID: uDQ_4laxVhlqgTqG73hOX)
```

On the other hand we also do have this error in logs:
```
Model requires a Pro subscription; check out hf.co/pricing to learn more. Make sure to include your HF token in your query.
```

Same time CI run in this PR is successful so I hope this will do the trick.