### PR TITLE
order datasets and versions in list_datasets query

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -725,9 +725,10 @@ class AbstractDBMetastore(AbstractMetastore):
 
     def list_datasets(self) -> Iterator["DatasetListRecord"]:
         """Lists all datasets."""
-        yield from self._parse_dataset_list(
-            self.db.execute(self._base_list_datasets_query())
+        query = self._base_list_datasets_query().order_by(
+            self._datasets.c.name, self._datasets_versions.c.version
         )
+        yield from self._parse_dataset_list(self.db.execute(query))
 
     def list_datasets_by_prefix(
         self, prefix: str, conn=None

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -772,6 +772,38 @@ def test_dataset_stats(test_session):
     assert dataset_version2.size == 18
 
 
+def test_ls_datasets_ordered(test_session):
+    ids = [1, 2, 3]
+    values = tuple(zip(["a", "b", "c"], ids))
+
+    assert not list(test_session.catalog.ls_datasets())
+
+    dc = DataChain.from_values(
+        ids=ids,
+        file=[File(path=name, size=size) for name, size in values],
+        session=test_session,
+    )
+    dc.save("cats")
+    dc.save("dogs")
+    dc.save("cats")
+    dc.save("cats")
+    dc.save("cats")
+    datasets = list(test_session.catalog.ls_datasets())
+
+    assert [
+        (d.name, v.version)
+        for d in datasets
+        for v in d.versions
+        if not d.name.startswith("session_")
+    ] == [
+        ("cats", 1),
+        ("cats", 2),
+        ("cats", 3),
+        ("cats", 4),
+        ("dogs", 1),
+    ]
+
+
 def test_ls_datasets_no_json(test_session):
     ids = [1, 2, 3]
     values = tuple(zip(["a", "b", "c"], [1, 2, 3]))


### PR DESCRIPTION
Related to https://github.com/iterative/studio/issues/7008 & https://github.com/iterative/studio/pull/11057

By ordering the query result for list_datasets we fix a couple of downstream problems.