### PR TITLE
Add 'bit_hamming_distance' and 'byte_hamming_distance' SQLite functions

### DIFF
--- a/src/datachain/func/__init__.py
+++ b/src/datachain/func/__init__.py
@@ -17,8 +17,9 @@ from .aggregate import (
 )
 from .array import cosine_distance, euclidean_distance, length, sip_hash_64
 from .conditional import greatest, least
-from .numeric import bit_and, bit_or, bit_xor, int_hash_64
+from .numeric import bit_and, bit_hamming_distance, bit_or, bit_xor, int_hash_64
 from .random import rand
+from .string import byte_hamming_distance
 from .window import window
 
 __all__ = [
@@ -26,8 +27,10 @@ __all__ = [
     "array",
     "avg",
     "bit_and",
+    "bit_hamming_distance",
     "bit_or",
     "bit_xor",
+    "byte_hamming_distance",
     "case",
     "collect",
     "concat",

--- a/src/datachain/func/numeric.py
+++ b/src/datachain/func/numeric.py
@@ -172,9 +172,9 @@ def bit_hamming_distance(*args: Union[ColT, int]) -> Func:
     in the integer indicate higher dissimilarity.
 
     Args:
-        args (str | literal): Two integers to compute the Hamming distance between.
-            If a string is provided, it is assumed to be the name of the column.
-            If a literal is provided, it is assumed to be an integer literal.
+        args (str | int): Two integers to compute the Hamming distance between.
+            If a str is provided, it is assumed to be the name of the column.
+            If an int is provided, it is assumed to be an integer literal.
 
     Returns:
         Func: A Func object that represents the Hamming distance function.

--- a/src/datachain/func/numeric.py
+++ b/src/datachain/func/numeric.py
@@ -160,3 +160,49 @@ def int_hash_64(col: Union[ColT, int]) -> Func:
     return Func(
         "int_hash_64", inner=numeric.int_hash_64, cols=cols, args=args, result_type=int
     )
+
+
+def bit_hamming_distance(*args: Union[ColT, int]) -> Func:
+    """
+    Computes the Hamming distance between the bit representations of two integer values.
+
+    The Hamming distance is the number of positions at which the corresponding bits
+    are different. This function returns the dissimilarity between the integers,
+    where 0 indicates identical integers and values closer to the number of bits
+    in the integer indicate higher dissimilarity.
+
+    Args:
+        args (str | literal): Two integers to compute the Hamming distance between.
+            If a string is provided, it is assumed to be the name of the column.
+            If a literal is provided, it is assumed to be an integer literal.
+
+    Returns:
+        Func: A Func object that represents the Hamming distance function.
+
+    Example:
+        ```py
+        dc.mutate(
+            ham_dist=func.bit_hamming_distance("embed1", 123456s),
+        )
+        ```
+
+    Notes:
+        - Result column will always be of type int.
+    """
+    cols, func_args = [], []
+    for arg in args:
+        if isinstance(arg, int):
+            func_args.append(arg)
+        else:
+            cols.append(arg)
+
+    if len(cols) + len(func_args) != 2:
+        raise ValueError("bit_hamming_distance() requires exactly two arguments")
+
+    return Func(
+        "bit_hamming_distance",
+        inner=numeric.bit_hamming_distance,
+        cols=cols,
+        args=func_args,
+        result_type=int,
+    )

--- a/src/datachain/func/numeric.py
+++ b/src/datachain/func/numeric.py
@@ -182,7 +182,7 @@ def bit_hamming_distance(*args: Union[ColT, int]) -> Func:
     Example:
         ```py
         dc.mutate(
-            ham_dist=func.bit_hamming_distance("embed1", 123456s),
+            ham_dist=func.bit_hamming_distance("embed1", 123456),
         )
         ```
 

--- a/src/datachain/func/string.py
+++ b/src/datachain/func/string.py
@@ -174,7 +174,7 @@ def byte_hamming_distance(*args: Union[str, Func]) -> Func:
     Example:
         ```py
         dc.mutate(
-            ham_dist=func.byte_hamming_distance("embed1", "embed2"),
+            ham_dist=func.byte_hamming_distance("file.phash", literal("hello")),
         )
         ```
 

--- a/src/datachain/func/string.py
+++ b/src/datachain/func/string.py
@@ -165,8 +165,8 @@ def byte_hamming_distance(*args: Union[str, Func]) -> Func:
 
     Args:
         args (str | literal): Two strings to compute the Hamming distance between.
-            If a string is provided, it is assumed to be the name of the column.
-            If a literal is provided, it is assumed to be a string literal.
+            If a str is provided, it is assumed to be the name of the column.
+            If a Literal is provided, it is assumed to be a string literal.
 
     Returns:
         Func: A Func object that represents the Hamming distance function.

--- a/src/datachain/func/string.py
+++ b/src/datachain/func/string.py
@@ -152,3 +152,49 @@ def regexp_replace(col: Union[str, Func], regex: str, replacement: str) -> Func:
         args = None
 
     return Func("regexp_replace", inner=inner, cols=cols, args=args, result_type=str)
+
+
+def byte_hamming_distance(*args: Union[str, Func]) -> Func:
+    """
+    Computes the Hamming distance between two strings.
+
+    The Hamming distance is the number of positions at which the corresponding
+    characters are different. This function returns the dissimilarity between
+    the strings, where 0 indicates identical strings and values closer to the length
+    of the strings indicate higher dissimilarity.
+
+    Args:
+        args (str | literal): Two strings to compute the Hamming distance between.
+            If a string is provided, it is assumed to be the name of the column.
+            If a literal is provided, it is assumed to be a string literal.
+
+    Returns:
+        Func: A Func object that represents the Hamming distance function.
+
+    Example:
+        ```py
+        dc.mutate(
+            ham_dist=func.byte_hamming_distance("embed1", "embed2"),
+        )
+        ```
+
+    Notes:
+        - Result column will always be of type int.
+    """
+    cols, func_args = [], []
+    for arg in args:
+        if get_origin(arg) is literal:
+            func_args.append(arg)
+        else:
+            cols.append(arg)
+
+    if len(cols) + len(func_args) != 2:
+        raise ValueError("byte_hamming_distance() requires exactly two arguments")
+
+    return Func(
+        "byte_hamming_distance",
+        inner=string.byte_hamming_distance,
+        cols=cols,
+        args=func_args,
+        result_type=int,
+    )

--- a/src/datachain/sql/functions/numeric.py
+++ b/src/datachain/sql/functions/numeric.py
@@ -35,9 +35,21 @@ class int_hash_64(GenericFunction):  # noqa: N801
     inherit_cache = True
 
 
+class bit_hamming_distance(GenericFunction):  # noqa: N801
+    """
+    Returns the Hamming distance between two integers.
+    """
+
+    type = Int64()
+    package = "numeric"
+    name = "hamming_distance"
+    inherit_cache = True
+
+
 compiler_not_implemented(bit_and)
 compiler_not_implemented(bit_or)
 compiler_not_implemented(bit_xor)
 compiler_not_implemented(bit_rshift)
 compiler_not_implemented(bit_lshift)
 compiler_not_implemented(int_hash_64)
+compiler_not_implemented(bit_hamming_distance)

--- a/src/datachain/sql/functions/string.py
+++ b/src/datachain/sql/functions/string.py
@@ -48,7 +48,19 @@ class replace(GenericFunction):  # noqa: N801
     inherit_cache = True
 
 
+class byte_hamming_distance(GenericFunction):  # noqa: N801
+    """
+    Returns the Hamming distance between two strings.
+    """
+
+    type = Int64()
+    package = "string"
+    name = "hamming_distance"
+    inherit_cache = True
+
+
 compiler_not_implemented(length)
 compiler_not_implemented(split)
 compiler_not_implemented(regexp_replace)
 compiler_not_implemented(replace)
+compiler_not_implemented(byte_hamming_distance)

--- a/src/datachain/sql/sqlite/base.py
+++ b/src/datachain/sql/sqlite/base.py
@@ -195,7 +195,10 @@ def sqlite_int_hash_64(x: int) -> int:
 
 def sqlite_bit_hamming_distance(a: int, b: int) -> int:
     """Calculate the Hamming distance between two integers."""
-    return ((a & MAX_INT64) ^ (b & MAX_INT64)).bit_count()
+    diff = (a & MAX_INT64) ^ (b & MAX_INT64)
+    if hasattr(diff, "bit_count"):
+        return diff.bit_count()
+    return bin(diff).count("1")
 
 
 def sqlite_byte_hamming_distance(a: str, b: str) -> int:

--- a/src/datachain/sql/sqlite/base.py
+++ b/src/datachain/sql/sqlite/base.py
@@ -90,6 +90,7 @@ def setup():
     compiles(string.split, "sqlite")(compile_string_split)
     compiles(string.regexp_replace, "sqlite")(compile_string_regexp_replace)
     compiles(string.replace, "sqlite")(compile_string_replace)
+    compiles(string.byte_hamming_distance, "sqlite")(compile_byte_hamming_distance)
     compiles(conditional.greatest, "sqlite")(compile_greatest)
     compiles(conditional.least, "sqlite")(compile_least)
     compiles(Values, "sqlite")(compile_values)
@@ -104,6 +105,7 @@ def setup():
     compiles(numeric.bit_rshift, "sqlite")(compile_bitwise_rshift)
     compiles(numeric.bit_lshift, "sqlite")(compile_bitwise_lshift)
     compiles(numeric.int_hash_64, "sqlite")(compile_int_hash_64)
+    compiles(numeric.bit_hamming_distance, "sqlite")(compile_bit_hamming_distance)
 
     if load_usearch_extension(sqlite3.connect(":memory:")):
         compiles(array.cosine_distance, "sqlite")(compile_cosine_distance_ext)
@@ -191,6 +193,23 @@ def sqlite_int_hash_64(x: int) -> int:
     return x if x < 1 << 63 else (x & MAX_INT64) - (1 << 64)
 
 
+def sqlite_bit_hamming_distance(a: int, b: int) -> int:
+    """Calculate the Hamming distance between two integers."""
+    return ((a & MAX_INT64) ^ (b & MAX_INT64)).bit_count()
+
+
+def sqlite_byte_hamming_distance(a: str, b: str) -> int:
+    """Calculate the Hamming distance between two strings."""
+    diff = 0
+    if len(a) < len(b):
+        diff = len(b) - len(a)
+        b = b[: len(a)]
+    elif len(b) < len(a):
+        diff = len(a) - len(b)
+        a = a[: len(b)]
+    return diff + sum(c1 != c2 for c1, c2 in zip(a, b))
+
+
 def register_user_defined_sql_functions() -> None:
     # Register optional functions if we have the necessary dependencies
     # and otherwise register functions that will raise an exception with
@@ -225,6 +244,9 @@ def register_user_defined_sql_functions() -> None:
             "bitwise_lshift", 2, lambda a, b: a << b, deterministic=True
         )
         conn.create_function("int_hash_64", 1, sqlite_int_hash_64, deterministic=True)
+        conn.create_function(
+            "bit_hamming_distance", 2, sqlite_bit_hamming_distance, deterministic=True
+        )
 
     _registered_function_creators["numeric_functions"] = create_numeric_functions
 
@@ -236,6 +258,9 @@ def register_user_defined_sql_functions() -> None:
         conn.create_function("split", 3, sqlite_string_split, deterministic=True)
         conn.create_function(
             "regexp_replace", 3, sqlite_regexp_replace, deterministic=True
+        )
+        conn.create_function(
+            "byte_hamming_distance", 2, sqlite_byte_hamming_distance, deterministic=True
         )
 
     _registered_function_creators["string_functions"] = create_string_functions
@@ -381,6 +406,18 @@ def compile_bitwise_lshift(element, compiler, **kwargs):
 
 def compile_int_hash_64(element, compiler, **kwargs):
     return compiler.process(func.int_hash_64(*element.clauses.clauses), **kwargs)
+
+
+def compile_bit_hamming_distance(element, compiler, **kwargs):
+    return compiler.process(
+        func.bit_hamming_distance(*element.clauses.clauses), **kwargs
+    )
+
+
+def compile_byte_hamming_distance(element, compiler, **kwargs):
+    return compiler.process(
+        func.byte_hamming_distance(*element.clauses.clauses), **kwargs
+    )
 
 
 def py_json_array_length(arr):


### PR DESCRIPTION
New `bit_hamming_distance` function will allow us to calculate [hamming distance](https://en.wikipedia.org/wiki/Hamming_distance) between to numbers. This will be useful on image deduplication (see [this article](https://fullstackml.com/wavelet-image-hash-in-python-3504fdd282b5) for more details).

Also added `byte_hamming_distance` function, just because it is similar and it is worth it to add in the same PR 👀