### PR TITLE
ci: add a consolidated `check` step for required PR checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,3 +170,13 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: nox -s examples -p ${{ matrix.pyv }} -- -m "${{ matrix.group }}"
+
+  check:
+    if: always()
+    needs: [lint, datachain, examples]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-failures: examples
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This commit introduces a check step that acts as a single point of failure for specified jobs in a workflow. The step fails if any of the specified jobs fail and passes only if they succeed. This is useful for adding a single step to "Required Checks" for PR.

This avoids the need to manually add each job to "Required Checks", and reduces maintenance overhead when renaming jobs.