### PR TITLE
ci: drop macos example test run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         pyv: ['3.9', '3.12']
         group: ['get_started', 'llm_and_nlp or computer_vision', 'multimodal']
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,9 +166,12 @@ jobs:
       - name: Install nox
         run: uv pip install nox --system
 
+      # HF runs against actual API - thus run it only once
+      - name: Set hf token
+        if: matrix.os == 'ubuntu-latest' && matrix.pyv == '3.12'
+        run: echo 'HF_TOKEN=${{ secrets.HF_TOKEN }}' >> "$GITHUB_ENV"
+
       - name: Run examples
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: nox -s examples -p ${{ matrix.pyv }} -- -m "${{ matrix.group }}"
 
   check:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -15,27 +15,9 @@ get_started_examples = sorted(
     ]
 )
 
-llm_and_nlp_examples = sorted(
-    [
-        filename
-        for filename in glob.glob("examples/llm_and_nlp/**/*.py", recursive=True)
-        # no anthropic token, HF runs against actual API - thus run it only once
-        if "claude" not in filename
-        and (
-            "hf-" not in filename
-            or (sys.platform == "darwin" and sys.version_info >= (3, 12))
-        )
-    ]
-)
+llm_and_nlp_examples = sorted(glob.glob("examples/llm_and_nlp/**/*.py", recursive=True))
 
-multimodal_examples = sorted(
-    [
-        filename
-        for filename in glob.glob("examples/multimodal/**/*.py", recursive=True)
-        # no OpenAI token
-        if "openai" not in filename
-    ]
-)
+multimodal_examples = sorted(glob.glob("examples/multimodal/**/*.py", recursive=True))
 
 computer_vision_examples = sorted(
     [
@@ -84,6 +66,14 @@ def test_get_started_examples(example):
 @pytest.mark.llm_and_nlp
 @pytest.mark.parametrize("example", llm_and_nlp_examples)
 def test_llm_and_nlp_examples(example):
+    name = os.path.basename(example)
+    if "hf-" in name:
+        import huggingface_hub
+
+        if not huggingface_hub.get_token():
+            pytest.skip("Hugging Face token not set")
+    if "claude" in name and "ANTHROPIC_API_KEY" not in os.environ:
+        pytest.skip("ANTHROPIC_API_KEY not set")
     smoke_test(example)
 
 
@@ -91,6 +81,8 @@ def test_llm_and_nlp_examples(example):
 @pytest.mark.multimodal
 @pytest.mark.parametrize("example", multimodal_examples)
 def test_multimodal(example):
+    if "openai" in os.path.basename(example) and "OPENAI_API_KEY" not in os.environ:
+        pytest.skip("OPENAI_API_KEY not set")
     smoke_test(
         example,
         {


### PR DESCRIPTION
GHA only provides 5 concurrent macOS jobs for a team. Running 8 macOS jobs for "examples" (for a single PR) is excessive, and frankly unnecessary here, since they are more or less covered in `ubuntu-latest`.

This makes us wait a lot of time before the PR succeeds, especially when GHA is overloaded.