### PR TITLE
Fix 'unstructured-summary-map' example

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -79,6 +79,7 @@ def dev(session: nox.Session) -> None:
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"])
 def examples(session: nox.Session) -> None:
     session.install(".[examples]")
+    session.run("uv", "pip", "list")
     session.run(
         "pytest",
         "-m",


### PR DESCRIPTION
- Added `pip list` step on examples run to be able to easily see requirements changes in future.
- Stick `unstructured[pdf,embed-huggingface]` requirement to `<0.15.13`