### PR TITLE
Implement cancel job operation for CLI

### DIFF
--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -294,6 +294,28 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         help="Python package requirement. Can be specified multiple times.",
     )
 
+    studio_cancel_help = "Cancel a job in Studio"
+    studio_cancel_description = "This command cancels a job in Studio."
+
+    studio_cancel_parser = studio_subparser.add_parser(
+        "cancel",
+        parents=[parent_parser],
+        description=studio_cancel_description,
+        help=studio_cancel_help,
+    )
+
+    studio_cancel_parser.add_argument(
+        "job_id",
+        action="store",
+        help="The job ID to cancel.",
+    )
+    studio_cancel_parser.add_argument(
+        "--team",
+        action="store",
+        default=None,
+        help="The team to cancel a job for. By default, it will use team from config.",
+    )
+
 
 def get_parser() -> ArgumentParser:  # noqa: PLR0915
     try:

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -359,3 +359,10 @@ class StudioClient:
             "requirements": requirements,
         }
         return self._send_request("datachain/job", data)
+
+    def cancel_job(
+        self,
+        job_id: str,
+    ) -> Response[JobData]:
+        url = f"datachain/job/{job_id}/cancel"
+        return self._send_request(url, data={}, method="POST")

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -19,7 +19,7 @@ POST_LOGIN_MESSAGE = (
 )
 
 
-def process_studio_cli_args(args: "Namespace"):
+def process_studio_cli_args(args: "Namespace"):  # noqa: PLR0911
     if args.cmd == "login":
         return login(args)
     if args.cmd == "logout":
@@ -46,6 +46,9 @@ def process_studio_cli_args(args: "Namespace"):
             args.req,
             args.req_file,
         )
+
+    if args.cmd == "cancel":
+        return cancel_job(args.job_id, args.team)
 
     if args.cmd == "team":
         return set_team(args)
@@ -248,3 +251,18 @@ def upload_files(client: StudioClient, files: list[str]) -> list[str]:
         if file_id:
             file_ids.append(str(file_id))
     return file_ids
+
+
+def cancel_job(job_id: str, team_name: Optional[str]):
+    token = Config().read().get("studio", {}).get("token")
+    if not token:
+        raise DataChainError(
+            "Not logged in to Studio. Log in with 'datachain studio login'."
+        )
+
+    client = StudioClient(team=team_name)
+    response = client.cancel_job(job_id)
+    if not response.ok:
+        raise_remote_error(response.message)
+
+    print(f"Job {job_id} canceled")

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -291,6 +291,24 @@ def test_studio_rm_dataset(capsys, mocker):
         }
 
 
+def test_studio_cancel_job(capsys, mocker):
+    job_id = "8bddde6c-c3ca-41b0-9d87-ee945bfdce70"
+    with requests_mock.mock() as m:
+        m.post(f"{STUDIO_URL}/api/datachain/job/{job_id}/cancel", json={})
+
+        # Studio token is required
+        assert main(["studio", "cancel", job_id]) == 1
+        out = capsys.readouterr().err
+        assert "Not logged in to Studio" in out
+
+        # Set the studio token
+        with Config(ConfigLevel.GLOBAL).edit() as conf:
+            conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
+
+        assert main(["studio", "cancel", job_id]) == 0
+        assert m.called
+
+
 def test_studio_run(capsys, mocker, tmp_dir):
     with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token", "team": "team_name"}


### PR DESCRIPTION
This introduces a cancel job operation for CLI that can be used to
cancel a job running in studio.

Command:
`datachain studio cancel <JOB_ID`
