### PR TITLE
fix(listing): pick exact or create new one on update

### DIFF
--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -840,13 +840,17 @@ def test_listing_stats(cloud_test_catalog):
 
     catalog.enlist_source(f"{src_uri}/dogs/", update=True)
     stats = listing_stats(src_uri, catalog)
+    assert stats.num_objects == 7
+    assert stats.size == 36
+
+    stats = listing_stats(f"{src_uri}/dogs/", catalog)
     assert stats.num_objects == 4
     assert stats.size == 15
 
     catalog.enlist_source(f"{src_uri}/dogs/")
     stats = listing_stats(src_uri, catalog)
-    assert stats.num_objects == 4
-    assert stats.size == 15
+    assert stats.num_objects == 7
+    assert stats.size == 36
 
 
 @pytest.mark.parametrize("cloud_type", ["s3", "azure", "gs"], indirect=True)


### PR DESCRIPTION
Partially addresses and stabilizes https://github.com/iterative/datachain/issues/725

Fixes a few situations in the way we find and suggest an existing cached listing when we do an `update=True`.

## 1. There was a bug in the origin code:

```python
# choosing the smallest possible one to minimize update time
listing = sorted(listings, key=lambda ls: len(ls.name))[0]
```

This code actually was picking the "biggest" one instead. There should have been `reverse=True`.

So, in a situation like:

`file:///whatever/dir1` exists and cached
`file:///whatever/` exists and cached

and we were trying to update the `file:///whatever/dir1` - it was updating the `file:///whatever/` instead.

## 2. Then, in a situation like:

`file:///whatever/` exists and cached
`file:///whatever/dir1` doesn't yet exist

and we do "update=True" for the `file:///whatever/dir1`

it was updating the whole `file:///whatever/` which can be arbitrary large. And we don't want to do this.

## So, bottom line is:

 Generalizing a bit code for both of those cases led to the code in this PR.
