### PR TITLE
fix(session): keep cached successful listings

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1617,7 +1617,9 @@ class DatasetQuery:
             )
             version = version or dataset.latest_version
 
-            self.session.add_dataset_version(dataset=dataset, version=version)
+            self.session.add_dataset_version(
+                dataset=dataset, version=version, listing=kwargs.get("listing", False)
+            )
 
             dr = self.catalog.warehouse.dataset_rows(dataset)
 

--- a/tests/func/test_session.py
+++ b/tests/func/test_session.py
@@ -1,0 +1,25 @@
+import pytest
+
+from datachain import DataChain
+from datachain.error import DatasetNotFoundError
+from datachain.query.session import Session
+
+
+def test_listing_dataset_lifecycle(tmp_path, catalog):
+    p = tmp_path / "hello.txt"
+    p.write_text("hello", encoding="utf-8")
+
+    session_name = "asd3d5"
+    ds_name = "my_test_ds13"
+
+    with pytest.raises(ValueError):
+        with Session(session_name, catalog=catalog):
+            ds_name = "my_test_ds13"
+            DataChain.from_storage(str(tmp_path)).exec()
+            DataChain.from_values(key=["a", "b", "c"]).save(ds_name)
+            raise ValueError("This is a test exception")
+
+    with pytest.raises(DatasetNotFoundError):
+        tmp_path, catalog.get_dataset(ds_name)
+
+    assert DataChain.listings(catalog=catalog).count() == 1


### PR DESCRIPTION
As found during debugging this use case https://github.com/iterative/datachain/issues/724 - it's better to keep already cached listing, otherwise some small operations become slow to iterate until you fully sure that script is running, and the script on every run does the same indexing, every single time. There is no reason for that to my mind.

## TODO:

- [x] See if we need tests