### PR TITLE
fix(dc): move parse uri and rename out of main class

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -52,6 +52,7 @@ from datachain.error import (
     QueryScriptCancelError,
     QueryScriptRunError,
 )
+from datachain.lib.listing import get_listing
 from datachain.node import DirType, Node, NodeWithPath
 from datachain.nodes_thread_pool import NodesThreadPool
 from datachain.remote.studio import StudioClient
@@ -599,7 +600,7 @@ class Catalog:
             source, session=self.session, update=update, object_name=object_name
         )
 
-        list_ds_name, list_uri, list_path, _ = DataChain.parse_uri(
+        list_ds_name, list_uri, list_path, _ = get_listing(
             source, self.session, update=update
         )
 
@@ -697,11 +698,9 @@ class Catalog:
                 )
                 indexed_sources = []
                 for source in dataset_sources:
-                    from datachain.lib.dc import DataChain
-
                     client = self.get_client(source, **client_config)
                     uri = client.uri
-                    dataset_name, _, _, _ = DataChain.parse_uri(uri, self.session)
+                    dataset_name, _, _, _ = get_listing(uri, self.session)
                     listing = Listing(
                         self.metastore.clone(),
                         self.warehouse.clone(),

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -15,6 +15,7 @@ from datachain.utils import uses_glob
 
 if TYPE_CHECKING:
     from datachain.lib.dc import DataChain
+    from datachain.query.session import Session
 
 LISTING_TTL = 4 * 60 * 60  # cached listing lasts 4 hours
 LISTING_PREFIX = "lst__"  # listing datasets start with this name
@@ -108,3 +109,46 @@ def listing_uri_from_name(dataset_name: str) -> str:
     if not is_listing_dataset(dataset_name):
         raise ValueError(f"Dataset {dataset_name} is not a listing")
     return dataset_name.removeprefix(LISTING_PREFIX)
+
+
+def get_listing(
+    uri: str, session: "Session", update: bool = False
+) -> tuple[str, str, str, bool]:
+    """Returns correct listing dataset name that must be used for saving listing
+    operation. It takes into account existing listings and reusability of those.
+    It also returns boolean saying if returned dataset name is reused / already
+    exists or not (on update it always returns False - just because there was no
+    reason to complicate it so far). And it returns correct listing path that should
+    be used to find rows based on uri.
+    """
+    from datachain.client.local import FileClient
+
+    catalog = session.catalog
+    cache = catalog.cache
+    client_config = catalog.client_config
+
+    client = Client.get_client(uri, cache, **client_config)
+    ds_name, list_uri, list_path = parse_listing_uri(uri, cache, client_config)
+    listing = None
+
+    listings = [
+        ls for ls in catalog.listings() if not ls.is_expired and ls.contains(ds_name)
+    ]
+
+    # if no need to update - choosing the most recent one;
+    # otherwise, we'll using the exact original `ds_name`` in this case:
+    # - if a "bigger" listing exists, we don't want to update it, it's better
+    #   to create a new "smaller" one on "update=True"
+    # - if an exact listing exists it will have the same name as `ds_name`
+    #   anyway below
+    if listings and not update:
+        listing = sorted(listings, key=lambda ls: ls.created_at)[-1]
+
+    # for local file system we need to fix listing path / prefix
+    # if we are reusing existing listing
+    if isinstance(client, FileClient) and listing and listing.name != ds_name:
+        list_path = f'{ds_name.strip("/").removeprefix(listing.name)}/{list_path}'
+
+    ds_name = listing.name if listing else ds_name
+
+    return ds_name, list_uri, list_path, bool(listing)

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -8,6 +8,7 @@ from datachain.lib.dc import DataChain
 from datachain.lib.file import File
 from datachain.lib.listing import (
     LISTING_PREFIX,
+    get_listing,
     is_listing_dataset,
     listing_uri_from_name,
     parse_listing_uri,
@@ -39,7 +40,7 @@ def _tree_to_entries(tree: dict, path=""):
 @pytest.fixture
 def listing(test_session):
     catalog = test_session.catalog
-    dataset_name, _, _, _ = DataChain.parse_uri("file:///whatever", test_session)
+    dataset_name, _, _, _ = get_listing("file:///whatever", test_session)
     DataChain.from_values(file=list(_tree_to_entries(TREE))).save(
         dataset_name, listing=True
     )
@@ -53,26 +54,24 @@ def listing(test_session):
     )
 
 
-def test_parse_uri_returns_exact_math_on_update(test_session):
+def test_get_listing_returns_exact_math_on_update(test_session):
     # Context: https://github.com/iterative/datachain/pull/726
     # On update it should be returning the exact match (not a "bigger" one)
-    dataset_name_dir1, _, _, exists = DataChain.parse_uri(
-        "file:///whatever/dir1", test_session
-    )
+    dataset_name_dir1, _, _, exists = get_listing("file:///whatever/dir1", test_session)
     DataChain.from_values(file=list(_tree_to_entries(TREE["dir1"]))).save(
         dataset_name_dir1, listing=True
     )
     assert dataset_name_dir1 == f"{LISTING_PREFIX}file:///whatever/dir1/"
     assert not exists
 
-    dataset_name, _, _, exists = DataChain.parse_uri("file:///whatever", test_session)
+    dataset_name, _, _, exists = get_listing("file:///whatever", test_session)
     DataChain.from_values(file=list(_tree_to_entries(TREE))).save(
         dataset_name, listing=True
     )
     assert dataset_name == f"{LISTING_PREFIX}file:///whatever/"
     assert not exists
 
-    dataset_name_dir1, _, _, exists = DataChain.parse_uri(
+    dataset_name_dir1, _, _, exists = get_listing(
         "file:///whatever/dir1", test_session, update=True
     )
     assert dataset_name_dir1 == f"{LISTING_PREFIX}file:///whatever/dir1/"


### PR DESCRIPTION
Moves `parse_uri` out of public DC methods + renames it a bit to make move obvious hopefully.