### PR TITLE
fix(from_storage): no listing / cache on a single file

### DIFF
--- a/src/datachain/catalog/datasource.py
+++ b/src/datachain/catalog/datasource.py
@@ -4,21 +4,19 @@ from datachain.node import DirType, NodeWithPath
 
 
 class DataSource:
-    def __init__(self, listing, node, as_container=False):
+    def __init__(self, listing, client, node, as_container=False):
         self.listing = listing
+        self.client = client
         self.node = node
         self.as_container = (
             as_container  # Indicates whether a .tar file is handled as a container
         )
 
-    def get_full_path(self):
-        return self.get_node_full_path(self.node)
-
     def get_node_full_path(self, node):
-        return self.listing.client.get_full_path(node.full_path)
+        return self.client.get_full_path(node.full_path)
 
     def get_node_full_path_from_path(self, full_path):
-        return self.listing.client.get_full_path(full_path)
+        return self.client.get_full_path(full_path)
 
     def is_single_object(self):
         return self.node.dir_type == DirType.FILE or (

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -204,6 +204,10 @@ class Client(ABC):
         info = await self.fs._info(self.get_full_path(file.path))
         return self.info_to_file(info, "").etag
 
+    def get_file_info(self, path: str) -> "File":
+        info = self.fs.info(self.get_full_path(path))
+        return self.info_to_file(info, path)
+
     async def get_size(self, path: str) -> int:
         return await self.fs._size(path)
 

--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -92,6 +92,7 @@ class DatasetDependency:
             return self.name
 
         list_dataset_name, _, _ = parse_listing_uri(self.name.strip("/"), None, {})
+        assert list_dataset_name
         return list_dataset_name
 
     @classmethod

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -94,7 +94,7 @@ def parse_listing_uri(uri: str, cache, client_config) -> tuple[Optional[str], st
     storage_uri, path = Client.parse_url(uri)
     telemetry.log_param("client", client.PREFIX)
 
-    if client.fs.isfile(uri):
+    if not uri.endswith("/") and client.fs.isfile(uri):
         return None, f'{storage_uri}/{path.lstrip("/")}', path
     if uses_glob(path):
         lst_uri_path = posixpath.dirname(path)

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -39,6 +39,15 @@ def list_bucket(uri: str, cache, client_config=None) -> Callable:
     return list_func
 
 
+def get_file_info(uri: str, cache, client_config=None) -> File:
+    """
+    Wrapper to return File object by its URI
+    """
+    client = Client.get_client(uri, cache, **(client_config or {}))  # type: ignore[arg-type]
+    _, path = Client.parse_url(uri)
+    return client.get_file_info(path)
+
+
 def ls(
     dc: D,
     path: str,
@@ -76,7 +85,7 @@ def ls(
     return dc.filter(pathfunc.parent(_file_c("path")) == path.lstrip("/").rstrip("/*"))
 
 
-def parse_listing_uri(uri: str, cache, client_config) -> tuple[str, str, str]:
+def parse_listing_uri(uri: str, cache, client_config) -> tuple[Optional[str], str, str]:
     """
     Parsing uri and returns listing dataset name, listing uri and listing path
     """
@@ -85,7 +94,9 @@ def parse_listing_uri(uri: str, cache, client_config) -> tuple[str, str, str]:
     storage_uri, path = Client.parse_url(uri)
     telemetry.log_param("client", client.PREFIX)
 
-    if uses_glob(path) or client.fs.isfile(uri):
+    if client.fs.isfile(uri):
+        return None, f'{storage_uri}/{path.lstrip("/")}', path
+    if uses_glob(path):
         lst_uri_path = posixpath.dirname(path)
     else:
         storage_uri, path = Client.parse_url(f'{uri.rstrip("/")}/')
@@ -113,7 +124,7 @@ def listing_uri_from_name(dataset_name: str) -> str:
 
 def get_listing(
     uri: str, session: "Session", update: bool = False
-) -> tuple[str, str, str, bool]:
+) -> tuple[Optional[str], str, str, bool]:
     """Returns correct listing dataset name that must be used for saving listing
     operation. It takes into account existing listings and reusability of those.
     It also returns boolean saying if returned dataset name is reused / already
@@ -130,6 +141,10 @@ def get_listing(
     client = Client.get_client(uri, cache, **client_config)
     ds_name, list_uri, list_path = parse_listing_uri(uri, cache, client_config)
     listing = None
+
+    # if we don't want to use cached dataset (e.g. for a single file listing)
+    if not ds_name:
+        return None, list_uri, list_path, False
 
     listings = [
         ls for ls in catalog.listings() if not ls.is_expired and ls.contains(ds_name)

--- a/src/datachain/listing.py
+++ b/src/datachain/listing.py
@@ -157,11 +157,7 @@ class Listing:
 
         counter = 0
         for node in all_nodes:
-            dst = os.path.join(output, *node.path)
-            dst_dir = os.path.dirname(dst)
-            os.makedirs(dst_dir, exist_ok=True)
-            file = node.n.to_file(self.client.uri)
-            self.client.instantiate_object(file, dst, progress_bar, force)
+            node.instantiate(self.client, output, progress_bar, force=force)
             counter += 1
             if counter > 1000:
                 progress_bar.update(counter)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -136,7 +136,9 @@ def test_from_storage_partials(cloud_test_catalog):
     catalog = session.catalog
 
     def _list_dataset_name(uri: str) -> str:
-        return parse_listing_uri(uri, catalog.cache, catalog.client_config)[0]
+        name = parse_listing_uri(uri, catalog.cache, catalog.client_config)[0]
+        assert name
+        return name
 
     dogs_uri = f"{src_uri}/dogs"
     DataChain.from_storage(dogs_uri, session=session)
@@ -178,7 +180,9 @@ def test_from_storage_partials_with_update(cloud_test_catalog):
     catalog = session.catalog
 
     def _list_dataset_name(uri: str) -> str:
-        return parse_listing_uri(uri, catalog.cache, catalog.client_config)[0]
+        name = parse_listing_uri(uri, catalog.cache, catalog.client_config)[0]
+        assert name
+        return name
 
     uri = f"{src_uri}/cats"
     DataChain.from_storage(uri, session=session)

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -161,7 +161,7 @@ def test_list_dir(listing):
 
 def test_list_file(listing):
     file = listing.resolve_path("dir1/dataset.csv")
-    src = DataSource(listing, file)
+    src = DataSource(listing, listing.client, file)
     results = list(src.ls(["sys__id", "name", "dir_type"]))
     assert {r[1] for r in results} == {"dataset.csv"}
     assert results[0][0] == file.sys__id


### PR DESCRIPTION
Adjusts `from_storage` to avoid creating a listing / or using a listing cache when we need a single file. In this case we are creating a single entry DC right away.

This speedups a lot simple cases when you need a single file from a repo and it stars indexing all files around. It won't do this again.

Also, it won't be failing by hitting the previously cached index when we just write and then read a single file.