### PR TITLE
Return url for file in GCP public bucket instead of error

### DIFF
--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -32,6 +32,14 @@ class GCSClient(Client):
 
         return cast(GCSFileSystem, super().create_fs(**kwargs))
 
+    def url(self, path: str, expires: int = 3600, **kwargs) -> str:
+        try:
+            return self.fs.sign(self.get_full_path(path), expiration=expires, **kwargs)
+        except AttributeError as exc:
+            if "you need a private key to sign credentials" in str(exc):
+                return f"https://storage.googleapis.com/{self.name}/{path}"
+            raise
+
     @staticmethod
     def parse_timestamp(timestamp: str) -> datetime:
         """

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -36,7 +36,8 @@ class GCSClient(Client):
         try:
             return self.fs.sign(self.get_full_path(path), expiration=expires, **kwargs)
         except AttributeError as exc:
-            if "you need a private key to sign credentials" in str(exc):
+            is_anon = self.fs.storage_options.get("token") == "anon"
+            if is_anon and "you need a private key to sign credentials" in str(exc):
                 return f"https://storage.googleapis.com/{self.name}/{path}"
             raise
 

--- a/tests/unit/test_client_gcs.py
+++ b/tests/unit/test_client_gcs.py
@@ -1,0 +1,6 @@
+from datachain.client import Client
+
+
+def test_anon_url():
+    client = Client.get_client("gs://foo", None, anon=True)
+    assert client.url("bar") == "https://storage.googleapis.com/foo/bar"

--- a/tests/unit/test_client_gcs.py
+++ b/tests/unit/test_client_gcs.py
@@ -1,6 +1,17 @@
 from datachain.client import Client
 
 
-def test_anon_url():
+def test_anon_url(mocker):
+    def sign(*args, **kwargs):
+        raise AttributeError(
+            "you need a private key to sign credentials."
+            "the credentials you are currently using"
+            " <class 'google.oauth2.credentials.Credentials'> just contains a token."
+            " see https://googleapis.dev/python/google-api-core/latest/auth.html"
+            "#setting-up-a-service-account for more details."
+        )
+
+    mocker.patch("gcsfs.GCSFileSystem.sign", side_effect=sign)
+
     client = Client.get_client("gs://foo", None, anon=True)
     assert client.url("bar") == "https://storage.googleapis.com/foo/bar"


### PR DESCRIPTION
When retrieving URL for file in GCP bucket if this bucket is public and we have no GCP credentials set, error will be raised.

In this PR we are returning public download URL in this case instead of exception.

Note: I think we need to do the same for other types of storages.