### PR TITLE
Return url for file in GCP public bucket instead of error

### DIFF
--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -35,19 +35,12 @@ class GCSClient(Client):
     def url(self, path: str, expires: int = 3600, **kwargs) -> str:
         """
         Generate a signed URL for the given path.
-        If the client is anonymous, a public URL is returned instead.
+        If the client is anonymous, a public URL is returned instead
+        (see https://cloud.google.com/storage/docs/access-public-data#api-link).
         """
-        fs = cast(GCSFileSystem, self.fs)
-        if fs.storage_options.get("token") == "anon":
-            return self.public_url(path)
-        return fs.sign(self.get_full_path(path), expiration=expires, **kwargs)
-
-    def public_url(self, path: str) -> str:
-        """
-        Generate a public URL for the given path.
-        See https://cloud.google.com/storage/docs/access-public-data#api-link
-        """
-        return f"https://storage.googleapis.com/{self.name}/{path}"
+        if self.fs.storage_options.get("token") == "anon":
+            return f"https://storage.googleapis.com/{self.name}/{path}"
+        return self.fs.sign(self.get_full_path(path), expiration=expires, **kwargs)
 
     @staticmethod
     def parse_timestamp(timestamp: str) -> datetime:

--- a/tests/unit/test_client_gcs.py
+++ b/tests/unit/test_client_gcs.py
@@ -1,17 +1,6 @@
 from datachain.client import Client
 
 
-def test_anon_url(mocker):
-    def sign(*args, **kwargs):
-        raise AttributeError(
-            "you need a private key to sign credentials."
-            "the credentials you are currently using"
-            " <class 'google.oauth2.credentials.Credentials'> just contains a token."
-            " see https://googleapis.dev/python/google-api-core/latest/auth.html"
-            "#setting-up-a-service-account for more details."
-        )
-
-    mocker.patch("gcsfs.GCSFileSystem.sign", side_effect=sign)
-
+def test_anon_url():
     client = Client.get_client("gs://foo", None, anon=True)
     assert client.url("bar") == "https://storage.googleapis.com/foo/bar"


### PR DESCRIPTION
Follow-up for the https://github.com/iterative/datachain/pull/748

If no Google Cloud credentials were set we still get an error in SaaS. This fix will allow us to return public URL without trying to sign it if `anon=True` is set.

I also can confirm this will works for public AWS S3 buckets without any changes. It will return public URL right out of the box.