### PR TITLE
Fix Storage abstract Client 'info_to_file' signature

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -211,7 +211,7 @@ class Client(ABC):
         info = await self.fs._info(
             self.get_full_path(file.path, file.version), **kwargs
         )
-        return self.info_to_file(info, "").etag
+        return self.info_to_file(info, file.path).etag
 
     def get_file_info(self, path: str, version_id: Optional[str] = None) -> "File":
         info = self.fs.info(self.get_full_path(path, version_id), version_id=version_id)
@@ -339,7 +339,7 @@ class Client(ABC):
         return self.version_path(f"{self.PREFIX}{self.name}/{rel_path}", version_id)
 
     @abstractmethod
-    def info_to_file(self, v: dict[str, Any], parent: str) -> "File": ...
+    def info_to_file(self, v: dict[str, Any], path: str) -> "File": ...
 
     def fetch_nodes(
         self,

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -364,7 +364,7 @@ class File(DataModel):
 
         try:
             info = client.fs.info(client.get_full_path(self.path))
-            converted_info = client.info_to_file(info, self.source)
+            converted_info = client.info_to_file(info, self.path)
             return type(self)(
                 path=self.path,
                 source=self.source,


### PR DESCRIPTION
In Storage `Client` abstract class we do have `info_to_file` method. All it implementation have `path` param, but in abstract class this is `parent` param. This PR is going to fix this error.