### PR TITLE
fix: better message if no files passed on parse tabular

### DIFF
--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -149,6 +149,10 @@ def infer_schema(chain: "DataChain", **kwargs) -> pa.Schema:
     for file in chain.collect("file"):
         ds = dataset(file.get_path(), filesystem=file.get_fs(), **kwargs)  # type: ignore[union-attr]
         schemas.append(ds.schema)
+    if not schemas:
+        raise ValueError(
+            "Cannot infer schema (no files to process or can't access them)"
+        )
     return pa.unify_schemas(schemas)
 
 

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1882,6 +1882,9 @@ class DataChain:
                     "`nrows` only supported for csv and json formats.",
                 )
 
+        if "file" not in self.schema or not self.count():
+            raise DatasetPrepareError(self.name, "no files to parse.")
+
         schema = None
         col_names = output if isinstance(output, Sequence) else None
         if col_names or not output:

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -10,9 +10,11 @@ from datasets import Dataset
 from datachain.lib.arrow import (
     ArrowGenerator,
     arrow_type_mapper,
+    infer_schema,
     schema_to_output,
 )
 from datachain.lib.data_model import dict_to_data_model
+from datachain.lib.dc import DataChain
 from datachain.lib.file import ArrowRow, File
 from datachain.lib.hf import HFClassLabel
 
@@ -264,3 +266,10 @@ def test_parquet_override_column_names_invalid():
     col_names = ["n1", "n2", "n3"]
     with pytest.raises(ValueError):
         schema_to_output(schema, col_names)
+
+
+def test_infer_schema_no_files(test_session):
+    schema = {"file": File, "my_col": int}
+    dc = DataChain.from_records([], schema=schema, session=test_session, in_memory=True)
+    with pytest.raises(ValueError):
+        infer_schema(dc)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 
 from datachain import Column
 from datachain.lib.data_model import DataModel
-from datachain.lib.dc import C, DataChain, Sys
+from datachain.lib.dc import C, DataChain, DatasetPrepareError, Sys
 from datachain.lib.file import File
 from datachain.lib.listing import LISTING_PREFIX
 from datachain.lib.listing_info import ListingInfo
@@ -1068,10 +1068,18 @@ def test_parse_tabular_partitions(tmp_dir, test_session):
     assert df_equal(df1, df.loc[:0])
 
 
-def test_parse_tabular_empty(tmp_dir, test_session):
-    path = tmp_dir / "test.parquet"
-    with pytest.raises(FileNotFoundError):
-        DataChain.from_storage(path.as_uri(), session=test_session).parse_tabular()
+def test_parse_tabular_no_files(test_session):
+    dc = DataChain.from_values(
+        f1=features, num=range(len(features)), session=test_session, in_memory=True
+    )
+    with pytest.raises(DatasetPrepareError):
+        dc.parse_tabular()
+
+    schema = {"file": File, "my_col": int}
+    dc = DataChain.from_records([], schema=schema, session=test_session, in_memory=True)
+
+    with pytest.raises(DatasetPrepareError):
+        dc.parse_tabular()
 
 
 def test_parse_tabular_unify_schema(tmp_dir, test_session):


### PR DESCRIPTION
The last less critical item from https://github.com/iterative/datachain/issues/725. 

Closes #725

If there is no file, before we were getting: 

`datachain.lib.dc.DatasetPrepareError: Dataset processing prepare error: Must provide at least one schema to unify.`

on a query like this: 

`dataset_chain = DataChain.from_parquet("file.parquet")` if `file.parquet` doesn't exist

now we are getting:

`datachain.lib.dc.DatasetPrepareError: Dataset processing prepare error: no files to parse.`

## TODO

- Add test
