### PR TITLE
Move jobs related commands under jobs and introduce logs

### DIFF
--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -113,7 +113,7 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
         "This will help us to run, cancel and view the status of the job in Studio. "
     )
     jobs_parser = subparsers.add_parser(
-        "jobs", parents=[parent_parser], description=jobs_description, help=jobs_help
+        "job", parents=[parent_parser], description=jobs_description, help=jobs_help
     )
     jobs_subparser = jobs_parser.add_subparsers(
         dest="cmd",
@@ -344,7 +344,7 @@ def add_studio_parser(subparsers, parent_parser) -> None:
     )
 
     ls_dataset_parser = studio_subparser.add_parser(
-        "datasets",
+        "dataset",
         parents=[parent_parser],
         description=studio_ls_dataset_description,
         help=studio_ls_dataset_help,
@@ -483,7 +483,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
     add_jobs_parser(subp, parent_parser)
 
     datasets_parser = subp.add_parser(
-        "datasets",
+        "dataset",
         aliases=["ds"],
         parents=[parent_parser],
         description="Commands for managing datasers",
@@ -1356,7 +1356,7 @@ def main(argv: Optional[list[str]] = None) -> int:  # noqa: C901, PLR0912, PLR09
                 edatachain=args.edatachain,
                 edatachain_file=args.edatachain_file,
             )
-        elif args.command in ("datasets", "ds"):
+        elif args.command in ("dataset", "ds"):
             if args.datasets_cmd == "pull":
                 catalog.pull_dataset(
                     args.dataset,
@@ -1481,7 +1481,7 @@ def main(argv: Optional[list[str]] = None) -> int:  # noqa: C901, PLR0912, PLR09
             garbage_collect(catalog)
         elif args.command == "studio":
             process_studio_cli_args(args)
-        elif args.command == "jobs":
+        elif args.command == "job":
             process_jobs_args(args)
         else:
             print(f"invalid command: {args.command}", file=sys.stderr)

--- a/src/datachain/cli.py
+++ b/src/datachain/cli.py
@@ -21,6 +21,7 @@ from datachain.lib.dc import DataChain
 from datachain.studio import (
     edit_studio_dataset,
     list_datasets,
+    process_jobs_args,
     process_studio_cli_args,
     remove_studio_dataset,
 )
@@ -103,6 +104,128 @@ def add_show_args(parser: ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="Do not collapse the columns",
+    )
+
+
+def add_jobs_parser(subparsers, parent_parser) -> None:
+    jobs_help = "Commands to handle the Job running with Iterative Studio"
+    jobs_description = (
+        "This will help us to run, cancel and view the status of the job in Studio. "
+    )
+    jobs_parser = subparsers.add_parser(
+        "jobs", parents=[parent_parser], description=jobs_description, help=jobs_help
+    )
+    jobs_subparser = jobs_parser.add_subparsers(
+        dest="cmd",
+        help="Use `DataChain studio CMD --help` to display command-specific help.",
+        required=True,
+    )
+
+    studio_run_help = "Run a job in Studio"
+    studio_run_description = "This command runs a job in Studio."
+
+    studio_run_parser = jobs_subparser.add_parser(
+        "run",
+        parents=[parent_parser],
+        description=studio_run_description,
+        help=studio_run_help,
+    )
+
+    studio_run_parser.add_argument(
+        "query_file",
+        action="store",
+        help="The query file to run.",
+    )
+
+    studio_run_parser.add_argument(
+        "--team",
+        action="store",
+        default=None,
+        help="The team to run a job for. By default, it will use team from config.",
+    )
+    studio_run_parser.add_argument(
+        "--env-file",
+        action="store",
+        help="File containing environment variables to set for the job.",
+    )
+
+    studio_run_parser.add_argument(
+        "--env",
+        nargs="+",
+        help="Environment variable. Can be specified multiple times. Format: KEY=VALUE",
+    )
+
+    studio_run_parser.add_argument(
+        "--workers",
+        type=int,
+        help="Number of workers to use for the job.",
+    )
+    studio_run_parser.add_argument(
+        "--files",
+        nargs="+",
+        help="Files to include in the job.",
+    )
+    studio_run_parser.add_argument(
+        "--python-version",
+        action="store",
+        help="Python version to use for the job (e.g. '3.9', '3.10', '3.11').",
+    )
+    studio_run_parser.add_argument(
+        "--req-file",
+        action="store",
+        help="File containing Python package requirements.",
+    )
+
+    studio_run_parser.add_argument(
+        "--req",
+        nargs="+",
+        help="Python package requirement. Can be specified multiple times.",
+    )
+
+    studio_cancel_help = "Cancel a job in Studio"
+    studio_cancel_description = "This command cancels a job in Studio."
+
+    studio_cancel_parser = jobs_subparser.add_parser(
+        "cancel",
+        parents=[parent_parser],
+        description=studio_cancel_description,
+        help=studio_cancel_help,
+    )
+
+    studio_cancel_parser.add_argument(
+        "job_id",
+        action="store",
+        help="The job ID to cancel.",
+    )
+    studio_cancel_parser.add_argument(
+        "--team",
+        action="store",
+        default=None,
+        help="The team to cancel a job for. By default, it will use team from config.",
+    )
+
+    studio_log_help = "Show the logs and latest status of Jobs in Studio"
+    studio_log_description = (
+        "This will display the logs and latest status of jobs in Studio"
+    )
+
+    studio_log_parser = jobs_subparser.add_parser(
+        "logs",
+        parents=[parent_parser],
+        description=studio_log_description,
+        help=studio_log_help,
+    )
+
+    studio_log_parser.add_argument(
+        "job_id",
+        action="store",
+        help="The job ID to show the logs.",
+    )
+    studio_log_parser.add_argument(
+        "--team",
+        action="store",
+        default=None,
+        help="The team to check the logs. By default, it will use team from config.",
     )
 
 
@@ -233,89 +356,6 @@ def add_studio_parser(subparsers, parent_parser) -> None:
         help="The team to list datasets for. By default, it will use team from config.",
     )
 
-    studio_run_help = "Run a job in Studio"
-    studio_run_description = "This command runs a job in Studio."
-
-    studio_run_parser = studio_subparser.add_parser(
-        "run",
-        parents=[parent_parser],
-        description=studio_run_description,
-        help=studio_run_help,
-    )
-
-    studio_run_parser.add_argument(
-        "query_file",
-        action="store",
-        help="The query file to run.",
-    )
-
-    studio_run_parser.add_argument(
-        "--team",
-        action="store",
-        default=None,
-        help="The team to run a job for. By default, it will use team from config.",
-    )
-    studio_run_parser.add_argument(
-        "--env-file",
-        action="store",
-        help="File containing environment variables to set for the job.",
-    )
-
-    studio_run_parser.add_argument(
-        "--env",
-        nargs="+",
-        help="Environment variable. Can be specified multiple times. Format: KEY=VALUE",
-    )
-
-    studio_run_parser.add_argument(
-        "--workers",
-        type=int,
-        help="Number of workers to use for the job.",
-    )
-    studio_run_parser.add_argument(
-        "--files",
-        nargs="+",
-        help="Files to include in the job.",
-    )
-    studio_run_parser.add_argument(
-        "--python-version",
-        action="store",
-        help="Python version to use for the job (e.g. '3.9', '3.10', '3.11').",
-    )
-    studio_run_parser.add_argument(
-        "--req-file",
-        action="store",
-        help="File containing Python package requirements.",
-    )
-
-    studio_run_parser.add_argument(
-        "--req",
-        nargs="+",
-        help="Python package requirement. Can be specified multiple times.",
-    )
-
-    studio_cancel_help = "Cancel a job in Studio"
-    studio_cancel_description = "This command cancels a job in Studio."
-
-    studio_cancel_parser = studio_subparser.add_parser(
-        "cancel",
-        parents=[parent_parser],
-        description=studio_cancel_description,
-        help=studio_cancel_help,
-    )
-
-    studio_cancel_parser.add_argument(
-        "job_id",
-        action="store",
-        help="The job ID to cancel.",
-    )
-    studio_cancel_parser.add_argument(
-        "--team",
-        action="store",
-        default=None,
-        help="The team to cancel a job for. By default, it will use team from config.",
-    )
-
 
 def get_parser() -> ArgumentParser:  # noqa: PLR0915
     try:
@@ -440,6 +480,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
     )
 
     add_studio_parser(subp, parent_parser)
+    add_jobs_parser(subp, parent_parser)
 
     datasets_parser = subp.add_parser(
         "datasets",
@@ -1440,6 +1481,8 @@ def main(argv: Optional[list[str]] = None) -> int:  # noqa: C901, PLR0912, PLR09
             garbage_collect(catalog)
         elif args.command == "studio":
             process_studio_cli_args(args)
+        elif args.command == "jobs":
+            process_jobs_args(args)
         else:
             print(f"invalid command: {args.command}", file=sys.stderr)
             return 1

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -48,7 +48,7 @@ def process_studio_cli_args(args: "Namespace"):
         return logout()
     if args.cmd == "token":
         return token()
-    if args.cmd == "datasets":
+    if args.cmd == "dataset":
         rows = [
             {"Name": name, "Version": version}
             for name, version in list_datasets(args.team)

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -20,21 +20,7 @@ POST_LOGIN_MESSAGE = (
 )
 
 
-def process_studio_cli_args(args: "Namespace"):  # noqa: PLR0911
-    if args.cmd == "login":
-        return login(args)
-    if args.cmd == "logout":
-        return logout()
-    if args.cmd == "token":
-        return token()
-    if args.cmd == "datasets":
-        rows = [
-            {"Name": name, "Version": version}
-            for name, version in list_datasets(args.team)
-        ]
-        print(tabulate(rows, headers="keys"))
-        return 0
-
+def process_jobs_args(args: "Namespace"):
     if args.cmd == "run":
         return create_job(
             args.query_file,
@@ -50,6 +36,25 @@ def process_studio_cli_args(args: "Namespace"):  # noqa: PLR0911
 
     if args.cmd == "cancel":
         return cancel_job(args.job_id, args.team)
+    if args.cmd == "logs":
+        return show_job_logs(args.job_id, args.team)
+    raise DataChainError(f"Unknown command '{args.cmd}'.")
+
+
+def process_studio_cli_args(args: "Namespace"):
+    if args.cmd == "login":
+        return login(args)
+    if args.cmd == "logout":
+        return logout()
+    if args.cmd == "token":
+        return token()
+    if args.cmd == "datasets":
+        rows = [
+            {"Name": name, "Version": version}
+            for name, version in list_datasets(args.team)
+        ]
+        print(tabulate(rows, headers="keys"))
+        return 0
 
     if args.cmd == "team":
         return set_team(args)
@@ -187,6 +192,32 @@ def save_config(hostname, token):
     return config.config_file()
 
 
+def show_logs_from_client(client, job_id):
+    # Sync usage
+    async def _run():
+        async for message in client.tail_job_logs(job_id):
+            if "logs" in message:
+                for log in message["logs"]:
+                    print(log["message"], end="")
+            elif "job" in message:
+                print(f"\n>>>> Job is now in {message['job']['status']} status.")
+
+    asyncio.run(_run())
+
+    response = client.dataset_job_versions(job_id)
+    if not response.ok:
+        raise_remote_error(response.message)
+
+    response_data = response.data
+    if response_data:
+        dataset_versions = response_data.get("dataset_versions", [])
+        print("\n\n>>>> Dataset versions created during the job:")
+        for version in dataset_versions:
+            print(f"    - {version.get('dataset_name')}@v{version.get('version')}")
+    else:
+        print("No dataset versions created during the job.")
+
+
 def create_job(
     query_file: str,
     team_name: Optional[str],
@@ -236,29 +267,7 @@ def create_job(
     print("Open the job in Studio at", response.data.get("job", {}).get("url"))
     print("=" * 40)
 
-    # Sync usage
-    async def _run():
-        async for message in client.tail_job_logs(job_id):
-            if "logs" in message:
-                for log in message["logs"]:
-                    print(log["message"], end="")
-            elif "job" in message:
-                print(f"\n>>>> Job is now in {message['job']['status']} status.")
-
-    asyncio.run(_run())
-
-    response = client.dataset_job_versions(job_id)
-    if not response.ok:
-        raise_remote_error(response.message)
-
-    response_data = response.data
-    if response_data:
-        dataset_versions = response_data.get("dataset_versions", [])
-        print("\n\n>>>> Dataset versions created during the job:")
-        for version in dataset_versions:
-            print(f"    - {version.get('dataset_name')}@v{version.get('version')}")
-    else:
-        print("No dataset versions created during the job.")
+    show_logs_from_client(client, job_id)
 
 
 def upload_files(client: StudioClient, files: list[str]) -> list[str]:
@@ -293,3 +302,14 @@ def cancel_job(job_id: str, team_name: Optional[str]):
         raise_remote_error(response.message)
 
     print(f"Job {job_id} canceled")
+
+
+def show_job_logs(job_id: str, team_name: Optional[str]):
+    token = Config().read().get("studio", {}).get("token")
+    if not token:
+        raise DataChainError(
+            "Not logged in to Studio. Log in with 'datachain studio login'."
+        )
+
+    client = StudioClient(team=team_name)
+    show_logs_from_client(client, job_id)

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -147,27 +147,27 @@ E2E_STEPS = (
         },
     },
     {
-        "command": ("datachain", "datasets", "ls"),
+        "command": ("datachain", "dataset", "ls"),
         "expected": _tabulated_datasets("mnt", 1),
     },
     {
-        "command": ("datachain", "datasets", "ls"),
+        "command": ("datachain", "dataset", "ls"),
         "expected": _tabulated_datasets("mnt", 1),
     },
     {
-        "command": ("datachain", "datasets", "edit", "mnt", "--new-name", "mnt-new"),
+        "command": ("datachain", "dataset", "edit", "mnt", "--new-name", "mnt-new"),
         "expected": "",
     },
     {
-        "command": ("datachain", "datasets", "ls"),
+        "command": ("datachain", "dataset", "ls"),
         "expected": _tabulated_datasets("mnt-new", 1),
     },
     {
-        "command": ("datachain", "datasets", "rm", "mnt-new", "--version", "1"),
+        "command": ("datachain", "dataset", "rm", "mnt-new", "--version", "1"),
         "expected": "",
     },
     {
-        "command": ("datachain", "datasets", "ls"),
+        "command": ("datachain", "dataset", "ls"),
         "expected": "",
     },
     {

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -318,7 +318,7 @@ def test_studio_cancel_job(capsys, mocker):
         m.post(f"{STUDIO_URL}/api/datachain/job/{job_id}/cancel", json={})
 
         # Studio token is required
-        assert main(["studio", "cancel", job_id]) == 1
+        assert main(["jobs", "cancel", job_id]) == 1
         out = capsys.readouterr().err
         assert "Not logged in to Studio" in out
 
@@ -326,7 +326,7 @@ def test_studio_cancel_job(capsys, mocker):
         with Config(ConfigLevel.GLOBAL).edit() as conf:
             conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
 
-        assert main(["studio", "cancel", job_id]) == 0
+        assert main(["jobs", "cancel", job_id]) == 0
         assert m.called
 
 
@@ -356,7 +356,7 @@ def test_studio_run(capsys, mocker, tmp_dir):
         assert (
             main(
                 [
-                    "studio",
+                    "jobs",
                     "run",
                     "example_query.py",
                     "--env-file",

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -108,7 +108,7 @@ def test_studio_token(capsys):
 
 
 def test_studio_ls_datasets(capsys, studio_datasets):
-    assert main(["studio", "datasets"]) == 0
+    assert main(["studio", "dataset"]) == 0
     out = capsys.readouterr().out
 
     expected_rows = [
@@ -167,23 +167,23 @@ def test_studio_datasets(capsys, studio_datasets, mocker):
     ]
     both_output = tabulate(both_rows, headers="keys")
 
-    assert main(["datasets", "ls", "--local"]) == 0
+    assert main(["dataset", "ls", "--local"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(local_output.splitlines())
 
-    assert main(["datasets", "ls", "--studio"]) == 0
+    assert main(["dataset", "ls", "--studio"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(studio_output.splitlines())
 
-    assert main(["datasets", "ls", "--local", "--studio"]) == 0
+    assert main(["dataset", "ls", "--local", "--studio"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(both_output.splitlines())
 
-    assert main(["datasets", "ls", "--all"]) == 0
+    assert main(["dataset", "ls", "--all"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(both_output.splitlines())
 
-    assert main(["datasets", "ls"]) == 0
+    assert main(["dataset", "ls"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(both_output.splitlines())
 
@@ -196,7 +196,7 @@ def test_studio_edit_dataset(capsys, mocker):
         assert (
             main(
                 [
-                    "datasets",
+                    "dataset",
                     "edit",
                     "name",
                     "--new-name",
@@ -218,7 +218,7 @@ def test_studio_edit_dataset(capsys, mocker):
         assert (
             main(
                 [
-                    "datasets",
+                    "dataset",
                     "edit",
                     "name",
                     "--new-name",
@@ -246,7 +246,7 @@ def test_studio_edit_dataset(capsys, mocker):
         assert (
             main(
                 [
-                    "datasets",
+                    "dataset",
                     "edit",
                     "name",
                     "--new-name",
@@ -277,7 +277,7 @@ def test_studio_rm_dataset(capsys, mocker):
         m.delete(f"{STUDIO_URL}/api/datachain/datasets", json={})
 
         # Studio token is required
-        assert main(["datasets", "rm", "name", "--team", "team_name", "--studio"]) == 1
+        assert main(["dataset", "rm", "name", "--team", "team_name", "--studio"]) == 1
         out = capsys.readouterr().err
         assert "Not logged in to Studio" in out
 
@@ -288,7 +288,7 @@ def test_studio_rm_dataset(capsys, mocker):
         assert (
             main(
                 [
-                    "datasets",
+                    "dataset",
                     "rm",
                     "name",
                     "--team",
@@ -318,7 +318,7 @@ def test_studio_cancel_job(capsys, mocker):
         m.post(f"{STUDIO_URL}/api/datachain/job/{job_id}/cancel", json={})
 
         # Studio token is required
-        assert main(["jobs", "cancel", job_id]) == 1
+        assert main(["job", "cancel", job_id]) == 1
         out = capsys.readouterr().err
         assert "Not logged in to Studio" in out
 
@@ -326,7 +326,7 @@ def test_studio_cancel_job(capsys, mocker):
         with Config(ConfigLevel.GLOBAL).edit() as conf:
             conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
 
-        assert main(["jobs", "cancel", job_id]) == 0
+        assert main(["job", "cancel", job_id]) == 0
         assert m.called
 
 
@@ -356,7 +356,7 @@ def test_studio_run(capsys, mocker, tmp_dir):
         assert (
             main(
                 [
-                    "jobs",
+                    "job",
                     "run",
                     "example_query.py",
                     "--env-file",


### PR DESCRIPTION
With this change, the jobs related commands are as:
- `datachain job run`
- `datachain job cancel`
- `datachain job logs`

[![asciicast](https://asciinema.org/a/XbgQ8Pa3tEEn0GtFSs01TNOXc.svg)](https://asciinema.org/a/XbgQ8Pa3tEEn0GtFSs01TNOXc)

[![asciicast](https://asciinema.org/a/9AAbWkEBm2ESiT58zyaqogECO.svg)](https://asciinema.org/a/9AAbWkEBm2ESiT58zyaqogECO)

With this, we can wrapup the [#10774](https://github.com/iterative/studio/issues/10774)

Closes [#10774](https://github.com/iterative/studio/issues/10774)
