### PR TITLE
split out testing of computer vision from llm and nlp examples in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         pyv: ['3.9', '3.12']
-        group: ['get_started', 'llm_and_nlp or computer_vision', 'multimodal']
+        group: ['get_started', 'computer_vision', 'llm_and_nlp', 'multimodal']
         exclude:
           - {os: ubuntu-latest, pyv: '3.9', group: 'multimodal'}
           - {os: ubuntu-latest, pyv: '3.12', group: 'multimodal'}


### PR DESCRIPTION
There are 5 computer vision and 4 llm and nlp examples under test. It makes sense to split these into separate groups now.

Run times from https://github.com/iterative/datachain/actions/runs/12623540854/job/35172643534?pr=781 - 

```
292.75s call     tests/examples/test_examples.py::test_computer_vision_examples[examples/computer_vision/iptc_exif_xmp_lib.py]
276.43s call     tests/examples/test_examples.py::test_llm_and_nlp_examples[examples/llm_and_nlp/unstructured-embeddings-gen.py]
104.46s call     tests/examples/test_examples.py::test_computer_vision_examples[examples/computer_vision/openimage-detect.py]
56.33s call     tests/examples/test_examples.py::test_llm_and_nlp_examples[examples/llm_and_nlp/unstructured-summary-map.py]
42.42s call     tests/examples/test_examples.py::test_llm_and_nlp_examples[examples/llm_and_nlp/hf-dataset-llm-eval.py]
27.27s call     tests/examples/test_examples.py::test_computer_vision_examples[examples/computer_vision/ultralytics-bbox.py]
26.70s call     tests/examples/test_examples.py::test_computer_vision_examples[examples/computer_vision/ultralytics-segment.py]
25.25s call     tests/examples/test_examples.py::test_computer_vision_examples[examples/computer_vision/ultralytics-pose.py]
0.01s setup    tests/examples/test_examples.py::test_llm_and_nlp_examples[examples/llm_and_nlp/claude-query.py]
```