### PR TITLE
use windows-2025 image for testing examples

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
         pyv: ['3.9', '3.12']
         group: ['get_started', 'computer_vision', 'llm_and_nlp', 'multimodal']
         exclude:


### PR DESCRIPTION
I am not sure if this will fix the error but you can see one [here](https://github.com/iterative/datachain/actions/runs/12623960984/job/35173552972?pr=784#step:7:212) and the list of available images is [here](https://github.com/actions/runner-images) (2025 is beta).

We can always try and then revert.