### PR TITLE
add max bound for unstructured package (broken on Windows)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ examples = [
   "defusedxml",
   "accelerate",
   "unstructured_ingest[embed-huggingface]",
-  "unstructured[pdf]",
+  "unstructured[pdf]<0.16.12",
   "pdfplumber==0.11.4",
   "huggingface_hub[hf_transfer]",
   "onnx==1.16.1",


### PR DESCRIPTION
LLM and NLP tests have been broken on Windows by the most recent `unstructured` release (what a surprise). This PR restricts the version to `<0.16.12`. Seems like a better option than #785 