### PR TITLE
turn off Yolo progress bars in ultralytics examples

### DIFF
--- a/examples/computer_vision/ultralytics-bbox.py
+++ b/examples/computer_vision/ultralytics-bbox.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ["YOLO_VERBOSE"] = "false"
+
+
 from io import BytesIO
 
 from PIL import Image

--- a/examples/computer_vision/ultralytics-pose.py
+++ b/examples/computer_vision/ultralytics-pose.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ["YOLO_VERBOSE"] = "false"
+
+
 from io import BytesIO
 
 from PIL import Image

--- a/examples/computer_vision/ultralytics-segment.py
+++ b/examples/computer_vision/ultralytics-segment.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ["YOLO_VERBOSE"] = "false"
+
+
 from io import BytesIO
 
 from PIL import Image


### PR DESCRIPTION
This PR disables the Yolo progress bars for the following computer vision examples:

- ultralytics-bbox
- ultralytics-pose
- ultralytics-segment

The main reason for doing this is keeping spam out of the examples output. Without the change the output for the bbox examples looks like this:

```console
❯ python examples/computer_vision/ultralytics-bbox.py                                                                                                        ✘ INT  .env 08:48:29
Preparing: 20 rows [00:00, 14503.13 rows/s]
Downloading https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt to 'yolo11n.pt'...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5.35M/5.35M [00:01<00:00, 2.94MB/s]
/Users/mattseddon/projects/datachain/.env/lib/python3.12/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds.
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
Download: 0.00B [00:00, ?B/s]
0: 640x480 (no detections), 38.6ms
Speed: 3.8ms preprocess, 38.6ms inference, 0.5ms postprocess per image at shape (1, 3, 640, 480)
Download: 141kB [00:01, 83.0kB/s]
0: 640x448 1 person, 45.4ms rows/s]
Speed: 3.5ms preprocess, 45.4ms inference, 0.6ms postprocess per image at shape (1, 3, 640, 448)
Download: 384kB [00:03, 135kB/s]
0: 480x640 3 persons, 1 bench, 41.8mss]
Speed: 2.4ms preprocess, 41.8ms inference, 0.7ms postprocess per image at shape (1, 3, 480, 640)
Download: 952kB [00:04, 253kB/s]
0: 480x640 1 truck, 35.3ms 1.08 rows/s]
Speed: 3.4ms preprocess, 35.3ms inference, 0.5ms postprocess per image at shape (1, 3, 480, 640)
Download: 1.11MB [00:05, 217kB/s]
0: 640x448 1 person, 1 tie, 1 bottle, 44.2ms
Speed: 3.1ms preprocess, 44.2ms inference, 0.4ms postprocess per image at shape (1, 3, 640, 448)
Download: 1.26MB [00:07, 183kB/s]
0: 448x640 (no detections), 30.5msrows]
Speed: 1.9ms preprocess, 30.5ms inference, 0.4ms postprocess per image at shape (1, 3, 448, 640)
Download: 2.12MB [00:08, 330kB/s]
0: 480x640 1 bear, 43.6ms  1.22s/ rows]
Speed: 3.0ms preprocess, 43.6ms inference, 0.7ms postprocess per image at shape (1, 3, 480, 640)
Download: 2.28MB [00:09, 312kB/s]
0: 384x640 1 vase, 61.1ms  1.33s/ rows]
Speed: 3.0ms preprocess, 61.1ms inference, 0.5ms postprocess per image at shape (1, 3, 384, 640)
Download: 2.35MB [00:10, 214kB/s]
0: 448x640 15 carrots, 31.9ms14s/ rows]
Speed: 2.4ms preprocess, 31.9ms inference, 0.5ms postprocess per image at shape (1, 3, 448, 640)
Download: 3.17MB [00:12, 327kB/s]
0: 480x640 1 horse, 32.0ms 1.25s/ rows]
Speed: 2.6ms preprocess, 32.0ms inference, 0.5ms postprocess per image at shape (1, 3, 480, 640)
Download: 4.00MB [00:13, 434kB/s]
0: 448x640 (no detections), 33.0ms rows]
Speed: 3.3ms preprocess, 33.0ms inference, 0.3ms postprocess per image at shape (1, 3, 448, 640)
Download: 4.40MB [00:15, 407kB/s]
0: 384x640 (no detections), 30.3ms rows]
Speed: 2.5ms preprocess, 30.3ms inference, 0.5ms postprocess per image at shape (1, 3, 384, 640)
Download: 4.81MB [00:15, 446kB/s]
0: 448x640 11 persons, 1 horse, 34.8mss]
Speed: 3.5ms preprocess, 34.8ms inference, 0.6ms postprocess per image at shape (1, 3, 448, 640)
Download: 4.98MB [00:16, 361kB/s]
0: 480x640 1 pizza, 2 chairs, 1 dining table, 40.2ms
Speed: 3.9ms preprocess, 40.2ms inference, 0.5ms postprocess per image at shape (1, 3, 480, 640)
Download: 5.27MB [00:17, 336kB/s]
0: 640x448 2 persons, 1 bottle, 2 chairs, 1 dining table, 38.5ms
Speed: 2.0ms preprocess, 38.5ms inference, 0.5ms postprocess per image at shape (1, 3, 640, 448)
Download: 5.47MB [00:18, 306kB/s]
0: 640x480 (no detections), 42.1ms rows]
Speed: 3.0ms preprocess, 42.1ms inference, 0.4ms postprocess per image at shape (1, 3, 640, 480)
Download: 5.61MB [00:19, 251kB/s]
0: 480x640 1 person, 1 fork, 1 bowl, 1 pizza, 36.1ms
Speed: 3.6ms preprocess, 36.1ms inference, 0.5ms postprocess per image at shape (1, 3, 480, 640)
Download: 5.84MB [00:21, 234kB/s]
0: 480x640 1 cat, 1 chair, 33.8ms/ rows]
Speed: 2.6ms preprocess, 33.8ms inference, 0.6ms postprocess per image at shape (1, 3, 480, 640)
Download: 6.16MB [00:21, 284kB/s]
0: 640x640 (no detections), 44.0ms rows]
Speed: 4.1ms preprocess, 44.0ms inference, 0.5ms postprocess per image at shape (1, 3, 640, 640)
Download: 6.31MB [00:22, 241kB/s]
0: 640x512 1 person, 2 boats, 41.6msows]
Speed: 3.1ms preprocess, 41.6ms inference, 0.7ms postprocess per image at shape (1, 3, 640, 512)
Download: 6.55MB [00:23, 298kB/s]
Processed: 20 rows [00:22,  1.12s/ rows]
Cleanup: 2 tables [00:00, 6689.48 tables/s]
                   file                                               file    file              file              file      file                             file     file  \
                 source                                               path    size           version              etag is_latest                    last_modified location
0   gs://datachain-demo  openimages-v6-test-jsonpairs/022c0ef054e23509.jpg  136281  1720044710181811  CLP3yu/xi4cDEAE=         1 2024-07-03 22:11:50.223000+00:00     None
1   gs://datachain-demo  openimages-v6-test-jsonpairs/02593109771880ed.jpg  248342  1720044713365303  CLeejfHxi4cDEAE=         1 2024-07-03 22:11:53.427000+00:00     None
2   gs://datachain-demo  openimages-v6-test-jsonpairs/040b79a3e1b2caca.jpg  582225  1720044727974242  COLyiPjxi4cDEAE=         1 2024-07-03 22:12:08.022000+00:00     None
3   gs://datachain-demo  openimages-v6-test-jsonpairs/052085668b890dee.jpg  187180  1720044727036933  CIXYz/fxi4cDEAE=         1 2024-07-03 22:12:07.085000+00:00     None
4   gs://datachain-demo  openimages-v6-test-jsonpairs/05ddac1ea53ebab1.jpg  160425  1720044681501632  CMC39OHxi4cDEAE=         1 2024-07-03 22:11:21.543000+00:00     None
5   gs://datachain-demo  openimages-v6-test-jsonpairs/08392c290ecc9d2a.jpg  902331  1720044714296363  CKuIxvHxi4cDEAE=         1 2024-07-03 22:11:54.367000+00:00     None
6   gs://datachain-demo  openimages-v6-test-jsonpairs/083fc354bbc3dfb1.jpg  169699  1720044733277180  CPzHzPrxi4cDEAE=         1 2024-07-03 22:12:13.318000+00:00     None
7   gs://datachain-demo  openimages-v6-test-jsonpairs/0b6870b626967559.jpg   71811  1720044709547857  CNGepO/xi4cDEAE=         1 2024-07-03 22:11:49.609000+00:00     None
8   gs://datachain-demo  openimages-v6-test-jsonpairs/0c060026076de4f2.jpg  857214  1720044713878258  CPLFrPHxi4cDEAE=         1 2024-07-03 22:11:53.931000+00:00     None
9   gs://datachain-demo  openimages-v6-test-jsonpairs/0c17c58d5e8e689b.jpg  871321  1720044695268538  CLrZvOjxi4cDEAE=         1 2024-07-03 22:11:35.327000+00:00     None
10  gs://datachain-demo  openimages-v6-test-jsonpairs/0f9714864d288053.jpg  419904  1720044687136493  CO2tzOTxi4cDEAE=         1 2024-07-03 22:11:27.185000+00:00     None
11  gs://datachain-demo  openimages-v6-test-jsonpairs/101747a3f7766ddc.jpg  433834  1720044716432354  COK3yPLxi4cDEAE=         1 2024-07-03 22:11:56.507000+00:00     None
12  gs://datachain-demo  openimages-v6-test-jsonpairs/10a36a0e29c23c70.jpg  173679  1720044697173876  CPT+sOnxi4cDEAE=         1 2024-07-03 22:11:37.222000+00:00     None
13  gs://datachain-demo  openimages-v6-test-jsonpairs/1178baa6c8333386.jpg  298476  1720044687461458  CNKY4OTxi4cDEAE=         1 2024-07-03 22:11:27.502000+00:00     None
14  gs://datachain-demo  openimages-v6-test-jsonpairs/12f41110896491be.jpg  214244  1720044674454819  CKOqxt7xi4cDEAE=         1 2024-07-03 22:11:14.499000+00:00     None
15  gs://datachain-demo  openimages-v6-test-jsonpairs/13d0a57ad8f518b6.jpg  148741  1720044706145795  CIPM1O3xi4cDEAE=         1 2024-07-03 22:11:46.203000+00:00     None
16  gs://datachain-demo  openimages-v6-test-jsonpairs/140fe60b44c28083.jpg  235701  1720044676151523  COPxrd/xi4cDEAE=         1 2024-07-03 22:11:16.217000+00:00     None
17  gs://datachain-demo  openimages-v6-test-jsonpairs/15859ba2e74bcdc6.jpg  340518  1720044694726112  CODLm+jxi4cDEAE=         1 2024-07-03 22:11:34.775000+00:00     None
18  gs://datachain-demo  openimages-v6-test-jsonpairs/1774d87b38c0c586.jpg  156638  1720044679877370  CPqlkeHxi4cDEAE=         1 2024-07-03 22:11:19.925000+00:00     None
19  gs://datachain-demo  openimages-v6-test-jsonpairs/18d59a3090c68870.jpg  256778  1720044708599296  CICs6u7xi4cDEAE=         1 2024-07-03 22:11:48.651000+00:00     None

                                                boxes                                              boxes                                              boxes                                              boxes
                                                  cls                                               name                                         confidence                                                box
0                                                  []                                                 []                                                 []                                                 []
1                                                 [0]                                           [person]                                          [0.92395]  [{'title': 'person', 'coords': [235, 147, 674,...
2                                       [0, 0, 0, 13]                    [person, person, person, bench]               [0.90631, 0.90378, 0.86453, 0.44241]  [{'title': 'person', 'coords': [665, 199, 1023...
3                                                 [7]                                            [truck]                                          [0.57536]  [{'title': 'truck', 'coords': [3, 44, 841, 763]}]
4                                         [0, 27, 39]                              [person, tie, bottle]                        [0.82459, 0.81849, 0.71287]  [{'title': 'person', 'coords': [184, 177, 684,...
5                                                  []                                                 []                                                 []                                                 []
6                                                [21]                                             [bear]                                          [0.86443]  [{'title': 'bear', 'coords': [199, 156, 892, 7...
7                                                [75]                                             [vase]                                          [0.39195]   [{'title': 'vase', 'coords': [3, 9, 1022, 559]}]
8   [51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 5...  [carrot, carrot, carrot, carrot, carrot, carro...  [0.70557, 0.5528, 0.53565, 0.53199, 0.52413, 0...  [{'title': 'carrot', 'coords': [489, 533, 766,...
9                                                [17]                                            [horse]                                          [0.91235]  [{'title': 'horse', 'coords': [113, 122, 720, ...
10                                                 []                                                 []                                                 []                                                 []
11                                                 []                                                 []                                                 []                                                 []
12              [0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0]  [person, person, horse, person, person, person...  [0.8175, 0.70903, 0.70852, 0.53737, 0.529, 0.4...  [{'title': 'person', 'coords': [136, 283, 193,...
13                                   [56, 56, 60, 53]                [chair, chair, dining table, pizza]               [0.55533, 0.40252, 0.32643, 0.32002]  [{'title': 'chair', 'coords': [0, 0, 170, 159]...
14                             [39, 0, 56, 0, 60, 56]  [bottle, person, chair, person, dining table, ...  [0.80755, 0.78092, 0.76248, 0.27738, 0.26981, ...  [{'title': 'bottle', 'coords': [155, 117, 190,...
15                                                 []                                                 []                                                 []                                                 []
16                                    [45, 0, 53, 42]                        [bowl, person, pizza, fork]                [0.58877, 0.47639, 0.35383, 0.2977]  [{'title': 'bowl', 'coords': [3, 66, 1023, 768...
17                                           [15, 56]                                       [cat, chair]                                  [0.92134, 0.4211]  [{'title': 'cat', 'coords': [54, 5, 721, 736]}...
18                                                 []                                                 []                                                 []                                                 []
19                                          [0, 8, 8]                               [person, boat, boat]                        [0.88353, 0.51353, 0.49711]  [{'title': 'person', 'coords': [130, 153, 400,...

[Limited by 20 rows]
/Users/mattseddon/projects/datachain/src/datachain/query/session.py:182: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
  if isinstance(obj, Session):  # Cleanup temp dataset for session variables.
```

With the change this is reduced to:

```console
❯ python examples/computer_vision/ultralytics-bbox.py                                                                                                          31s  .env 08:49:39
Preparing: 20 rows [00:00, 4482.29 rows/s]
/Users/mattseddon/projects/datachain/.env/lib/python3.12/site-packages/google/auth/_default.py:76: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds.
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
Download: 6.55MB [00:22, 307kB/s]
Processed: 20 rows [00:21,  1.09s/ rows]
Cleanup: 2 tables [00:00, 6269.51 tables/s]
                   file                                               file    file              file              file      file                             file     file  \
                 source                                               path    size           version              etag is_latest                    last_modified location
0   gs://datachain-demo  openimages-v6-test-jsonpairs/022c0ef054e23509.jpg  136281  1720044710181811  CLP3yu/xi4cDEAE=         1 2024-07-03 22:11:50.223000+00:00     None
1   gs://datachain-demo  openimages-v6-test-jsonpairs/02593109771880ed.jpg  248342  1720044713365303  CLeejfHxi4cDEAE=         1 2024-07-03 22:11:53.427000+00:00     None
2   gs://datachain-demo  openimages-v6-test-jsonpairs/040b79a3e1b2caca.jpg  582225  1720044727974242  COLyiPjxi4cDEAE=         1 2024-07-03 22:12:08.022000+00:00     None
3   gs://datachain-demo  openimages-v6-test-jsonpairs/052085668b890dee.jpg  187180  1720044727036933  CIXYz/fxi4cDEAE=         1 2024-07-03 22:12:07.085000+00:00     None
4   gs://datachain-demo  openimages-v6-test-jsonpairs/05ddac1ea53ebab1.jpg  160425  1720044681501632  CMC39OHxi4cDEAE=         1 2024-07-03 22:11:21.543000+00:00     None
5   gs://datachain-demo  openimages-v6-test-jsonpairs/08392c290ecc9d2a.jpg  902331  1720044714296363  CKuIxvHxi4cDEAE=         1 2024-07-03 22:11:54.367000+00:00     None
6   gs://datachain-demo  openimages-v6-test-jsonpairs/083fc354bbc3dfb1.jpg  169699  1720044733277180  CPzHzPrxi4cDEAE=         1 2024-07-03 22:12:13.318000+00:00     None
7   gs://datachain-demo  openimages-v6-test-jsonpairs/0b6870b626967559.jpg   71811  1720044709547857  CNGepO/xi4cDEAE=         1 2024-07-03 22:11:49.609000+00:00     None
8   gs://datachain-demo  openimages-v6-test-jsonpairs/0c060026076de4f2.jpg  857214  1720044713878258  CPLFrPHxi4cDEAE=         1 2024-07-03 22:11:53.931000+00:00     None
9   gs://datachain-demo  openimages-v6-test-jsonpairs/0c17c58d5e8e689b.jpg  871321  1720044695268538  CLrZvOjxi4cDEAE=         1 2024-07-03 22:11:35.327000+00:00     None
10  gs://datachain-demo  openimages-v6-test-jsonpairs/0f9714864d288053.jpg  419904  1720044687136493  CO2tzOTxi4cDEAE=         1 2024-07-03 22:11:27.185000+00:00     None
11  gs://datachain-demo  openimages-v6-test-jsonpairs/101747a3f7766ddc.jpg  433834  1720044716432354  COK3yPLxi4cDEAE=         1 2024-07-03 22:11:56.507000+00:00     None
12  gs://datachain-demo  openimages-v6-test-jsonpairs/10a36a0e29c23c70.jpg  173679  1720044697173876  CPT+sOnxi4cDEAE=         1 2024-07-03 22:11:37.222000+00:00     None
13  gs://datachain-demo  openimages-v6-test-jsonpairs/1178baa6c8333386.jpg  298476  1720044687461458  CNKY4OTxi4cDEAE=         1 2024-07-03 22:11:27.502000+00:00     None
14  gs://datachain-demo  openimages-v6-test-jsonpairs/12f41110896491be.jpg  214244  1720044674454819  CKOqxt7xi4cDEAE=         1 2024-07-03 22:11:14.499000+00:00     None
15  gs://datachain-demo  openimages-v6-test-jsonpairs/13d0a57ad8f518b6.jpg  148741  1720044706145795  CIPM1O3xi4cDEAE=         1 2024-07-03 22:11:46.203000+00:00     None
16  gs://datachain-demo  openimages-v6-test-jsonpairs/140fe60b44c28083.jpg  235701  1720044676151523  COPxrd/xi4cDEAE=         1 2024-07-03 22:11:16.217000+00:00     None
17  gs://datachain-demo  openimages-v6-test-jsonpairs/15859ba2e74bcdc6.jpg  340518  1720044694726112  CODLm+jxi4cDEAE=         1 2024-07-03 22:11:34.775000+00:00     None
18  gs://datachain-demo  openimages-v6-test-jsonpairs/1774d87b38c0c586.jpg  156638  1720044679877370  CPqlkeHxi4cDEAE=         1 2024-07-03 22:11:19.925000+00:00     None
19  gs://datachain-demo  openimages-v6-test-jsonpairs/18d59a3090c68870.jpg  256778  1720044708599296  CICs6u7xi4cDEAE=         1 2024-07-03 22:11:48.651000+00:00     None

                                                boxes                                              boxes                                              boxes                                              boxes
                                                  cls                                               name                                         confidence                                                box
0                                                  []                                                 []                                                 []                                                 []
1                                                 [0]                                           [person]                                          [0.92395]  [{'title': 'person', 'coords': [235, 147, 674,...
2                                       [0, 0, 0, 13]                    [person, person, person, bench]               [0.90631, 0.90378, 0.86453, 0.44241]  [{'title': 'person', 'coords': [665, 199, 1023...
3                                                 [7]                                            [truck]                                          [0.57536]  [{'title': 'truck', 'coords': [3, 44, 841, 763]}]
4                                         [0, 27, 39]                              [person, tie, bottle]                        [0.82459, 0.81849, 0.71287]  [{'title': 'person', 'coords': [184, 177, 684,...
5                                                  []                                                 []                                                 []                                                 []
6                                                [21]                                             [bear]                                          [0.86443]  [{'title': 'bear', 'coords': [199, 156, 892, 7...
7                                                [75]                                             [vase]                                          [0.39195]   [{'title': 'vase', 'coords': [3, 9, 1022, 559]}]
8   [51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 5...  [carrot, carrot, carrot, carrot, carrot, carro...  [0.70557, 0.5528, 0.53565, 0.53199, 0.52413, 0...  [{'title': 'carrot', 'coords': [489, 533, 766,...
9                                                [17]                                            [horse]                                          [0.91235]  [{'title': 'horse', 'coords': [113, 122, 720, ...
10                                                 []                                                 []                                                 []                                                 []
11                                                 []                                                 []                                                 []                                                 []
12              [0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0]  [person, person, horse, person, person, person...  [0.8175, 0.70903, 0.70852, 0.53737, 0.529, 0.4...  [{'title': 'person', 'coords': [136, 283, 193,...
13                                   [56, 56, 60, 53]                [chair, chair, dining table, pizza]               [0.55533, 0.40252, 0.32643, 0.32002]  [{'title': 'chair', 'coords': [0, 0, 170, 159]...
14                             [39, 0, 56, 0, 60, 56]  [bottle, person, chair, person, dining table, ...  [0.80755, 0.78092, 0.76248, 0.27738, 0.26981, ...  [{'title': 'bottle', 'coords': [155, 117, 190,...
15                                                 []                                                 []                                                 []                                                 []
16                                    [45, 0, 53, 42]                        [bowl, person, pizza, fork]                [0.58877, 0.47639, 0.35383, 0.2977]  [{'title': 'bowl', 'coords': [3, 66, 1023, 768...
17                                           [15, 56]                                       [cat, chair]                                  [0.92134, 0.4211]  [{'title': 'cat', 'coords': [54, 5, 721, 736]}...
18                                                 []                                                 []                                                 []                                                 []
19                                          [0, 8, 8]                               [person, boat, boat]                        [0.88353, 0.51353, 0.49711]  [{'title': 'person', 'coords': [130, 153, 400,...

[Limited by 20 rows]
/Users/mattseddon/projects/datachain/src/datachain/query/session.py:182: FutureWarning: `torch.distributed.reduce_op` is deprecated, please use `torch.distributed.ReduceOp` instead
  if isinstance(obj, Session):  # Cleanup temp dataset for session variables.
```

uses the suggestion from https://github.com/ultralytics/ultralytics/issues/4906