### PR TITLE
do not persist completed progress bars

### DIFF
--- a/examples/get_started/torch-loader.py
+++ b/examples/get_started/torch-loader.py
@@ -80,7 +80,10 @@ if __name__ == "__main__":
     # Train the model
     for epoch in range(NUM_EPOCHS):
         with tqdm(
-            train_loader, desc=f"epoch {epoch + 1}/{NUM_EPOCHS}", unit="batch"
+            train_loader,
+            desc=f"epoch {epoch + 1}/{NUM_EPOCHS}",
+            unit="batch",
+            leave=False,
         ) as loader:
             for data in loader:
                 inputs, labels = data

--- a/src/datachain/cache.py
+++ b/src/datachain/cache.py
@@ -63,7 +63,7 @@ class DataChainCache:
         if size < 0:
             size = await client.get_size(from_path, version_id=file.version)
         cb = callback or TqdmCallback(
-            tqdm_kwargs={"desc": odb_fs.name(from_path), "bytes": True},
+            tqdm_kwargs={"desc": odb_fs.name(from_path), "bytes": True, "leave": False},
             tqdm_cls=Tqdm,
             size=size,
         )

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -405,6 +405,7 @@ def get_download_bar(bar_format: str, total_size: int):
         unit_scale=True,
         unit_divisor=1000,
         total=total_size,
+        leave=False,
     )
 
 
@@ -429,6 +430,7 @@ def instantiate_node_groups(
             unit_scale=True,
             unit_divisor=1000,
             total=total_files,
+            leave=False,
         )
     )
 
@@ -1437,6 +1439,7 @@ class Catalog:
             unit_scale=True,
             unit_divisor=1000,
             total=ds_stats.num_objects,  # type: ignore [union-attr]
+            leave=False,
         )
 
         schema = DatasetRecord.parse_schema(remote_ds_version.schema)

--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -42,7 +42,7 @@ class AzureClient(Client):
             prefix = prefix.lstrip(DELIMITER) + DELIMITER
         found = False
         try:
-            with tqdm(desc=f"Listing {self.uri}", unit=" objects") as pbar:
+            with tqdm(desc=f"Listing {self.uri}", unit=" objects", leave=False) as pbar:
                 async with self.fs.service_client.get_container_client(
                     container=self.name
                 ) as container_client:

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -249,7 +249,7 @@ class Client(ABC):
         await main_task
 
     async def _fetch_nested(self, start_prefix: str, result_queue: ResultQueue) -> None:
-        progress_bar = tqdm(desc=f"Listing {self.uri}", unit=" objects")
+        progress_bar = tqdm(desc=f"Listing {self.uri}", unit=" objects", leave=False)
         loop = get_loop()
 
         queue: asyncio.Queue[str] = asyncio.Queue()

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -83,7 +83,7 @@ class GCSClient(Client):
         self, page_queue: PageQueue, result_queue: ResultQueue
     ) -> bool:
         found = False
-        with tqdm(desc=f"Listing {self.uri}", unit=" objects") as pbar:
+        with tqdm(desc=f"Listing {self.uri}", unit=" objects", leave=False) as pbar:
             while (page := await page_queue.get()) is not None:
                 if page:
                     found = True

--- a/src/datachain/client/s3.py
+++ b/src/datachain/client/s3.py
@@ -61,7 +61,7 @@ class ClientS3(Client):
 
         async def process_pages(page_queue, result_queue):
             found = False
-            with tqdm(desc=f"Listing {self.uri}", unit=" objects") as pbar:
+            with tqdm(desc=f"Listing {self.uri}", unit=" objects", leave=False) as pbar:
                 while (res := await page_queue.get()) is not None:
                     if res:
                         found = True

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -670,7 +670,7 @@ class SQLiteWarehouse(AbstractWarehouse):
         ]
         table = self.create_udf_table(columns)
 
-        with tqdm(desc="Preparing", unit=" rows") as pbar:
+        with tqdm(desc="Preparing", unit=" rows", leave=False) as pbar:
             self.copy_table(table, query, progress_cb=pbar.update)
 
         return table

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -904,8 +904,11 @@ class AbstractWarehouse(ABC, Serializable):
         This should be implemented to ensure that the provided tables
         are cleaned up as soon as they are no longer needed.
         """
-        with tqdm(desc="Cleanup", unit=" tables") as pbar:
-            for name in set(names):
+        to_drop = set(names)
+        with tqdm(
+            desc="Cleanup", unit=" tables", total=len(to_drop), leave=False
+        ) as pbar:
+            for name in to_drop:
                 self.db.drop_table(Table(name, self.db.metadata), if_exists=True)
                 pbar.update(1)
 

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -91,7 +91,9 @@ class ArrowGenerator(Generator):
                 yield from record_batch.to_pylist()
 
         it = islice(iter_records(), self.nrows)
-        with tqdm(it, desc="Parsed by pyarrow", unit="rows", total=self.nrows) as pbar:
+        with tqdm(
+            it, desc="Parsed by pyarrow", unit="rows", total=self.nrows, leave=False
+        ) as pbar:
             for index, record in enumerate(pbar):
                 yield self._process_record(
                     record, file, index, hf_schema, use_datachain_schema

--- a/src/datachain/lib/hf.py
+++ b/src/datachain/lib/hf.py
@@ -95,7 +95,7 @@ class HFGenerator(Generator):
         ds = self.ds_dict[split]
         if split:
             desc += f" split '{split}'"
-        with tqdm(desc=desc, unit=" rows") as pbar:
+        with tqdm(desc=desc, unit=" rows", leave=False) as pbar:
             for row in ds:
                 output_dict = {}
                 if split and "split" in self.output_schema.model_fields:

--- a/src/datachain/listing.py
+++ b/src/datachain/listing.py
@@ -153,6 +153,7 @@ class Listing:
             unit_scale=True,
             unit_divisor=1000,
             total=total_files,
+            leave=False,
         )
 
         counter = 0

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -351,17 +351,23 @@ def process_udf_outputs(
 
 def get_download_callback() -> Callback:
     return CombinedDownloadCallback(
-        {"desc": "Download", "unit": "B", "unit_scale": True, "unit_divisor": 1024}
+        {
+            "desc": "Download",
+            "unit": "B",
+            "unit_scale": True,
+            "unit_divisor": 1024,
+            "leave": False,
+        }
     )
 
 
 def get_processed_callback() -> Callback:
-    return TqdmCallback({"desc": "Processed", "unit": " rows"})
+    return TqdmCallback({"desc": "Processed", "unit": " rows", "leave": False})
 
 
 def get_generated_callback(is_generator: bool = False) -> Callback:
     if is_generator:
-        return TqdmCallback({"desc": "Generated", "unit": " rows"})
+        return TqdmCallback({"desc": "Generated", "unit": " rows", "leave": False})
     return DEFAULT_CALLBACK
 
 


### PR DESCRIPTION
related to https://github.com/iterative/datachain/issues/723

This PR removes completed progress bars from DataChain's console output. This gives us a quick way to quieten down the output for "quick commands"

### main


https://github.com/user-attachments/assets/a01b638d-065a-426c-ad51-6f5aec96227f




### completed progress bars removed

https://github.com/user-attachments/assets/cff1d02d-806c-4c91-b1e6-8d7477265e89

