### PR TITLE
git ignore files all pytorch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ cython_debug/
 .vscode/
 .datachain/
 .dvcx/
+
+# pt files produced by ultralytics examples
+*.pt


### PR DESCRIPTION
When running the `ultralytics` examples files like `yolo11n-seg.pt` are produced in the root directory. I have come close to committing these a couple of times.