### PR TITLE
fix(map): don't allow rewriting existing columns

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -602,6 +602,13 @@ class UDFSignal(UDFStep):
         signal_name_cols = {c.name: c for c in signal_cols}
         cols = signal_cols
 
+        overlap = {c.name for c in original_cols} & {c.name for c in cols}
+        if overlap:
+            raise ValueError(
+                "Column already exists or added in the previous steps: "
+                + ", ".join(overlap)
+            )
+
         def q(*columns):
             cols1 = []
             cols2 = []

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -482,6 +482,21 @@ def test_map(test_session):
         assert x.my_name == test_fr.my_name
 
 
+def test_map_existing_column_after_step(test_session):
+    dc = DataChain.from_values(t1=features, session=test_session).map(
+        x=lambda _: "test",
+        params="t1",
+        output={"x": str},
+    )
+
+    with pytest.raises(ValueError):
+        dc.map(
+            x=lambda _: "test",
+            params="t1",
+            output={"x": str},
+        ).exec()
+
+
 def test_agg(test_session):
     class _TestFr(BaseModel):
         f: File


### PR DESCRIPTION
Code like this:

```python
video_dc = (
    video_dc
    .limit(1)
    .map(video=lambda file: add_video_metadata(file), output={'video': Video})
    .map(video=lambda file: add_video_metadata(file), output={'video': Video})
)
```

ignores or rewrites the `video`,

additional mapper: 

```python
video_dc = (
    video_dc
    .limit(1)
    .map(video=lambda file: add_video_metadata(file), output={'video': Video})
    .map(video=lambda file: add_video_metadata(file), output={'video': Video})
    .map(video=lambda file: add_video_metadata(file), output={'video': Video})
)
```

breaks it with an obscure error:

```python
  File "/Users/ivan/Projects/dvcx/.venv/lib/python3.11/site-packages/sqlalchemy/sql/base.py", line 1324, in _set_parent_with_dispatch
    self._set_parent(parent, **kw)
  File "/Users/ivan/Projects/dvcx/.venv/lib/python3.11/site-packages/sqlalchemy/sql/schema.py", line 2346, in _set_parent
    raise exc.DuplicateColumnError(
sqlalchemy.exc.DuplicateColumnError: A column with name 'video__video_id' is already present in table 'udf_A5uwFz'.
```

This PR makes it consistent and raise a bit more human readable error in both cases. It checks if we are trying to add some already existing columns.


## TODO:

- [x] Add tests