### PR TITLE
fix(schema): reconnect closed connection

### DIFF
--- a/src/datachain/data_storage/db_engine.py
+++ b/src/datachain/data_storage/db_engine.py
@@ -79,6 +79,15 @@ class DatabaseEngine(ABC, Serializable):
         conn: Optional[Any] = None,
     ) -> Iterator[tuple[Any, ...]]: ...
 
+    def get_table(self, name: str) -> "Table":
+        table = self.metadata.tables.get(name)
+        if table is None:
+            sa.Table(name, self.metadata, autoload_with=self.engine)
+            # ^^^ This table may not be correctly initialised on some dialects
+            # Grab it from metadata instead.
+            table = self.metadata.tables[name]
+        return table
+
     @abstractmethod
     def executemany(
         self, query, params, cursor: Optional[Any] = None

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -186,6 +186,12 @@ class SQLiteDatabaseEngine(DatabaseEngine):
         self.db_file = db_file
         self.is_closed = False
 
+    def get_table(self, name: str) -> Table:
+        if self.is_closed:
+            # Reconnect in case of being closed previously.
+            self._reconnect()
+        return super().get_table(name)
+
     @retry_sqlite_locks
     def execute(
         self,

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -191,8 +191,7 @@ class AbstractWarehouse(ABC, Serializable):
         table_name = self.dataset_table_name(dataset.name, version)
         return self.schema.dataset_row_cls(
             table_name,
-            self.db.engine,
-            self.db.metadata,
+            self.db,
             dataset.get_schema(version),
             object_name=object_name,
         )
@@ -220,7 +219,7 @@ class AbstractWarehouse(ABC, Serializable):
         num_yielded = 0
 
         # Ensure we're using a thread-local connection
-        with self.clone() as wh:
+        with self.clone(use_new_connection=True) as wh:
             while True:
                 if limit is not None:
                     limit -= num_yielded


### PR DESCRIPTION
Fixes #660 

Refactors `DataTable` by removing direct access to sqlachemy (and thus requiring direct access to sa.Engine, etc). This allows us to do a check and reconnect if connection was already closed.
