### PR TITLE
prefetching: remove prefetched item after use in udf

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1276,7 +1276,12 @@ class DataChain:
                 yield ret[0] if len(cols) == 1 else tuple(ret)
 
     def to_pytorch(
-        self, transform=None, tokenizer=None, tokenizer_kwargs=None, num_samples=0
+        self,
+        transform=None,
+        tokenizer=None,
+        tokenizer_kwargs=None,
+        num_samples=0,
+        remove_prefetched: bool = False,
     ):
         """Convert to pytorch dataset format.
 
@@ -1286,6 +1291,7 @@ class DataChain:
             tokenizer_kwargs (dict): Additional kwargs to pass when calling tokenizer.
             num_samples (int): Number of random samples to draw for each epoch.
                 This argument is ignored if `num_samples=0` (the default).
+            remove_prefetched (bool): Whether to remove prefetched files after reading.
 
         Example:
             ```py
@@ -1312,6 +1318,7 @@ class DataChain:
             tokenizer_kwargs=tokenizer_kwargs,
             num_samples=num_samples,
             dc_settings=chain._settings,
+            remove_prefetched=remove_prefetched,
         )
 
     def remove_file_signals(self) -> "Self":  # noqa: D102

--- a/src/datachain/lib/pytorch.py
+++ b/src/datachain/lib/pytorch.py
@@ -50,6 +50,7 @@ class PytorchDataset(IterableDataset):
         tokenizer_kwargs: Optional[dict[str, Any]] = None,
         num_samples: int = 0,
         dc_settings: Optional[Settings] = None,
+        remove_prefetched: bool = False,
     ):
         """
         Pytorch IterableDataset that streams DataChain datasets.
@@ -84,6 +85,7 @@ class PytorchDataset(IterableDataset):
 
         self._cache = catalog.cache
         self._prefetch_cache: Optional[Cache] = None
+        self._remove_prefetched = remove_prefetched
         if prefetch and not self.cache:
             tmp_dir = catalog.cache.tmp_dir
             assert tmp_dir
@@ -147,7 +149,7 @@ class PytorchDataset(IterableDataset):
             rows,
             self.prefetch,
             download_cb=download_cb,
-            after_prefetch=download_cb.increment_file_count,
+            remove_prefetched=self._remove_prefetched,
         )
 
         with download_cb, closing(rows):

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -16,6 +16,7 @@ from datachain.lib.convert.flatten import flatten
 from datachain.lib.data_model import DataValue
 from datachain.lib.file import File
 from datachain.lib.utils import AbstractUDF, DataChainError, DataChainParamsError
+from datachain.progress import CombinedDownloadCallback
 from datachain.query.batch import (
     Batch,
     BatchingStrategy,
@@ -301,20 +302,42 @@ async def _prefetch_input(
     return row
 
 
+def _remove_prefetched(row: T) -> None:
+    for obj in row:
+        if isinstance(obj, File):
+            catalog = obj._catalog
+            assert catalog is not None
+            try:
+                catalog.cache.remove(obj)
+            except Exception as e:  # noqa: BLE001
+                print(f"Failed to remove prefetched item {obj.name!r}: {e!s}")
+
+
 def _prefetch_inputs(
     prepared_inputs: "Iterable[T]",
     prefetch: int = 0,
     download_cb: Optional["Callback"] = None,
-    after_prefetch: "Callable[[], None]" = noop,
+    after_prefetch: Optional[Callable[[], None]] = None,
+    remove_prefetched: bool = False,
 ) -> "abc.Generator[T, None, None]":
-    if prefetch > 0:
-        f = partial(
-            _prefetch_input,
-            download_cb=download_cb,
-            after_prefetch=after_prefetch,
-        )
-        prepared_inputs = AsyncMapper(f, prepared_inputs, workers=prefetch).iterate()  # type: ignore[assignment]
-    yield from prepared_inputs
+    if not prefetch:
+        yield from prepared_inputs
+        return
+
+    if after_prefetch is None:
+        after_prefetch = noop
+        if isinstance(download_cb, CombinedDownloadCallback):
+            after_prefetch = download_cb.increment_file_count
+
+    f = partial(_prefetch_input, download_cb=download_cb, after_prefetch=after_prefetch)
+    mapper = AsyncMapper(f, prepared_inputs, workers=prefetch)
+    with closing(mapper.iterate()) as row_iter:
+        for row in row_iter:
+            try:
+                yield row  # type: ignore[misc]
+            finally:
+                if remove_prefetched:
+                    _remove_prefetched(row)
 
 
 def _get_cache(
@@ -351,7 +374,13 @@ class Mapper(UDFBase):
                     )
 
         prepared_inputs = _prepare_rows(udf_inputs)
-        prepared_inputs = _prefetch_inputs(prepared_inputs, self.prefetch)
+        prepared_inputs = _prefetch_inputs(
+            prepared_inputs,
+            self.prefetch,
+            download_cb=download_cb,
+            remove_prefetched=bool(self.prefetch) and not cache,
+        )
+
         with closing(prepared_inputs):
             for id_, *udf_args in prepared_inputs:
                 result_objs = self.process_safe(udf_args)
@@ -430,7 +459,12 @@ class Generator(UDFBase):
                     )
 
         prepared_inputs = _prepare_rows(udf_inputs)
-        prepared_inputs = _prefetch_inputs(prepared_inputs, self.prefetch)
+        prepared_inputs = _prefetch_inputs(
+            prepared_inputs,
+            self.prefetch,
+            download_cb=download_cb,
+            remove_prefetched=bool(self.prefetch) and not cache,
+        )
         with closing(prepared_inputs):
             for row in prepared_inputs:
                 result_objs = self.process_safe(row)

--- a/tests/benchmarks/test_datachain.py
+++ b/tests/benchmarks/test_datachain.py
@@ -6,6 +6,11 @@ def test_datachain(tmp_dir, test_session, datasets, benchmark):
     def run_script(uri, **kwargs):
         DataChain.from_storage(uri, session=test_session, **kwargs).gen(
             emd=process_laion_meta
+        ).settings(
+            # Disable `prefetch` for `map()` because `process_laion_meta` repeatedly
+            # returns the dataset file. This causes `prefetch` to download and
+            # remove the file multiple times unnecessarily, slowing down the process.
+            prefetch=0,
         ).map(
             stem=lambda file: file.get_file_stem(),
             params=["emd.file"],

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from datachain.cache import DataChainCache
+from datachain.lib.file import File
 from datachain.lib.pytorch import PytorchDataset
 from datachain.lib.settings import Settings
 
@@ -40,6 +41,35 @@ def test_close(mocker, catalog, cache):
         spy.assert_not_called()
     else:
         spy.assert_called_once()
+
+
+def test_prefetched_files_are_removed_after_yield(tmp_dir, mocker, catalog, cache):
+    files = []
+    for name in "abc":
+        (tmp_dir / name).write_text(name, encoding="utf-8")
+        file = File(path=tmp_dir / name)
+        file._set_stream(catalog)
+        files.append((file,))
+
+    ds = PytorchDataset(
+        "fake",
+        1,
+        catalog,
+        dc_settings=Settings(prefetch=10),
+        remove_prefetched=True,
+    )
+    mocker.patch.object(ds, "_row_iter", return_value=iter(files))
+
+    seen = []
+    for (file,) in ds._iter_with_prefetch():
+        # previously prefetched files should have been removed by now
+        for f in seen:
+            assert not f._catalog.cache.contains(f)
+            assert not f.get_local_path()
+        seen.append(file)
+
+        assert file._catalog.cache.contains(file)
+        assert file.get_local_path()
 
 
 @pytest.mark.parametrize("cache", [True, False])


### PR DESCRIPTION
This PR removes the prefetched item after use in the UDF. This is enabled by default on `prefetch>0`, unless `cache=True` is set in the UDF, in which case the prefetched item is not removed.

For pytorch dataset, this is not enabled by default, but can be enabled by setting `remove_prefetched=True` in the `PytorchDataset` class. This is done so because the dataset can be used in multiple epochs, and removing the prefetched item after use can cause it to redownload again in the next epoch.

The exposed `remove_prefetched=True|False` setting could be renamed to
some better option. Feedbacks are welcome.
(I think the UX around prefetch needs to be improved and made obvious).