### PR TITLE
ReferenceFileSystem: use fs.open instead of fs._open

### DIFF
--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -33,7 +33,7 @@ class ReferenceFileSystem(fsspec.implementations.reference.ReferenceFileSystem):
         # reads the whole file in-memory.
         (uri,) = self.references[path]
         protocol, _ = split_protocol(uri)
-        return self.fss[protocol]._open(uri, mode, *args, **kwargs)
+        return self.fss[protocol].open(uri, mode, *args, **kwargs)
 
 
 class ArrowGenerator(Generator):


### PR DESCRIPTION
There is a bug in `fsspec==2024.12.0` that causes the `ReferenceFileSystem` to incorrectly make `fs._open` return a coroutine object instead of a file-like object. (See a proposed PR to fix this issue: fsspec/filesystem_spec#1769.)

We have a test for the expected behavior ([`test_arrow_generator_partitioned` in `tests/unit/lib/test_arrow.py`](https://github.com/iterative/datachain/blob/aad99e2eab48513387bc187d9196084614012f2b/tests/unit/lib/test_arrow.py#L111-L112)) running in the CI environment.
But that does not fail because the latest version of `fsspec` does not get installed in the CI due to the upper limit set by the `datasets` library.

The `datasets` library is only installed as part of the `hf` and `tests` extras, so the default installation of `datachain` will encounter this issue.

### How has this been tested?

I have tested this PR with older and newer version of fsspec and the test passes on both. And the test fails with the latest version of fsspec without this patch. 


Fixes https://github.com/iterative/datachain/issues/806.
