### PR TITLE
tests: reduce pytorch functional tests' runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ tests = [
   "virtualenv",
   "dulwich",
   "hypothesis",
-  "open_clip_torch",
   "aiotools>=1.7.0",
   "requests-mock",
   "scipy"
@@ -112,7 +111,8 @@ examples = [
   "pdfplumber==0.11.5",
   "huggingface_hub[hf_transfer]",
   "onnx==1.16.1",
-  "ultralytics==8.3.61"
+  "ultralytics==8.3.61",
+  "open_clip_torch"
 ]
 
 [project.urls]


### PR DESCRIPTION
This is achieved by:
1. reducing the number of images in the fake dataset from 1000 to 100,
2. removing tokenizer from open_clip_torch, to a fake one, and,
3. disabling cache and prefetch in the `fake_dataset` fixture. The fixture does not use the files, and `PytorchDataset` reopens the dataset, so there is no need to cache or prefetch the data.

With this, the runtime for `tests/func/test_pytorch.py` is reduced from ~80s to <8s on my machine.