### PR TITLE
Revert "build(deps): bump mkdocs-material from 9.5.22 to 9.5.50"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 docs = [
   "mkdocs>=1.5.2",
   "mkdocs-gen-files>=0.5.0",
-  "mkdocs-material==9.5.50",
+  "mkdocs-material==9.5.22",
   "mkdocs-section-index>=0.3.6",
   "mkdocstrings-python>=1.6.3",
   "mkdocs-literate-nav>=0.6.1"


### PR DESCRIPTION
- Reverts iterative/datachain#838
- It was downgraded to fix https://github.com/iterative/datachain/issues/690
- Let's use the old version for now and feel free to close the PR if dependent-bot to stop them from recreating