### PR TITLE
add infrastructure for logging

### DIFF
--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -1,3 +1,4 @@
+from datachain import logger
 from datachain.lib.data_model import DataModel, DataType, is_chain_type
 from datachain.lib.dc import C, Column, DataChain, Sys
 from datachain.lib.file import (
@@ -13,6 +14,8 @@ from datachain.lib.udf import Aggregator, Generator, Mapper
 from datachain.lib.utils import AbstractUDF, DataChainError
 from datachain.query import metrics, param
 from datachain.query.session import Session
+
+logger.setup_logging()
 
 __all__ = [
     "AbstractUDF",

--- a/src/datachain/logger.py
+++ b/src/datachain/logger.py
@@ -1,0 +1,35 @@
+import logging
+import os
+
+
+def process_info(record: logging.LogRecord) -> logging.LogRecord:
+    """Add process id, threadname and taskname to the log record"""
+    if record.process:
+        proc = [str(record.process)]
+    if record.threadName and record.threadName != "MainThread":
+        proc.append(record.threadName)
+    if task_name := getattr(record, "taskName", None):
+        proc.append(task_name)
+    record.process_info = "[" + "/".join(proc) + "]"
+    return record
+
+
+def setup_logging() -> None:
+    logger = logging.getLogger("datachain")
+    level = logging.WARNING
+    if log_level := os.getenv("DATACHAIN_LOG_LEVEL"):
+        level = getattr(logging, log_level.upper())
+        logger.setLevel(level)
+
+    if "DATACHAIN_LOG_OUTPUT" not in os.environ:
+        return
+
+    format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s %(process_info)s"
+    handler = logging.StreamHandler()
+    handler.addFilter(process_info)
+    logging.basicConfig(format=format, handlers=[handler], datefmt="%X")
+
+    for module in os.getenv("DATACHAIN_LOG_EXTERNAL", "").split(","):
+        module = module.strip()
+        if module:
+            logging.getLogger(module).setLevel(level)


### PR DESCRIPTION
```console
export DATACHAIN_LOG_LEVEL="debug" DATACHAIN_LOG_OUTPUT=true DATACHAIN_LOG_EXTERNAL=fsspec,s3fs
python script.py
```

```log
09:29:07 - s3fs - DEBUG - Setting up s3fs instance [4084/fsspecIO/Task-1]
09:29:07 - s3fs - DEBUG - RC: caching enabled? True (explicit option is True) [4084/fsspecIO/Task-1]
09:29:09 - s3fs - DEBUG - RC: Creating a new regional client for 'bucket' on the region 'us-east-1' [4084/fsspecIO/Task-1]
09:29:11 - s3fs - DEBUG - RC: Creating a new regional client for 'dvc-public' on the region 'us-east-2' [4084/fsspecIO/Task-8]
09:29:11 - s3fs - DEBUG - CALL: head_object - ({},) - {'Bucket': 'dvc-public', 'Key': 'data/dvcx/cats-and-dogs'} [4084/fsspecIO/Task-8]
09:29:12 - s3fs - DEBUG - Client error (maybe retryable): An error occurred (404) when calling the HeadObject operation: Not Found [4084/fsspecIO/Task-8]
```