### PR TITLE
ci: switch trigger from `pull_request_target` to `pull_request`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
 
 env:
@@ -14,15 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  authorize:
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
   lint:
-    needs: authorize
-
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -62,8 +54,6 @@ jobs:
         run: nox -s lint
 
   datachain:
-    needs: authorize
-
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
@@ -129,8 +119,6 @@ jobs:
         run: nox -s docs
 
   examples:
-    needs: authorize
-
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
The current setup with `pull_request_target` is unnecessary because tests are skipped when tokens are unavailable.

This currently affects HuggingFace-related tests.
Maintainers can help when the contributor's change affects those areas. This situation is no different from other tests that require `ANTHROPIC_API_KEY` or `OPENAPI_KEY`, or Studio tests that don't run in fork.

Using `pull_request_target` also prevents changes to workflows from being tested, as it always runs workflows from the default branch. This makes it difficult to modify workflows.
Switching to `pull_request` resolves this issue.

Also, see https://github.com/iterative/datachain/pull/667#issuecomment-2527821664.