### PR TITLE
add upload classmethod to File

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -390,6 +390,10 @@ class Client(ABC):
 
     def upload(self, path: str, data: bytes) -> "File":
         full_path = self.get_full_path(path)
+
+        parent = "/".join(full_path.split("/")[:-1])
+        self.fs.makedirs(parent, exist_ok=True)
+
         self.fs.pipe_file(full_path, data)
         file_info = self.fs.info(full_path)
         return self.info_to_file(file_info, path)

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -191,6 +191,24 @@ class File(DataModel):
         self._caching_enabled: bool = False
 
     @classmethod
+    def upload(
+        cls, path: str, data: bytes, catalog: Optional["Catalog"] = None
+    ) -> "File":
+        if catalog is None:
+            from datachain.catalog.loader import get_catalog
+
+            catalog = get_catalog()
+
+        parts = path.split("/")
+        parent = "/".join(parts[:-1])
+        name = parts[-1]
+
+        client = catalog.get_client(parent)
+        file = client.upload(name, data)
+        file._set_stream(catalog)
+        return file
+
+    @classmethod
     def _from_row(cls, row: "RowDict") -> "Self":
         return cls(**{key: row[key] for key in cls._datachain_column_types})
 

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -43,3 +43,23 @@ def test_resolve_file_no_exist(cloud_test_catalog):
     assert resolved_non_existent.size == 0
     assert resolved_non_existent.etag == ""
     assert resolved_non_existent.last_modified == TIME_ZERO
+
+
+def test_upload(cloud_test_catalog):
+    ctc = cloud_test_catalog
+
+    src_uri = ctc.src_uri
+    filename = "image_1.jpg"
+    source = f"{src_uri}/upload-test-images"
+    catalog = ctc.catalog
+
+    img_bytes = b"bytes"
+
+    f = File.upload(f"{source}/{filename}", img_bytes, catalog)
+
+    assert f.path == filename
+    assert f.source == source
+    assert f.read() == img_bytes
+
+    client = catalog.get_client(src_uri)
+    client.fs.rm(source, recursive=True)


### PR DESCRIPTION
Closes #771

The original example https://github.com/iterative/datachain/pull/758 from becomes:

```python


import io
from collections.abc import Iterator

import imageio
import imageio.v3 as iio
from ultralytics import YOLO

from datachain import DataChain, File
from datachain.model.ultralytics import YoloPoses

base_path = "gs://redacted"


def pose_estimation(
    yolo: YOLO, file: File
) -> Iterator[tuple[File, int, float, YoloPoses]]:
    stem = file.get_file_stem()
    ext = file.get_file_ext()

    reader = imageio.get_reader(io.BytesIO(file.read()), format=ext)
    fps = reader.get_meta_data()["fps"]

    for frame, img in enumerate(reader):
        filename = f"{base_path}/frames/{stem}_{frame:06d}.jpg"
        img_encoded = iio.imwrite("<bytes>", img, extension=".jpeg")
        f = File.upload(filename, img_encoded)

        timestamp = frame / fps
        results = yolo(img)

        yield f, frame, timestamp, YoloPoses.from_results(results)


(
    DataChain.from_storage(f"{base_path}/videos/1e28")
    .limit(1)
    .setup(
        yolo=lambda: YOLO("yolo11n-pose.pt"),
    )
    .gen(pose_estimation, output=("file", "frame", "timestamp", "poses"))
    .save("videos-frames-poses")
)

DataChain.from_dataset("videos-frames-poses").show()

```