### PR TITLE
append e2e tests coverage instead of overwriting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
         shell: bash
 
       - name: Run E2E tests
-        run: nox -s tests-${{ matrix.pyv }} -- -m "e2e" $DISABLE_REMOTES_ARG
+        run: nox -s tests-${{ matrix.pyv }} -- -m "e2e" --cov-append $DISABLE_REMOTES_ARG
         shell: bash
 
       - name: Upload coverage report


### PR DESCRIPTION
Docs are here: https://pytest-cov.readthedocs.io/en/latest/readme.html#coverage-data-file

See change from #842 -https://app.codecov.io/gh/iterative/datachain/commit/7d0913e37a31f42704ba24a1e602193f58f99b0e