### PR TITLE
Filter logging to hide massive stacktrace for access issue

### DIFF
--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import posixpath
 from collections.abc import Iterator
@@ -23,6 +24,10 @@ LISTING_TTL = 4 * 60 * 60  # cached listing lasts 4 hours
 LISTING_PREFIX = "lst__"  # listing datasets start with this name
 
 D = TypeVar("D", bound="DataChain")
+
+# Disable warnings for remote errors in clients
+logging.getLogger("aiobotocore.credentials").setLevel(logging.CRITICAL)
+logging.getLogger("gcsfs").setLevel(logging.CRITICAL)
 
 
 def list_bucket(uri: str, cache, client_config=None) -> Callable:


### PR DESCRIPTION
# main > #856 > #857  (this)


With this change, we will return the ClientError without any extra error
or logs in the terminal. As a result, if we capture the ClientError in
the script, we will have minimum output.

Example query:
```python
from datachain.error import ClientError
from datachain.lib.dc import C, DataChain

try:
    wds = (
        DataChain.from_storage("az://amrit-datachain-test/shards")
        .filter(C.name.glob("00000000.tar"))
        .settings(parallel=8, cache=True)
    )

    wds.show()
except ClientError as e:
    print(str(e))

print("Exception caught")
```

Before changes:
```
Traceback (most recent call last):                                                                                                                           
  File "/Users/amritghimire/Documents/coding/iterative/datachain/.venv/lib/python3.12/site-packages/adlfs/spec.py", line 505, in do_connect
    raise ValueError(
ValueError: Must provide either a connection_string or account_name with credentials!!

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/amritghimire/Documents/coding/iterative/datachain/test.py", line 12, in <module>
    DataChain.from_storage("az://amrit-datachain-test/shards")
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/lib/dc.py", line 468, in from_storage
    .save(list_ds_name, listing=True)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/lib/dc.py", line 715, in save
    query=self._query.save(
          ^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/query/dataset.py", line 1637, in save
    query = self.apply_steps()
            ^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/query/dataset.py", line 1183, in apply_steps
    result = step.apply(
             ^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/query/dataset.py", line 598, in apply
    self.populate_udf_table(udf_table, query)
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/query/dataset.py", line 516, in populate_udf_table
    process_udf_outputs(
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/query/dataset.py", line 340, in process_udf_outputs
    for row in udf_output:
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/lib/udf.py", line 463, in _process_row
    for result_obj in result_objs:
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/lib/listing.py", line 36, in list_func
    for entries in iter_over_async(client.scandir(path.rstrip("/")), get_loop()):
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/asyn.py", line 280, in iter_over_async
    done, obj = asyncio.run_coroutine_threadsafe(get_next(), loop).result()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/.pyenv/versions/3.12.4/lib/python3.12/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/.pyenv/versions/3.12.4/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/asyn.py", line 273, in get_next
    obj = await ait.__anext__()
          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/client/fsspec.py", line 249, in scandir
    await main_task
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/client/azure.py", line 50, in _fetch_flat
    async with self.fs.service_client.get_container_client(
               ^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/client/fsspec.py", line 201, in fs
    self._fs = self.create_fs(**self.fs_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/src/datachain/client/fsspec.py", line 136, in create_fs
    fs = cls.FS_CLASS(**kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/.venv/lib/python3.12/site-packages/fsspec/spec.py", line 81, in __call__
    obj = super().__call__(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amritghimire/Documents/coding/iterative/datachain/.venv/lib/python3.12/site-packages/adlfs/spec.py", line 334, in __init__
    self.do_connect()
  File "/Users/amritghimire/Documents/coding/iterative/datachain/.venv/lib/python3.12/site-packages/adlfs/spec.py", line 515, in do_connect
    raise ValueError(f"unable to connect to account for {e}")
ValueError: unable to connect to account for Must provide either a connection_string or account_name with credentials!!
```
After changes:
```
unable to connect to account for Must provide either a connection_string or account_name with credentials!!
Exception caught
```

Closes #600
