### PR TITLE
Added ability for constant literals in `DataChain.mutate(...)`

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1134,8 +1134,7 @@ class DataChain:
 
         for col_name, expr in kwargs.items():
             if (
-                not isinstance(expr, primitives)
-                and not isinstance(expr, (Column, Func))
+                not isinstance(expr, primitives + (Column, Func))
                 and isinstance(expr.type, NullType)
             ):
                 raise DataChainColumnError(

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1133,7 +1133,7 @@ class DataChain:
         primitives = (bool, str, int, float)
 
         for col_name, expr in kwargs.items():
-            if not isinstance(expr, primitives + (Column, Func)) and isinstance(
+            if not isinstance(expr, (*primitives, Column, Func)) and isinstance(
                 expr.type, NullType
             ):
                 raise DataChainColumnError(
@@ -1152,7 +1152,9 @@ class DataChain:
                 mutated[name] = value.get_column(schema)
             elif isinstance(value, primitives):
                 # adding simple python constant primitives like str, int, float, bool
-                mutated[name] = literal(value)  # type: ignore[assignment]
+                val = literal(value)
+                val.type = python_to_sql(type(value))()
+                mutated[name] = val  # type: ignore[assignment]
             else:
                 # adding new signal
                 mutated[name] = value

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import posixpath
 from collections.abc import Iterator
@@ -23,6 +24,10 @@ LISTING_TTL = 4 * 60 * 60  # cached listing lasts 4 hours
 LISTING_PREFIX = "lst__"  # listing datasets start with this name
 
 D = TypeVar("D", bound="DataChain")
+
+# Disable warnings for remote errors in clients
+logging.getLogger("aiobotocore.credentials").setLevel(logging.CRITICAL)
+logging.getLogger("gcsfs").setLevel(logging.CRITICAL)
 
 
 def list_bucket(uri: str, cache, client_config=None) -> Callable:

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -425,6 +425,20 @@ def test_lt_mutate(dc):
     assert list(res) == [0, 0, 0, 0, 0]
 
 
+def test_mutate_with_literal(dc):
+    res = dc.mutate(test=1).collect("test")
+    assert list(res) == [1, 1, 1, 1, 1]
+
+    res = dc.mutate(test=0.5).collect("test")
+    assert list(res) == [0.5, 0.5, 0.5, 0.5, 0.5]
+
+    res = dc.mutate(test="a").collect("test")
+    assert list(res) == ["a", "a", "a", "a", "a"]
+
+    res = dc.mutate(test=True).collect("test")
+    assert list(res) == [True, True, True, True, True]
+
+
 def test_le():
     rnd1, rnd2 = rand(), rand()
 

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -425,18 +425,10 @@ def test_lt_mutate(dc):
     assert list(res) == [0, 0, 0, 0, 0]
 
 
-def test_mutate_with_literal(dc):
-    res = dc.mutate(test=1).collect("test")
-    assert list(res) == [1, 1, 1, 1, 1]
-
-    res = dc.mutate(test=0.5).collect("test")
-    assert list(res) == [0.5, 0.5, 0.5, 0.5, 0.5]
-
-    res = dc.mutate(test="a").collect("test")
-    assert list(res) == ["a", "a", "a", "a", "a"]
-
-    res = dc.mutate(test=True).collect("test")
-    assert list(res) == [True, True, True, True, True]
+@pytest.mark.parametrize("value", [1, 0.5, "a", True])
+def test_mutate_with_literal(dc, value):
+    res = dc.mutate(test=value).collect("test")
+    assert list(res) == [value] * 5
 
 
 def test_le():


### PR DESCRIPTION
Adding ability to do something like: 
```python
dc = dc.mutate(val=0.5)
```
This will create column `val` with constant value `0.5` for all rows.

For now it's implement for basic primitives like `int`, `bool`, `str` and `float`. Later on we can extend it to things like lists etc.