### PR TITLE
rearrange input params for upload methods

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -389,7 +389,7 @@ class Client(ABC):
             self.fs.open(self.get_full_path(file.path, file.version)), cb
         )  # type: ignore[return-value]
 
-    def upload(self, path: str, data: bytes) -> "File":
+    def upload(self, data: bytes, path: str) -> "File":
         full_path = self.get_full_path(path)
 
         parent = posixpath.dirname(full_path)

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -192,7 +192,7 @@ class File(DataModel):
 
     @classmethod
     def upload(
-        cls, path: str, data: bytes, catalog: Optional["Catalog"] = None
+        cls, data: bytes, path: str, catalog: Optional["Catalog"] = None
     ) -> "File":
         if catalog is None:
             from datachain.catalog.loader import get_catalog
@@ -202,7 +202,7 @@ class File(DataModel):
         parent, name = posixpath.split(path)
 
         client = catalog.get_client(parent)
-        file = client.upload(name, data)
+        file = client.upload(data, name)
         file._set_stream(catalog)
         return file
 

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -375,7 +375,7 @@ class StudioClient:
             method="GET",
         )
 
-    def upload_file(self, file_name: str, content: bytes) -> Response[FileUploadData]:
+    def upload_file(self, content: bytes, file_name: str) -> Response[FileUploadData]:
         data = {
             "file_content": base64.b64encode(content).decode("utf-8"),
             "file_name": file_name,

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -282,7 +282,7 @@ def upload_files(client: StudioClient, files: list[str]) -> list[str]:
         file_name = os.path.basename(file)
         with open(file, "rb") as f:
             file_content = f.read()
-        response = client.upload_file(file_name, file_content)
+        response = client.upload_file(file_content, file_name)
         if not response.ok:
             raise_remote_error(response.message)
 

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -55,7 +55,7 @@ def test_upload(cloud_test_catalog):
 
     img_bytes = b"bytes"
 
-    f = File.upload(f"{source}/{filename}", img_bytes, catalog)
+    f = File.upload(img_bytes, f"{source}/{filename}", catalog)
 
     assert f.path == filename
     assert f.source == source


### PR DESCRIPTION
This PR changes the `upload` methods to have data (from) first and then path (to) second as input parameters.