### PR TITLE
Add toolkit link to API Reference index page

### DIFF
--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -12,3 +12,4 @@ DataChain's API is organized into several modules:
 - [UDF](./udf.md) - User-defined functions and transformations
 - [Functions](./func.md) - Built-in functions for data manipulation and analysis
 - [Torch](./torch.md) - PyTorch data loading utilities
+- [Toolkit](./toolkit.md) - Functions for common DS/ML operations


### PR DESCRIPTION
Follow-up for the https://github.com/iterative/datachain/pull/885

> Could you add a link to to [Overview page](https://docs.datachain.ai/references/) as well?