### PR TITLE
Adding explicit `or_` function

### DIFF
--- a/src/datachain/func/__init__.py
+++ b/src/datachain/func/__init__.py
@@ -16,7 +16,7 @@ from .aggregate import (
     sum,
 )
 from .array import contains, cosine_distance, euclidean_distance, length, sip_hash_64
-from .conditional import case, greatest, ifelse, isnone, least
+from .conditional import case, greatest, ifelse, isnone, least, or_
 from .numeric import bit_and, bit_hamming_distance, bit_or, bit_xor, int_hash_64
 from .random import rand
 from .string import byte_hamming_distance
@@ -49,6 +49,7 @@ __all__ = [
     "literal",
     "max",
     "min",
+    "or_",
     "path",
     "rand",
     "random",

--- a/src/datachain/func/conditional.py
+++ b/src/datachain/func/conditional.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 from sqlalchemy import ColumnElement
 from sqlalchemy import case as sql_case
+from sqlalchemy import or_ as sql_or
 
 from datachain.lib.utils import DataChainParamsError
 from datachain.query.schema import Column
@@ -204,3 +205,32 @@ def isnone(col: Union[str, Column]) -> Func:
         col = C(col)
 
     return case((col.is_(None) if col is not None else True, True), else_=False)
+
+
+def or_(*args: Union[ColumnElement, Func]) -> Func:
+    """
+    Returns the function that produces conjunction of expressions joined by OR
+    logical operator
+
+    Args:
+        args (ColumnElement | Func): The expressions for OR statement.
+
+    Returns:
+        Func: A Func object that represents the or function.
+
+    Example:
+        ```py
+        dc.mutate(
+            test=ifelse(or_(isnone("num"), C("num") == 0), "Empty", "Not Empty")
+        )
+        ```
+    """
+    cols, func_args = [], []
+
+    for arg in args:
+        if isinstance(arg, (str, Func)):
+            cols.append(arg)
+        else:
+            func_args.append(arg)
+
+    return Func("or", inner=sql_or, cols=cols, args=func_args, result_type=bool)

--- a/src/datachain/func/conditional.py
+++ b/src/datachain/func/conditional.py
@@ -210,7 +210,7 @@ def isnone(col: Union[str, Column]) -> Func:
 def or_(*args: Union[ColumnElement, Func]) -> Func:
     """
     Returns the function that produces conjunction of expressions joined by OR
-    logical operator
+    logical operator.
 
     Args:
         args (ColumnElement | Func): The expressions for OR statement.
@@ -221,7 +221,7 @@ def or_(*args: Union[ColumnElement, Func]) -> Func:
     Example:
         ```py
         dc.mutate(
-            test=ifelse(or_(isnone("num"), C("num") == 0), "Empty", "Not Empty")
+            test=ifelse(or_(isnone("name"), C("name") == ''), "Empty", "Not Empty")
         )
         ```
     """

--- a/tests/unit/sql/test_conditional.py
+++ b/tests/unit/sql/test_conditional.py
@@ -154,3 +154,19 @@ def test_isnone(warehouse, val, expected):
     query = select(isnone(val))
     result = tuple(warehouse.db.execute(query))
     assert result == ((expected,),)
+
+
+@pytest.mark.parametrize(
+    "val1,val2,expected",
+    [
+        [None, func.literal("a"), True],
+        [None, None, True],
+        [func.literal("a"), func.literal("a"), False],
+    ],
+)
+def test_or(warehouse, val1, val2, expected):
+    from datachain.func.conditional import isnone, or_
+
+    query = select(or_(isnone(val1), isnone(val2)))
+    result = tuple(warehouse.db.execute(query))
+    assert result == ((expected,),)

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -10,6 +10,7 @@ from datachain.func import (
     int_hash_64,
     isnone,
     literal,
+    or_,
 )
 from datachain.func.array import contains
 from datachain.func.random import rand
@@ -304,6 +305,18 @@ def test_or_mutate(dc):
 
     res = dc.mutate(test=strlen("val") | strlen("val")).order_by("num").collect("test")
     assert list(res) == [1, 2, 3, 4, 5]
+
+
+@skip_if_not_sqlite
+def test_or_func_mutate(dc):
+    res = dc.mutate(test=ifelse(or_(C("num") < 3, C("num") > 4), "Match", "Not Match"))
+    assert list(res.order_by("num").collect("test")) == [
+        "Match",
+        "Match",
+        "Not Match",
+        "Not Match",
+        "Match",
+    ]
 
 
 def test_xor():


### PR DESCRIPTION
It's possible to use `|` for OR expressions, but  sometimes it's just more handy to have explicit `or_` function, just like sqlalchemy has.