### PR TITLE
add eval-type-backport for docs built with python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ docs = [
   "mkdocs-material==9.5.22",
   "mkdocs-section-index>=0.3.6",
   "mkdocstrings-python>=1.6.3",
-  "mkdocs-literate-nav>=0.6.1"
+  "mkdocs-literate-nav>=0.6.1",
+  "eval-type-backport"
 ]
 torch = [
   "torch>=2.1.0",


### PR DESCRIPTION
`build docs` is currently failing for all platforms in the CI against Python 3.9. This PR follows the provided error message.

example: https://github.com/iterative/datachain/actions/runs/13126453256/job/36623622317