### PR TITLE
Add datasets filter for `datachain ds ls`

### DIFF
--- a/src/datachain/cli/__init__.py
+++ b/src/datachain/cli/__init__.py
@@ -161,7 +161,7 @@ def handle_dataset_command(args, catalog):
             all=args.all,
             team=args.team,
             latest_only=not args.versions,
-            dataset_name=args.dataset_name,
+            name=args.name,
         ),
         "rm": lambda: rm_dataset(
             catalog,

--- a/src/datachain/cli/__init__.py
+++ b/src/datachain/cli/__init__.py
@@ -161,6 +161,7 @@ def handle_dataset_command(args, catalog):
             all=args.all,
             team=args.team,
             latest_only=not args.versions,
+            dataset_name=args.dataset_name,
         ),
         "rm": lambda: rm_dataset(
             catalog,

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -255,7 +255,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         formatter_class=CustomHelpFormatter,
     )
     datasets_ls_parser.add_argument(
-        "dataset_name", action="store", help="Name of the dataset to list", nargs="?"
+        "name", action="store", help="Name of the dataset to list", nargs="?"
     )
     datasets_ls_parser.add_argument(
         "--versions",

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -255,6 +255,9 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         formatter_class=CustomHelpFormatter,
     )
     datasets_ls_parser.add_argument(
+        "dataset_name", action="store", help="Name of the dataset to list", nargs="?"
+    )
+    datasets_ls_parser.add_argument(
         "--versions",
         action="store_true",
         default=False,

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -140,9 +140,9 @@ def token():
     print(token)
 
 
-def list_datasets(team: Optional[str] = None, dataset_name: Optional[str] = None):
-    if dataset_name:
-        yield from list_dataset_versions(team, dataset_name)
+def list_datasets(team: Optional[str] = None, name: Optional[str] = None):
+    if name:
+        yield from list_dataset_versions(team, name)
         return
 
     client = StudioClient(team=team)
@@ -165,10 +165,10 @@ def list_datasets(team: Optional[str] = None, dataset_name: Optional[str] = None
             yield (name, version)
 
 
-def list_dataset_versions(team: Optional[str] = None, dataset_name: str = ""):
+def list_dataset_versions(team: Optional[str] = None, name: str = ""):
     client = StudioClient(team=team)
 
-    response = client.dataset_info(dataset_name)
+    response = client.dataset_info(name)
 
     if not response.ok:
         raise_remote_error(response.message)
@@ -178,7 +178,7 @@ def list_dataset_versions(team: Optional[str] = None, dataset_name: str = ""):
 
     for v in response.data.get("versions", []):
         version = v.get("version")
-        yield (dataset_name, version)
+        yield (name, version)
 
 
 def edit_studio_dataset(

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -140,11 +140,18 @@ def token():
     print(token)
 
 
-def list_datasets(team: Optional[str] = None):
+def list_datasets(team: Optional[str] = None, dataset_name: Optional[str] = None):
+    if dataset_name:
+        yield from list_dataset_versions(team, dataset_name)
+        return
+
     client = StudioClient(team=team)
+
     response = client.ls_datasets()
+
     if not response.ok:
         raise_remote_error(response.message)
+
     if not response.data:
         return
 
@@ -156,6 +163,22 @@ def list_datasets(team: Optional[str] = None):
         for v in d.get("versions", []):
             version = v.get("version")
             yield (name, version)
+
+
+def list_dataset_versions(team: Optional[str] = None, dataset_name: str = ""):
+    client = StudioClient(team=team)
+
+    response = client.dataset_info(dataset_name)
+
+    if not response.ok:
+        raise_remote_error(response.message)
+
+    if not response.data:
+        return
+
+    for v in response.data.get("versions", []):
+        version = v.get("version")
+        yield (dataset_name, version)
 
 
 def edit_studio_dataset(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -631,12 +631,14 @@ def studio_datasets(requests_mock):
     with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
 
+    dogs_dataset = {
+        "id": 1,
+        "name": "dogs",
+        "versions": [{"version": 1}, {"version": 2}],
+    }
+
     datasets = [
-        {
-            "id": 1,
-            "name": "dogs",
-            "versions": [{"version": 1}, {"version": 2}],
-        },
+        dogs_dataset,
         {
             "id": 2,
             "name": "cats",
@@ -650,6 +652,10 @@ def studio_datasets(requests_mock):
     ]
 
     requests_mock.get(f"{STUDIO_URL}/api/datachain/datasets", json=datasets)
+    requests_mock.get(
+        f"{STUDIO_URL}/api/datachain/datasets/info?dataset_name=dogs&team_name=team_name",
+        json=dogs_dataset,
+    )
 
 
 @pytest.fixture

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -120,7 +120,7 @@ def test_studio_team_global():
 
 
 def test_studio_datasets(capsys, studio_datasets, mocker):
-    def list_datasets_local(_):
+    def list_datasets_local(_, __):
         yield "local", 1
         yield "both", 1
 
@@ -161,6 +161,12 @@ def test_studio_datasets(capsys, studio_datasets, mocker):
     ]
     both_output_versions = tabulate(both_rows_versions, headers="keys")
 
+    dogs_rows = [
+        {"Name": "dogs", "Latest Version": "v1"},
+        {"Name": "dogs", "Latest Version": "v2"},
+    ]
+    dogs_output = tabulate(dogs_rows, headers="keys")
+
     assert main(["dataset", "ls", "--local"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(local_output.splitlines())
@@ -184,6 +190,10 @@ def test_studio_datasets(capsys, studio_datasets, mocker):
     assert main(["dataset", "ls", "--versions"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(both_output_versions.splitlines())
+
+    assert main(["dataset", "ls", "dogs", "--studio"]) == 0
+    out = capsys.readouterr().out
+    assert sorted(out.splitlines()) == sorted(dogs_output.splitlines())
 
 
 def test_studio_edit_dataset(capsys, mocker):


### PR DESCRIPTION
With this change, a optional positional arg is added for datachain ds
ls.

Example output:
```
datachain ds ls temp
Name    Studio    Local
------  --------  -------
temp    v1        ✖
temp    v2        ✖
temp    v3        ✖
temp    v4        ✖
temp    v5        ✖
temp    v6        ✖
temp    v7        ✖
temp    v8        ✖
temp    v9        ✖
temp    v10       ✖
temp    v11       ✖
temp    v12       ✖
temp    v13       v13
```
