### PR TITLE
add loadgroup to test_shutdown_on_sigterm

### DIFF
--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -117,6 +117,7 @@ else:
     SIGKILL = signal.SIGKILL
 
 
+@pytest.mark.xdist_group(name="tmpfile")
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows does not have SIGTERM")
 @pytest.mark.parametrize(
     "setup,expected_return_code",


### PR DESCRIPTION
I've seen `test_shutdown_on_sigterm` fail a few times in the CI:

- https://github.com/iterative/datachain/actions/runs/13183455150/job/36799824090
- https://github.com/iterative/datachain/actions/runs/13185638547/job/36808507612
- https://github.com/iterative/datachain/actions/runs/13185638547/job/36808498643

My assumption is that the following line is causing issues when the tests are distributed between workers (we use `tmp_dir` fixture).

```
pathlib.Path("ready").touch(exist_ok=False)
```

I've added them to the same xdist loadgroup so they won't be able to run into one another.