### PR TITLE
fix(cli, studio): don't retry on non request/http errors

### DIFF
--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -14,6 +14,7 @@ from typing import (
 from urllib.parse import urlparse, urlunparse
 
 import websockets
+from requests.exceptions import HTTPError, Timeout
 
 from datachain.config import Config
 from datachain.error import DataChainError
@@ -104,8 +105,8 @@ class StudioClient:
             raise DataChainError(
                 "Studio team is not set. "
                 "Use `datachain auth team <team_name>` "
-                "or environment variable `DVC_STUDIO_TEAM` to set it."
-                "You can also set it in the config file as team under studio."
+                "or environment variable `DVC_STUDIO_TEAM` to set it. "
+                "You can also set `studio.team` in the config file."
             )
 
         return team
@@ -158,15 +159,14 @@ class StudioClient:
             message = content.get("message", "")
         return Response(response_data, ok, message)
 
-    @retry_with_backoff(retries=5)
+    @retry_with_backoff(retries=3, errors=(HTTPError, Timeout))
     def _send_request(
         self, route: str, data: dict[str, Any], method: Optional[str] = "POST"
     ) -> Response[Any]:
         """
         Function that communicate Studio API.
         It will raise an exception, and try to retry, if 5xx status code is
-        returned, or if ConnectionError or Timeout exceptions are thrown from
-        requests lib
+        returned, or if Timeout exceptions is thrown from the requests lib
         """
         import requests
 
@@ -188,7 +188,7 @@ class StudioClient:
         )
         try:
             response.raise_for_status()
-        except requests.exceptions.HTTPError:
+        except HTTPError:
             if _is_server_error(response.status_code):
                 # going to retry
                 raise


### PR DESCRIPTION
W/o this fix, if team is not set via env variable `DVC_STUDIO_TEAM` and / or DataChain config, `self.team` in Studio remote client raises a `DataChainError` (which is fine). What is not fine is that `_send_request` keeps retying with an exponential backoff on those.

Pretty much means that first time someone is trying to run something like `datachain ds pull ...` there are big chances to hit a long hang w/o any messages at all. Then if you are like to wait you can see that it just expect team to be set.

Also improves the messaging around `get_team` errors a bit.

## TODO:

- [ ] Add tests
- [x] Add logger to at least see what is going on with retries in debug mode.