### PR TITLE
Fix/upload set source as bucket

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -214,10 +214,13 @@ class File(DataModel):
 
             catalog = get_catalog()
 
-        parent, name = posixpath.split(path)
+        from datachain.client.fsspec import Client
 
-        client = catalog.get_client(parent)
-        file = client.upload(data, name)
+        client_cls = Client.get_implementation(path)
+        source, rel_path = client_cls.split_url(path)
+
+        client = catalog.get_client(client_cls.get_uri(source))
+        file = client.upload(data, rel_path)
         if not isinstance(file, cls):
             file = cls(**file.model_dump())
         file._set_stream(catalog)

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -50,16 +50,18 @@ def test_upload(cloud_test_catalog):
 
     src_uri = ctc.src_uri
     filename = "image_1.jpg"
-    source = f"{src_uri}/upload-test-images"
+    dest = f"{src_uri}/upload-test-images"
     catalog = ctc.catalog
 
     img_bytes = b"bytes"
 
-    f = File.upload(img_bytes, f"{source}/{filename}", catalog)
-
-    assert f.path == filename
-    assert f.source == source
-    assert f.read() == img_bytes
+    f = File.upload(img_bytes, f"{dest}/{filename}", catalog)
 
     client = catalog.get_client(src_uri)
-    client.fs.rm(source, recursive=True)
+    source, rel_path = client.split_url(f"{dest}/{filename}")
+
+    assert f.path == rel_path
+    assert f.source == client.get_uri(source)
+    assert f.read() == img_bytes
+
+    client.fs.rm(dest, recursive=True)


### PR DESCRIPTION
Fixes `File.upload` when source and path are set not as bucket + full path within bucket, but as bucket/path + file name.

E.g.:

<img width="904" alt="Screenshot 2025-02-09 at 4 48 59 PM" src="https://github.com/user-attachments/assets/6fa4cd6b-eb74-48a0-affd-3e400c00c7a8" />

vs 

<img width="901" alt="Screenshot 2025-02-09 at 4 49 19 PM" src="https://github.com/user-attachments/assets/3a88674a-f087-4753-baa9-e5f1e0215fb9" />

It breaks download (and potentially some other code)

Along the way, some refactoring simplifying things 🤞 
