### PR TITLE
Adding explicit `and_` function

### DIFF
--- a/src/datachain/func/__init__.py
+++ b/src/datachain/func/__init__.py
@@ -16,13 +16,14 @@ from .aggregate import (
     sum,
 )
 from .array import contains, cosine_distance, euclidean_distance, length, sip_hash_64
-from .conditional import case, greatest, ifelse, isnone, least, or_
+from .conditional import and_, case, greatest, ifelse, isnone, least, or_
 from .numeric import bit_and, bit_hamming_distance, bit_or, bit_xor, int_hash_64
 from .random import rand
 from .string import byte_hamming_distance
 from .window import window
 
 __all__ = [
+    "and_",
     "any_value",
     "array",
     "avg",

--- a/src/datachain/func/conditional.py
+++ b/src/datachain/func/conditional.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union
 
 from sqlalchemy import ColumnElement
+from sqlalchemy import and_ as sql_and
 from sqlalchemy import case as sql_case
 from sqlalchemy import or_ as sql_or
 
@@ -238,3 +239,32 @@ def or_(*args: Union[ColumnElement, Func]) -> Func:
             func_args.append(arg)
 
     return Func("or", inner=sql_or, cols=cols, args=func_args, result_type=bool)
+
+
+def and_(*args: Union[ColumnElement, Func]) -> Func:
+    """
+    Returns the function that produces conjunction of expressions joined by AND
+    logical operator.
+
+    Args:
+        args (ColumnElement | Func): The expressions for AND statement.
+
+    Returns:
+        Func: A Func object that represents the and function.
+
+    Example:
+        ```py
+        dc.mutate(
+            test=ifelse(and_(isnone("name"), isnone("surname")), "Empty", "Not Empty")
+        )
+        ```
+    """
+    cols, func_args = [], []
+
+    for arg in args:
+        if isinstance(arg, (str, Func)):
+            cols.append(arg)
+        else:
+            func_args.append(arg)
+
+    return Func("and", inner=sql_and, cols=cols, args=func_args, result_type=bool)

--- a/tests/unit/sql/test_conditional.py
+++ b/tests/unit/sql/test_conditional.py
@@ -170,3 +170,19 @@ def test_or(warehouse, val1, val2, expected):
     query = select(or_(isnone(val1), isnone(val2)))
     result = tuple(warehouse.db.execute(query))
     assert result == ((expected,),)
+
+
+@pytest.mark.parametrize(
+    "val1,val2,expected",
+    [
+        [None, func.literal("a"), False],
+        [None, None, True],
+        [func.literal("a"), func.literal("a"), False],
+    ],
+)
+def test_and(warehouse, val1, val2, expected):
+    from datachain.func.conditional import and_, isnone
+
+    query = select(and_(isnone(val1), isnone(val2)))
+    result = tuple(warehouse.db.execute(query))
+    assert result == ((expected,),)

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -3,6 +3,7 @@ from sqlalchemy import Label
 
 from datachain import C, DataChain
 from datachain.func import (
+    and_,
     bit_hamming_distance,
     byte_hamming_distance,
     case,
@@ -316,6 +317,18 @@ def test_or_func_mutate(dc):
         "Not Match",
         "Not Match",
         "Match",
+    ]
+
+
+@skip_if_not_sqlite
+def test_and_func_mutate(dc):
+    res = dc.mutate(test=ifelse(and_(C("num") > 1, C("num") < 4), "Match", "Not Match"))
+    assert list(res.order_by("num").collect("test")) == [
+        "Not Match",
+        "Match",
+        "Match",
+        "Not Match",
+        "Not Match",
     ]
 
 


### PR DESCRIPTION
It's possible to use `&` for AND expressions, but  sometimes it's just more handy to have explicit `and_` function, just like sqlalchemy has.
Also we already have explicit `or_`