### PR TITLE
set `COVERAGE_CORE=sysmon` to improve tests' performance in 3.12

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,6 +32,12 @@ def bench(session: nox.Session) -> None:
 @nox.session(python=["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"])
 def tests(session: nox.Session) -> None:
     session.install(".[tests]")
+    env = {"COVERAGE_FILE": f".coverage.{session.python}"}
+    if session.python == "3.12":
+        # improve performance of tests in Python 3.12 when used with coverage
+        # https://github.com/nedbat/coveragepy/issues/1665
+        # https://github.com/python/cpython/issues/107674
+        env["COVERAGE_CORE"] = "sysmon"
     session.run(
         "pytest",
         "--cov",
@@ -41,7 +47,7 @@ def tests(session: nox.Session) -> None:
         "--numprocesses=logical",
         "--dist=loadgroup",
         *session.posargs,
-        env={"COVERAGE_FILE": f".coverage.{session.python}"},
+        env=env,
     )
 
 


### PR DESCRIPTION
Closes #906.

> Running tests without the `--cov` option is significantly faster on Python 3.12. Similarly,  the tests run quite fast on Python 3.11 with or without `--cov`.
>
> It turns out that this slowdown is caused by `pytest-cov`, which happens due to a regression in CPython 3.12, see:
>
>- https://github.com/python/cpython/issues/107674
>- https://github.com/nedbat/coveragepy/issues/1665
>
>It took me a lot of time to figure out why, because this did not show up on profiling, just that everything was 3x - 4x slower. And profilers do tend to add significant overhead, so I ignored it initially.
>
>With `pytest-cov`, the specific test is already running quite close to ~5s timeout, that the newer dependencies that `datamodel-code-generator` brought were enough to increase that to >5s, and started timing out. (For comparison, in Python 3.12, the test without `--cov` completes in ~1s, whereas in 3.11 with `--cov`, it completes in <1.5s.)
>
>If I had led with why the test was only failing on 3.12, I might have figured this out quickly, rather than chasing dependencies, xdist and multiprocessing issues.
>
>There is an experimental implementation inside `coverage` that should be faster, which can be set through `COVERAGE_CORE=sysmon` envvar, which will hopefully fix this issue. If not, I'll increase the timeout if necessary.

It looks like this change saves more than a minute of runtime on 3.12, and is now the fastest python version among what we test.

#### Before

![image](https://github.com/user-attachments/assets/eaaa5682-a6a8-4f4b-9e6b-2a8d0439f5b5)


#### After

<img width="660" alt="" src="https://github.com/user-attachments/assets/f84efc81-bf59-47bf-b0dd-ecf99e8f8942" />


Also worth mentioning that we do run coverage with `branch=true`, and it seems this could end slowing things down, but I haven't noticed that at the moment.

- https://github.com/nedbat/coveragepy/issues/1812
