### PR TITLE
Rename export_files to to_storage with cloud support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ high confidence scores.
 
     likely_cats = annotated.filter((Column("meta.inference.confidence") > 0.93) \
                                    & (Column("meta.inference.class_") == "cat"))
-    likely_cats.export_files("high-confidence-cats/", signal="file")
+    likely_cats.to_storage("high-confidence-cats/", signal="file")
 
 
 Example: LLM based text-file evaluation
@@ -109,7 +109,7 @@ Python code:
     )
 
     successful_chain = chain.filter(Column("is_success") == True)
-    successful_chain.export_files("./output_mistral")
+    successful_chain.to_storage("./output_mistral")
 
     print(f"{successful_chain.count()} files were exported")
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -47,7 +47,7 @@ annotated = images_id.merge(meta, on="id", right_on="meta.id")
 
 likely_cats = annotated.filter((Column("meta.inference.confidence") > 0.93) \
                                & (Column("meta.inference.class_") == "cat"))
-likely_cats.export_files("high-confidence-cats/", signal="file")
+likely_cats.to_storage("high-confidence-cats/", signal="file")
 ```
 
 ## Data curation with a local AI model
@@ -85,7 +85,7 @@ chain = (
 )
 
 positive_chain = chain.filter(Column("is_positive") == True)
-positive_chain.export_files("./output")
+positive_chain.to_storage("./output")
 
 print(f"{positive_chain.count()} files were exported")
 ```

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -390,7 +390,7 @@ class Client(ABC):
         )  # type: ignore[return-value]
 
     def upload(self, data: bytes, path: str) -> "File":
-        full_path = self.get_full_path(path)
+        full_path = path if path.startswith(self.PREFIX) else self.get_full_path(path)
 
         parent = posixpath.dirname(full_path)
         self.fs.makedirs(parent, exist_ok=True)

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -2444,7 +2444,7 @@ class DataChain:
         self._setup = self._setup | kwargs
         return self
 
-    def export_files(
+    def to_storage(
         self,
         output: str,
         signal: str = "file",

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -2462,6 +2462,13 @@ class DataChain:
             use_cache: If `True`, cache the files before exporting.
             link_type: Method to use for exporting files.
                 Falls back to `'copy'` if symlinking fails.
+
+        Example:
+            Cross cloud transfer
+            ```py
+            ds = DataChain.from_storage("s3://mybucket")
+            ds.to_storage("gs://mybucket", placement="filename")
+            ```
         """
         if placement == "filename" and (
             self._query.distinct(pathfunc.name(C(f"{signal}__path"))).count()

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -17,6 +17,7 @@ from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
+from fsspec.utils import stringify_path
 from PIL import Image as PilImage
 from pydantic import Field, field_validator
 
@@ -270,9 +271,9 @@ class File(DataModel):
 
     def save(self, destination: str):
         """Writes it's content to destination"""
-
-        client: Client = self._catalog.get_client(destination)
-        client.upload(self.read(), destination)
+        destination = stringify_path(destination)
+        client: Client = self._catalog.get_client(str(destination))
+        client.upload(self.read(), str(destination))
 
     def _symlink_to(self, destination: str):
         if self.location:
@@ -499,6 +500,7 @@ class TextFile(File):
 
     def save(self, destination: str):
         """Writes it's content to destination"""
+        destination = stringify_path(destination)
 
         client: Client = self._catalog.get_client(destination)
         with client.fs.open(destination, mode="w") as f:
@@ -515,6 +517,8 @@ class ImageFile(File):
 
     def save(self, destination: str):
         """Writes it's content to destination"""
+        destination = stringify_path(destination)
+
         client: Client = self._catalog.get_client(destination)
         with client.fs.open(destination, mode="wb") as f:
             self.read().save(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -472,9 +472,9 @@ def cloud_server_credentials(cloud_server, monkeypatch):
 
 def get_cloud_test_catalog(cloud_server, tmp_path, metastore, warehouse):
     cache_dir = tmp_path / ".datachain" / "cache"
-    cache_dir.mkdir(parents=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
     tmpfile_dir = tmp_path / ".datachain" / "tmp"
-    tmpfile_dir.mkdir()
+    tmpfile_dir.mkdir(exist_ok=True)
 
     catalog = Catalog(
         metastore=metastore,

--- a/tests/func/test_cloud_transfer.py
+++ b/tests/func/test_cloud_transfer.py
@@ -1,16 +1,23 @@
+import pytest
+
 from datachain import Session
 from datachain.lib.dc import DataChain
 from tests.conftest import get_cloud_test_catalog, make_cloud_server
 
 
 def test_cross_cloud_transfer(
+    request,
     tmp_upath_factory,
     tree,
     tmp_path,
     metastore,
     warehouse,
 ):
-    # Setup cloud storage paths and servers
+    disabled_remotes = request.config.getoption("--disable-remotes") or []
+
+    if any(remote in disabled_remotes for remote in ["azure", "gs", "all"]):
+        pytest.skip("Skipping all tests for azure, gs or all remotes")
+
     azure_path = tmp_upath_factory.mktemp("azure", version_aware=False)
     azure_server = make_cloud_server(azure_path, "azure", tree)
 

--- a/tests/func/test_cloud_transfer.py
+++ b/tests/func/test_cloud_transfer.py
@@ -1,0 +1,58 @@
+from datachain import Session
+from datachain.lib.dc import DataChain
+from tests.conftest import get_cloud_test_catalog, make_cloud_server
+
+
+def test_cross_cloud_transfer(
+    tmp_upath_factory,
+    tree,
+    tmp_path,
+    metastore,
+    warehouse,
+):
+    # Setup cloud storage paths and servers
+    azure_path = tmp_upath_factory.mktemp("azure", version_aware=False)
+    azure_server = make_cloud_server(azure_path, "azure", tree)
+
+    gcloud_path = tmp_upath_factory.mktemp("gs", version_aware=False)
+    gcloud_server = make_cloud_server(gcloud_path, "gs", tree)
+
+    # Initialize cloud catalogs
+    azure_catalog = get_cloud_test_catalog(azure_server, tmp_path, metastore, warehouse)
+    gcloud_catalog = get_cloud_test_catalog(
+        gcloud_server, tmp_path, metastore, warehouse
+    )
+
+    # Define test file paths
+    test_filename = "image_1.jpg"
+    test_content = b"bytes"
+
+    source_dir = f"{azure_catalog.src_uri}/source-test-images"
+    source_file = f"{source_dir}/{test_filename}"
+
+    dest_dir = f"{gcloud_catalog.src_uri}/destination-test-images"
+    dest_file = f"{dest_dir}/{test_filename}"
+
+    # Get cloud clients
+    azure_client = azure_catalog.catalog.get_client(source_file)
+    gcloud_client = gcloud_catalog.catalog.get_client(dest_file)
+
+    try:
+        # Create test file in Azure
+        with azure_client.fs.open(source_file, "wb") as f:
+            f.write(test_content)
+
+        # Perform cross-cloud transfer
+        combined_config = azure_server.client_config | gcloud_server.client_config
+        with Session("testSession", client_config=combined_config, in_memory=True):
+            datachain = DataChain.from_storage(source_dir)
+            datachain.to_storage(dest_dir, placement="filename")
+
+        # Verify transfer
+        with gcloud_client.fs.open(dest_file, "rb") as f:
+            assert f.read() == test_content
+
+    finally:
+        # Cleanup
+        azure_client.fs.rm(source_dir, recursive=True)
+        gcloud_client.fs.rm(dest_dir, recursive=True)

--- a/tests/func/test_cloud_transfer.py
+++ b/tests/func/test_cloud_transfer.py
@@ -61,5 +61,8 @@ def test_cross_cloud_transfer(
 
     finally:
         # Cleanup
-        azure_client.fs.rm(source_dir, recursive=True)
-        gcloud_client.fs.rm(dest_dir, recursive=True)
+        try:
+            azure_client.fs.rm(source_dir, recursive=True)
+            gcloud_client.fs.rm(dest_dir, recursive=True)
+        except FileNotFoundError:
+            pass

--- a/tests/func/test_cloud_transfer.py
+++ b/tests/func/test_cloud_transfer.py
@@ -51,7 +51,7 @@ def test_cross_cloud_transfer(
 
         # Perform cross-cloud transfer
         combined_config = azure_server.client_config | gcloud_server.client_config
-        with Session("testSession", client_config=combined_config, in_memory=True):
+        with Session("testSession", client_config=combined_config):
             datachain = DataChain.from_storage(source_dir)
             datachain.to_storage(dest_dir, placement="filename")
 

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -292,20 +292,20 @@ def test_read_file(cloud_test_catalog, use_cache):
 @pytest.mark.parametrize("use_cache", [True, False])
 @pytest.mark.parametrize("file_type", ["", "binary", "text"])
 @pytest.mark.parametrize("cloud_type", ["file"], indirect=True)
-def test_export_files(
+def test_to_storage(
     tmp_dir, cloud_test_catalog, test_session, placement, use_map, use_cache, file_type
 ):
     ctc = cloud_test_catalog
     df = DataChain.from_storage(ctc.src_uri, type=file_type, session=test_session)
     if use_map:
-        df.export_files(tmp_dir / "output", placement=placement, use_cache=use_cache)
+        df.to_storage(tmp_dir / "output", placement=placement, use_cache=use_cache)
         df.map(
             res=lambda file: file.export(
                 tmp_dir / "output", placement=placement, use_cache=use_cache
             )
         ).exec()
     else:
-        df.export_files(tmp_dir / "output", placement=placement)
+        df.to_storage(tmp_dir / "output", placement=placement)
 
     expected = {
         "description": "Cats and Dogs",
@@ -341,14 +341,14 @@ def test_export_images_files(test_session, tmp_dir, tmp_path, use_cache):
             ImageFile(path=img["name"], source=f"file://{tmp_path}") for img in images
         ],
         session=test_session,
-    ).export_files(tmp_dir / "output", placement="filename", use_cache=use_cache)
+    ).to_storage(tmp_dir / "output", placement="filename", use_cache=use_cache)
 
     for img in images:
         exported_img = Image.open(tmp_dir / "output" / img["name"])
         assert images_equal(img["data"], exported_img)
 
 
-def test_export_files_filename_placement_not_unique_files(tmp_dir, test_session):
+def test_to_storage_files_filename_placement_not_unique_files(tmp_dir, test_session):
     data = b"some\x00data\x00is\x48\x65\x6c\x57\x6f\x72\x6c\x64\xff\xffheRe"
     bucket_name = "mybucket"
     files = ["dir1/a.json", "dir1/dir2/a.json"]
@@ -364,7 +364,7 @@ def test_export_files_filename_placement_not_unique_files(tmp_dir, test_session)
 
     df = DataChain.from_storage((tmp_dir / bucket_name).as_uri(), session=test_session)
     with pytest.raises(ValueError):
-        df.export_files(tmp_dir / "output", placement="filename")
+        df.to_storage(tmp_dir / "output", placement="filename")
 
 
 def test_show(capsys, test_session):


### PR DESCRIPTION
This renames the export files to to storage adding the support for the
cloud destinations as well.

With this change, the following code will work:
```py
from datachain.lib.dc import DataChain

ds = DataChain.from_storage("az://amrit-test-az/image.png")
ds.save("az")

ds.to_storage("gs://amrit-datachain-test/destination", placement="filename")

```

Closes #859
