### PR TITLE
Add option to pass client config to from_storage

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -448,7 +448,8 @@ class DataChain:
         """
         file_type = get_file_type(type)
 
-        client_config = {"anon": True} if anon else client_config
+        if anon:
+            client_config = (client_config or {}) | {"anon": True}
         session = Session.get(session, client_config=client_config, in_memory=in_memory)
         cache = session.catalog.cache
         client_config = session.catalog.client_config

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -411,6 +411,7 @@ class DataChain:
         object_name: str = "file",
         update: bool = False,
         anon: bool = False,
+        client_config: Optional[dict] = None,
     ) -> "Self":
         """Get data from a storage as a list of file with all file attributes.
         It returns the chain itself as usual.
@@ -423,15 +424,31 @@ class DataChain:
             object_name : Created object column name.
             update : force storage reindexing. Default is False.
             anon : If True, we will treat cloud bucket as public one
+            client_config : Optional client configuration for the storage client.
 
         Example:
+            Simple call from s3
             ```py
             chain = DataChain.from_storage("s3://my-bucket/my-dir")
+            ```
+
+            With AWS S3-compatible storage
+            ```py
+            chain = DataChain.from_storage(
+                "s3://my-bucket/my-dir",
+                client_config = {"aws_endpoint_url": "<minio-endpoint-url>"}
+            )
+            ```
+
+            Pass existing session
+            ```py
+            session = Session.get()
+            chain = DataChain.from_storage("s3://my-bucket/my-dir", session=session)
             ```
         """
         file_type = get_file_type(type)
 
-        client_config = {"anon": True} if anon else None
+        client_config = {"anon": True} if anon else client_config
         session = Session.get(session, client_config=client_config, in_memory=in_memory)
         cache = session.catalog.cache
         client_config = session.catalog.client_config

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -158,8 +158,8 @@ class Session:
 
         if client_config and session.catalog.client_config != client_config:
             session = Session(
-                name="session_" + uuid4().hex[:4],
-                catalog=catalog,
+                "session" + uuid4().hex[:4],
+                catalog,
                 client_config=client_config,
                 in_memory=in_memory,
             )

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -64,6 +64,11 @@ def test_catalog_anon(tmp_dir, catalog, anon):
     assert chain.session.catalog.client_config.get("anon", False) is anon
 
 
+def test_from_storage_client_config(tmp_dir, catalog):
+    dc = DataChain.from_storage(tmp_dir.as_uri(), client_config={"anon": True})
+    assert dc.session.catalog.client_config == {"anon": True}
+
+
 def test_from_storage(cloud_test_catalog):
     ctc = cloud_test_catalog
     dc = DataChain.from_storage(ctc.src_uri, session=ctc.session)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -65,8 +65,13 @@ def test_catalog_anon(tmp_dir, catalog, anon):
 
 
 def test_from_storage_client_config(tmp_dir, catalog):
+    dc = DataChain.from_storage(tmp_dir.as_uri())
+    assert dc.session.catalog.client_config == {}  # Default client config is set.
+
     dc = DataChain.from_storage(tmp_dir.as_uri(), client_config={"anon": True})
-    assert dc.session.catalog.client_config == {"anon": True}
+    assert dc.session.catalog.client_config == {
+        "anon": True
+    }  # New client config is set.
 
 
 def test_from_storage(cloud_test_catalog):


### PR DESCRIPTION
This adds a new argument named client_config for from_storage call for DataChain.

Usage:
```py
chain = DataChain.from_storage(
    "s3://my-bucket/my-dir",
    client_config = {"aws_endpoint_url": "<minio-endpoint-url>"}
)
```

Closes #911
