### PR TITLE
Add option to specify the hidden field

### DIFF
--- a/src/datachain/cli/__init__.py
+++ b/src/datachain/cli/__init__.py
@@ -215,6 +215,7 @@ def handle_show_command(args, catalog):
         columns=args.columns,
         no_collapse=args.no_collapse,
         schema=args.schema,
+        include_hidden=args.hidden,
     )
 
 

--- a/src/datachain/cli/commands/show.py
+++ b/src/datachain/cli/commands/show.py
@@ -16,6 +16,7 @@ def show(
     columns: Sequence[str] = (),
     no_collapse: bool = False,
     schema: bool = False,
+    include_hidden: bool = False,
 ) -> None:
     from datachain import Session
     from datachain.lib.dc import DataChain
@@ -24,9 +25,13 @@ def show(
 
     dataset = catalog.get_dataset(name)
     dataset_version = dataset.get_version(version or dataset.latest_version)
-    hidden_fields = SignalSchema.get_flatten_hidden_fields(
-        dataset_version.feature_schema
-    )
+
+    if include_hidden:
+        hidden_fields = []
+    else:
+        hidden_fields = SignalSchema.get_flatten_hidden_fields(
+            dataset_version.feature_schema
+        )
 
     query = (
         DatasetQuery(name=name, version=version, catalog=catalog)

--- a/src/datachain/cli/commands/show.py
+++ b/src/datachain/cli/commands/show.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional
 
+from datachain.lib.signal_schema import SignalSchema
+
 if TYPE_CHECKING:
     from datachain.catalog import Catalog
 
@@ -22,6 +24,7 @@ def show(
 
     dataset = catalog.get_dataset(name)
     dataset_version = dataset.get_version(version or dataset.latest_version)
+    hidden_fields = SignalSchema.get_hidden_fields(dataset_version.feature_schema)
 
     query = (
         DatasetQuery(name=name, version=version, catalog=catalog)
@@ -30,7 +33,8 @@ def show(
         .offset(offset)
     )
     records = query.to_db_records()
-    show_records(records, collapse_columns=not no_collapse)
+    show_records(records, collapse_columns=not no_collapse, hidden_fields=hidden_fields)
+
     if schema and dataset_version.feature_schema:
         print("\nSchema:")
         session = Session.get(catalog=catalog)

--- a/src/datachain/cli/commands/show.py
+++ b/src/datachain/cli/commands/show.py
@@ -24,7 +24,9 @@ def show(
 
     dataset = catalog.get_dataset(name)
     dataset_version = dataset.get_version(version or dataset.latest_version)
-    hidden_fields = SignalSchema.get_hidden_fields(dataset_version.feature_schema)
+    hidden_fields = SignalSchema.get_flatten_hidden_fields(
+        dataset_version.feature_schema
+    )
 
     query = (
         DatasetQuery(name=name, version=version, catalog=catalog)

--- a/src/datachain/cli/parser/utils.py
+++ b/src/datachain/cli/parser/utils.py
@@ -98,3 +98,9 @@ def add_show_args(parser: ArgumentParser) -> None:
         default=False,
         help="Do not collapse the columns",
     )
+    parser.add_argument(
+        "--hidden",
+        action="store_true",
+        default=False,
+        help="Show hidden fields",
+    )

--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -26,6 +26,7 @@ class DataModel(BaseModel):
     """Pydantic model wrapper that registers model with `DataChain`."""
 
     _version: ClassVar[int] = 1
+    _hidden_fields: ClassVar[list[str]] = []
 
     @classmethod
     def __pydantic_init_subclass__(cls):
@@ -40,6 +41,11 @@ class DataModel(BaseModel):
             models = [models]
         for val in models:
             ModelStore.register(val)
+
+    @classmethod
+    def hidden_fields(cls) -> list[str]:
+        """Returns a list of fields that should be hidden from the user."""
+        return cls._hidden_fields
 
 
 def is_chain_type(t: type) -> bool:

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1254,7 +1254,7 @@ class DataChain:
         )
         with self._query.ordered_select(*db_signals).as_iterable() as rows:
             if row_factory:
-                rows = (row_factory(db_signals, r) for r in rows)  # type: ignore[assignment]
+                rows = (row_factory(db_signals, r) for r in rows)
             yield from rows
 
     def to_columnar_data_with_names(

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -65,7 +65,6 @@ _T = TypeVar("_T")
 D = TypeVar("D", bound="DataChain")
 UDFObjT = TypeVar("UDFObjT", bound=UDFBase)
 
-
 DEFAULT_PARQUET_CHUNK_SIZE = 100_000
 
 
@@ -1226,22 +1225,36 @@ class DataChain:
     def collect_flatten(self) -> Iterator[tuple[Any, ...]]: ...
 
     @overload
+    def collect_flatten(self, *, exclude_hidden: bool) -> Iterator[tuple[Any, ...]]: ...
+
+    @overload
     def collect_flatten(
         self, *, row_factory: Callable[[list[str], tuple[Any, ...]], _T]
     ) -> Iterator[_T]: ...
 
-    def collect_flatten(self, *, row_factory=None):
+    @overload
+    def collect_flatten(
+        self,
+        *,
+        row_factory: Callable[[list[str], tuple[Any, ...]], _T],
+        exclude_hidden: bool,
+    ) -> Iterator[_T]: ...
+
+    def collect_flatten(self, *, row_factory=None, exclude_hidden: bool = False):
         """Yields flattened rows of values as a tuple.
 
         Args:
             row_factory : A callable to convert row to a custom format.
                           It should accept two arguments: a list of column names and
                           a tuple of row values.
+            exclude_hidden: Whether to exclude hidden signals from the schema.
         """
-        db_signals = self._effective_signals_schema.db_signals()
+        db_signals = self._effective_signals_schema.db_signals(
+            exclude_hidden=exclude_hidden
+        )
         with self._query.ordered_select(*db_signals).as_iterable() as rows:
             if row_factory:
-                rows = (row_factory(db_signals, r) for r in rows)
+                rows = (row_factory(db_signals, r) for r in rows)  # type: ignore[assignment]
             yield from rows
 
     def to_columnar_data_with_names(
@@ -1275,10 +1288,23 @@ class DataChain:
         self, *, row_factory: Callable[[list[str], tuple[Any, ...]], _T]
     ) -> list[_T]: ...
 
-    def results(self, *, row_factory=None):  # noqa: D102
+    @overload
+    def results(
+        self,
+        *,
+        row_factory: Callable[[list[str], tuple[Any, ...]], _T],
+        exclude_hidden: bool,
+    ) -> list[_T]: ...
+
+    @overload
+    def results(self, *, exclude_hidden: bool) -> list[tuple[Any, ...]]: ...
+
+    def results(self, *, row_factory=None, exclude_hidden=False):  # noqa: D102
         if row_factory is None:
-            return list(self.collect_flatten())
-        return list(self.collect_flatten(row_factory=row_factory))
+            return list(self.collect_flatten(exclude_hidden=exclude_hidden))
+        return list(
+            self.collect_flatten(row_factory=row_factory, exclude_hidden=exclude_hidden)
+        )
 
     def to_records(self) -> list[dict[str, Any]]:
         """Convert every row to a dictionary."""
@@ -1788,21 +1814,25 @@ class DataChain:
             **fr_map,
         )
 
-    def to_pandas(self, flatten=False) -> "pd.DataFrame":
+    def to_pandas(self, flatten=False, exclude_hidden=False) -> "pd.DataFrame":
         """Return a pandas DataFrame from the chain.
 
         Parameters:
             flatten : Whether to use a multiindex or flatten column names.
+            exclude_hidden : Whether to exclude hidden columns.
         """
         import pandas as pd
 
-        headers, max_length = self._effective_signals_schema.get_headers_with_length()
+        headers, max_length = self._effective_signals_schema.get_headers_with_length(
+            exclude_hidden=exclude_hidden
+        )
         if flatten or max_length < 2:
             columns = [".".join(filter(None, header)) for header in headers]
         else:
             columns = pd.MultiIndex.from_tuples(map(tuple, headers))
 
-        return pd.DataFrame.from_records(self.results(), columns=columns)
+        results = self.results(exclude_hidden=exclude_hidden)
+        return pd.DataFrame.from_records(results, columns=columns)
 
     def show(
         self,
@@ -1810,6 +1840,7 @@ class DataChain:
         flatten=False,
         transpose=False,
         truncate=True,
+        exclude_hidden=True,
     ) -> None:
         """Show a preview of the chain results.
 
@@ -1818,11 +1849,12 @@ class DataChain:
             flatten : Whether to use a multiindex or flatten column names.
             transpose : Whether to transpose rows and columns.
             truncate : Whether or not to truncate the contents of columns.
+            exclude_hidden : Whether to exclude hidden columns.
         """
         import pandas as pd
 
         dc = self.limit(limit) if limit > 0 else self  # type: ignore[misc]
-        df = dc.to_pandas(flatten)
+        df = dc.to_pandas(flatten, exclude_hidden=exclude_hidden)
 
         if df.empty:
             print("Empty result")

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -1254,7 +1254,7 @@ class DataChain:
         )
         with self._query.ordered_select(*db_signals).as_iterable() as rows:
             if row_factory:
-                rows = (row_factory(db_signals, r) for r in rows)
+                rows = (row_factory(db_signals, r) for r in rows)  # type: ignore[assignment]
             yield from rows
 
     def to_columnar_data_with_names(

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -158,6 +158,7 @@ class File(DataModel):
         "last_modified": DateTime,
         "location": JSON,
     }
+    _hidden_fields: ClassVar[list[str]] = ["version", "source"]
 
     _unique_id_keys: ClassVar[list[str]] = [
         "source",

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -393,7 +393,7 @@ class SignalSchema:
         return SignalSchema(signals)
 
     @staticmethod
-    def get_hidden_fields(schema):
+    def get_flatten_hidden_fields(schema):
         custom_types = schema.get("_custom_types", {})
         if not custom_types:
             return []

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -91,6 +91,7 @@ class CustomType(BaseModel):
     name: str
     fields: dict[str, str]
     bases: list[tuple[str, str, Optional[str]]]
+    hidden_fields: Optional[list[str]] = None
 
     @classmethod
     def deserialize(cls, data: dict[str, Any], type_name: str) -> "CustomType":
@@ -102,6 +103,7 @@ class CustomType(BaseModel):
                 "name": type_name,
                 "fields": data,
                 "bases": [],
+                "hidden_fields": [],
             }
 
         return cls(**data)
@@ -203,7 +205,13 @@ class SignalSchema:
             )
             bases.append((type_.__name__, type_.__module__, model_store_name))
 
-        ct = CustomType(schema_version=2, name=version_name, fields=fields, bases=bases)
+        ct = CustomType(
+            schema_version=2,
+            name=version_name,
+            fields=fields,
+            bases=bases,
+            hidden_fields=getattr(fr, "_hidden_fields", []),
+        )
         custom_types[version_name] = ct.model_dump()
 
         return version_name
@@ -384,6 +392,37 @@ class SignalSchema:
 
         return SignalSchema(signals)
 
+    @staticmethod
+    def get_hidden_fields(schema):
+        custom_types = schema.get("_custom_types", {})
+        if not custom_types:
+            return []
+
+        hidden_by_types = {
+            name: schema.get("hidden_fields", [])
+            for name, schema in custom_types.items()
+        }
+
+        hidden_fields = []
+
+        def traverse(prefix, schema_info):
+            for field, field_type in schema_info.items():
+                if field == "_custom_types":
+                    continue
+
+                if field_type in custom_types:
+                    hidden_fields.extend(
+                        f"{prefix}{field}__{f}" for f in hidden_by_types[field_type]
+                    )
+                    traverse(
+                        prefix + field + "__",
+                        custom_types[field_type].get("fields", {}),
+                    )
+
+        traverse("", schema)
+
+        return hidden_fields
+
     def to_udf_spec(self) -> dict[str, type]:
         res = {}
         for path, type_, has_subtree, _ in self.get_flat_tree():
@@ -479,7 +518,7 @@ class SignalSchema:
         raise SignalResolvingError([col_name], "is not found")
 
     def db_signals(
-        self, name: Optional[str] = None, as_columns=False
+        self, name: Optional[str] = None, as_columns=False, exclude_hidden: bool = False
     ) -> Union[list[str], list[Column]]:
         """
         Returns DB columns as strings or Column objects with proper types
@@ -489,7 +528,9 @@ class SignalSchema:
             DEFAULT_DELIMITER.join(path)
             if not as_columns
             else Column(DEFAULT_DELIMITER.join(path), python_to_sql(_type))
-            for path, _type, has_subtree, _ in self.get_flat_tree()
+            for path, _type, has_subtree, _ in self.get_flat_tree(
+                exclude_hidden=exclude_hidden
+            )
             if not has_subtree
         ]
 
@@ -624,19 +665,31 @@ class SignalSchema:
             for name, val in values.items()
         }
 
-    def get_flat_tree(self) -> Iterator[tuple[list[str], DataType, bool, int]]:
-        yield from self._get_flat_tree(self.tree, [], 0)
+    def get_flat_tree(
+        self, exclude_hidden: bool = False
+    ) -> Iterator[tuple[list[str], DataType, bool, int]]:
+        yield from self._get_flat_tree(self.tree, [], 0, exclude_hidden)
 
     def _get_flat_tree(
-        self, tree: dict, prefix: list[str], depth: int
+        self, tree: dict, prefix: list[str], depth: int, exclude_hidden: bool
     ) -> Iterator[tuple[list[str], DataType, bool, int]]:
         for name, (type_, substree) in tree.items():
             suffix = name.split(".")
             new_prefix = prefix + suffix
+            hidden_fields = getattr(type_, "_hidden_fields", None)
+            if exclude_hidden and hidden_fields and substree:
+                substree = {
+                    field: info
+                    for field, info in substree.items()
+                    if field not in hidden_fields
+                }
+
             has_subtree = substree is not None
             yield new_prefix, type_, has_subtree, depth
             if substree is not None:
-                yield from self._get_flat_tree(substree, new_prefix, depth + 1)
+                yield from self._get_flat_tree(
+                    substree, new_prefix, depth + 1, exclude_hidden
+                )
 
     def print_tree(self, indent: int = 4, start_at: int = 0):
         for path, type_, _, depth in self.get_flat_tree():
@@ -649,9 +702,13 @@ class SignalSchema:
                     sub_schema = SignalSchema({"* list of": args[0]})
                     sub_schema.print_tree(indent=indent, start_at=total_indent + indent)
 
-    def get_headers_with_length(self):
+    def get_headers_with_length(self, exclude_hidden: bool = False):
         paths = [
-            path for path, _, has_subtree, _ in self.get_flat_tree() if not has_subtree
+            path
+            for path, _, has_subtree, _ in self.get_flat_tree(
+                exclude_hidden=exclude_hidden
+            )
+            if not has_subtree
         ]
         max_length = max([len(path) for path in paths], default=0)
         return [

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -392,34 +392,20 @@ class SignalSchema:
 
         return SignalSchema(signals)
 
-    @staticmethod
-    def get_flatten_hidden_fields(schema):
-        custom_types = schema.get("_custom_types", {})
-        if not custom_types:
-            return []
-
-        hidden_by_types = {
-            name: schema.get("hidden_fields", [])
-            for name, schema in custom_types.items()
-        }
-
+    def get_flattened_hidden_fields(self):
         hidden_fields = []
 
-        def traverse(prefix, schema_info):
-            for field, field_type in schema_info.items():
+        def traverse(prefix, tree):
+            for field, (field_type, subtree) in tree.items():
                 if field == "_custom_types":
                     continue
 
-                if field_type in custom_types:
-                    hidden_fields.extend(
-                        f"{prefix}{field}__{f}" for f in hidden_by_types[field_type]
-                    )
-                    traverse(
-                        prefix + field + "__",
-                        custom_types[field_type].get("fields", {}),
-                    )
+                if fields := getattr(field_type, "_hidden_fields", None):
+                    hidden_fields.extend(f"{prefix}{field}__{f}" for f in fields)
+                if subtree:
+                    traverse(prefix + field + DEFAULT_DELIMITER, subtree)
 
-        traverse("", schema)
+        traverse("", self.tree)
 
         return hidden_fields
 

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -362,6 +362,7 @@ def show_records(
     records: Optional[list[dict]],
     collapse_columns: bool = False,
     system_columns: bool = False,
+    hidden_fields: Optional[list[str]] = None,
 ) -> None:
     import pandas as pd
 
@@ -369,6 +370,8 @@ def show_records(
         return
 
     df = pd.DataFrame.from_records(records)
+    if hidden_fields:
+        df = df.drop(columns=hidden_fields, errors="ignore")
     return show_df(df, collapse_columns=collapse_columns, system_columns=system_columns)
 
 

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -57,7 +57,7 @@ def test_datachain_show_include_hidden(capsys, test_session):
     assert output_lines == expected_lines
 
 
-def test_datachain_save(test_session):
+def test_datachain_save_hidden_fields(test_session):
     inner = InnerClass(inner_value=1.1, hide_inner=1.2)
     outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
 
@@ -66,5 +66,6 @@ def test_datachain_save(test_session):
     version = test_session.catalog.get_dataset(ds.name).get_version(1)
     feature_schema = version.feature_schema
 
-    hidden_fields = SignalSchema.get_flatten_hidden_fields(feature_schema)
+    schema = SignalSchema.deserialize(feature_schema)
+    hidden_fields = schema.get_flattened_hidden_fields()
     assert hidden_fields == ["outer__hide_outer", "outer__inner_object__hide_inner"]

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -38,6 +38,25 @@ def test_datachain_show(capsys, test_session):
     assert output_lines == expected_lines
 
 
+def test_datachain_show_include_hidden(capsys, test_session):
+    inner = InnerClass(inner_value=1.1, hide_inner=1.2)
+    outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
+
+    expected = """
+        outer      outer        outer        outer nums
+  outer_value hide_outer inner_object inner_object
+                          inner_value   hide_inner
+0         1.3        1.4          1.1          1.2    1
+"""
+    DataChain.from_values(outer=[outer], nums=[1]).show(include_hidden=True)
+
+    captured = capsys.readouterr()
+    output_lines = [line.strip() for line in captured.out.strip().split("\n")]
+    expected_lines = [line.strip() for line in expected.strip().split("\n")]
+
+    assert output_lines == expected_lines
+
+
 def test_datachain_save(test_session):
     inner = InnerClass(inner_value=1.1, hide_inner=1.2)
     outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -47,5 +47,5 @@ def test_datachain_save(test_session):
     version = test_session.catalog.get_dataset(ds.name).get_version(1)
     feature_schema = version.feature_schema
 
-    hidden_fields = SignalSchema.get_hidden_fields(feature_schema)
+    hidden_fields = SignalSchema.get_flatten_hidden_fields(feature_schema)
     assert hidden_fields == ["outer__hide_outer", "outer__inner_object__hide_inner"]

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -1,0 +1,51 @@
+from typing import ClassVar
+
+from datachain import DataChain, DataModel
+from datachain.lib.signal_schema import SignalSchema
+
+
+class InnerClass(DataModel):
+    inner_value: float
+    hide_inner: float
+
+    _hidden_fields: ClassVar[list[str]] = ["hide_inner"]
+
+
+class OuterClass(DataModel):
+    outer_value: float
+    hide_outer: float
+
+    inner_object: InnerClass
+    _hidden_fields: ClassVar[list[str]] = ["hide_outer"]
+
+
+def test_datachain_show(capsys, test_session):
+    inner = InnerClass(inner_value=1.1, hide_inner=1.2)
+    outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
+
+    expected = """
+       outer        outer nums
+  outer_value inner_object
+               inner_value
+0         1.3          1.1    1
+"""
+    DataChain.from_values(outer=[outer], nums=[1]).show()
+
+    captured = capsys.readouterr()
+    output_lines = [line.strip() for line in captured.out.strip().split("\n")]
+    expected_lines = [line.strip() for line in expected.strip().split("\n")]
+
+    assert output_lines == expected_lines
+
+
+def test_datachain_save(test_session):
+    inner = InnerClass(inner_value=1.1, hide_inner=1.2)
+    outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
+
+    ds = DataChain.from_values(outer=[outer], nums=[1], session=test_session).save()
+
+    version = test_session.catalog.get_dataset(ds.name).get_version(1)
+    feature_schema = version.feature_schema
+
+    hidden_fields = SignalSchema.get_hidden_fields(feature_schema)
+    assert hidden_fields == ["outer__hide_outer", "outer__inner_object__hide_inner"]

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -57,7 +57,7 @@ def test_datachain_show_include_hidden(capsys, test_session):
     assert output_lines == expected_lines
 
 
-def test_datachain_save_hidden_fields(test_session):
+def test_datachain_save(test_session):
     inner = InnerClass(inner_value=1.1, hide_inner=1.2)
     outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
 
@@ -66,6 +66,5 @@ def test_datachain_save_hidden_fields(test_session):
     version = test_session.catalog.get_dataset(ds.name).get_version(1)
     feature_schema = version.feature_schema
 
-    schema = SignalSchema.deserialize(feature_schema)
-    hidden_fields = schema.get_flattened_hidden_fields()
+    hidden_fields = SignalSchema.get_flatten_hidden_fields(feature_schema)
     assert hidden_fields == ["outer__hide_outer", "outer__inner_object__hide_inner"]

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -146,6 +146,7 @@ def test_feature_schema_serialize_optional():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         }
     }
 
@@ -174,6 +175,7 @@ def test_feature_schema_serialize_list():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         }
     }
 
@@ -202,6 +204,7 @@ def test_feature_schema_serialize_list_old():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         }
     }
 
@@ -235,6 +238,7 @@ def test_feature_schema_serialize_nested_types():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
         "MyType2@v1": {
             "schema_version": 2,
@@ -246,6 +250,7 @@ def test_feature_schema_serialize_nested_types():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
     }
 
@@ -276,6 +281,7 @@ def test_feature_schema_serialize_nested_duplicate_types():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
         "MyType2@v1": {
             "schema_version": 2,
@@ -287,6 +293,7 @@ def test_feature_schema_serialize_nested_duplicate_types():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
     }
 
@@ -315,6 +322,7 @@ def test_feature_schema_serialize_complex():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
         "MyType2@v1": {
             "schema_version": 2,
@@ -326,6 +334,7 @@ def test_feature_schema_serialize_complex():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
         "MyTypeComplex@v1": {
             "schema_version": 2,
@@ -345,6 +354,7 @@ def test_feature_schema_serialize_complex():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
     }
 
@@ -373,6 +383,7 @@ def test_feature_schema_serialize_complex_old():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
         "MyType2@v1": {
             "schema_version": 2,
@@ -384,6 +395,7 @@ def test_feature_schema_serialize_complex_old():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
         "MyTypeComplexOld@v1": {
             "schema_version": 2,
@@ -403,6 +415,7 @@ def test_feature_schema_serialize_complex_old():
                 ("BaseModel", "pydantic.main", None),
                 ("object", "builtins", None),
             ],
+            "hidden_fields": [],
         },
     }
 


### PR DESCRIPTION
For any hidden fields, a `_hidden_fields` class variable will hide the
fields from the values when showing using `dc.show`.


Example on how to hide fields for custom model:
```python

from datachain import DataModel, DataChain


class InnerClass(DataModel):
    inner_value: float
    hide_inner: float

    _hidden_fields = ["hide_inner"]


class OuterClass(DataModel):
    outer_value: float
    hide_outer: float

    inner_object: InnerClass
    _hidden_fields = ["hide_outer"]


inner = InnerClass(inner_value=1.1, hide_inner=1.2)
outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
DataChain.from_values(
        outer=[outer],
        nums=[1]
).show()
```

This also takes care when we display the datachain using following command:
```
datachain show az
```

Similarly, https://github.com/iterative/studio/pull/11357 takes care of the UX in Studio. 

Test is also added.

Closes #830
