### PR TITLE
Fix 'too many open files' error during video upload

### DIFF
--- a/src/datachain/lib/video.py
+++ b/src/datachain/lib/video.py
@@ -170,7 +170,7 @@ def save_video_frame(
     output_file = posixpath.join(
         output, f"{video.get_file_stem()}_{frame:04d}.{format}"
     )
-    return ImageFile.upload(img, output_file)
+    return ImageFile.upload(img, output_file, catalog=video._catalog)
 
 
 def save_video_fragment(
@@ -218,6 +218,6 @@ def save_video_fragment(
         ).output(output_file_tmp).run(quiet=True)
 
         with open(output_file_tmp, "rb") as f:
-            return VideoFile.upload(f.read(), output_file)
+            return VideoFile.upload(f.read(), output_file, catalog=video._catalog)
     finally:
         shutil.rmtree(temp_dir)


### PR DESCRIPTION
In this PR there is a fix for `too many open files` error during video fragments/frames upload.

For every new uploaded file we are initializing new catalog and creating new connection to SQLite DB:

```
$ lsof -p 15463
Python  15463 vlad    0u      CHR               16,2 0t12628660                3211 /dev/ttys002
Python  15463 vlad    1u      CHR               16,2 0t12628660                3211 /dev/ttys002
Python  15463 vlad    2u      CHR               16,2 0t12628660                3211 /dev/ttys002
...
Python  15463 vlad   22u      REG               1,17  220061696           104546080 /Users/vlad/work/iterative/playground/.datachain/db
Python  15463 vlad   23u      REG               1,17      16512           111515250 /Users/vlad/work/iterative/playground/.datachain/db-wal
Python  15463 vlad   24u      REG               1,17  220061696           104546080 /Users/vlad/work/iterative/playground/.datachain/db
Python  15463 vlad   25u      REG               1,17      16512           111515250 /Users/vlad/work/iterative/playground/.datachain/db-wal
...
Python  15463 vlad   67u      REG               1,17  220061696           104546080 /Users/vlad/work/iterative/playground/.datachain/db
Python  15463 vlad   68u      REG               1,17      16512           111515250 /Users/vlad/work/iterative/playground/.datachain/db-wal
Python  15463 vlad   69u      REG               1,17  220061696           104546080 /Users/vlad/work/iterative/playground/.datachain/db
Python  15463 vlad   70u      REG               1,17      16512           111515250 /Users/vlad/work/iterative/playground/.datachain/db-wal
```

```
$ lsof -p 15463 | fgrep '.datachain/db' | wc -l
122
```

In this fix I am setting `catalog` used by new file upload to the previous (original) file catalog, this prevents `upload` method from initializing new catalog every time it is called (see [here](https://github.com/iterative/datachain/blob/main/src/datachain/lib/file.py#L253) for more details).