### PR TITLE
fix(huggingface): wrap HfFileSystem to an async filesystem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,11 +141,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         pyv: ['3.9', '3.13']
-        group: ['get_started', 'computer_vision', 'llm_and_nlp', 'multimodal']
+        group: ['get_started', 'computer_vision', 'multimodal']
         exclude:
           - {os: ubuntu-latest, pyv: '3.9', group: 'multimodal'}
           - {os: ubuntu-latest, pyv: '3.13', group: 'multimodal'}
         include:
+          # HF runs against actual API - thus run it only once
+          - {os: ubuntu-latest, pyv: "3.13", group: llm_and_nlp}
           - {os: ubuntu-latest-4-cores, pyv: "3.9", group: multimodal}
           - {os: ubuntu-latest-4-cores, pyv: "3.13", group: multimodal}
 
@@ -169,9 +171,8 @@ jobs:
       - name: Install nox
         run: uv pip install nox --system
 
-      # HF runs against actual API - thus run it only once
       - name: Set hf token
-        if: matrix.os == 'ubuntu-latest' && matrix.pyv == '3.13'
+        if: matrix.group == 'llm_and_nlp'
         run: echo 'HF_TOKEN=${{ secrets.HF_TOKEN }}' >> "$GITHUB_ENV"
 
       - name: Run examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ vector = [
 ]
 hf = [
   "numba>=0.60.0",
-  "datasets[audio,vision]>=2.21.0"
+  "datasets[audio,vision]>=2.21.0",
+  "fsspec>=2024.12.0"
 ]
 video = [
   "ffmpeg-python",

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -212,7 +212,7 @@ class Client(ABC):
 
     async def get_current_etag(self, file: "File") -> str:
         kwargs = {}
-        if self.fs.version_aware:
+        if getattr(self.fs, "version_aware", False):
             kwargs["version_id"] = file.version
         info = await self.fs._info(
             self.get_full_path(file.path, file.version), **kwargs

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -336,7 +336,9 @@ class Client(ABC):
         return not (key.startswith("/") or key.endswith("/") or "//" in key)
 
     async def ls_dir(self, path):
-        return await self.fs._ls(path, detail=True, versions=True)
+        if getattr(self.fs, "version_aware", False):
+            kwargs = {"versions": True}
+        return await self.fs._ls(path, detail=True, **kwargs)
 
     def rel_path(self, path: str) -> str:
         return self.fs.split_path(path)[1]

--- a/src/datachain/client/hf.py
+++ b/src/datachain/client/hf.py
@@ -10,9 +10,13 @@ from datachain.lib.file import File
 
 from .fsspec import Client
 
+AsyncHfFileSystem = AsyncFileSystemWrapper.wrap_class(HfFileSystem)
+# AsyncFileSystemWrapper does not set class properties, so we need to set them back.
+AsyncHfFileSystem.protocol = HfFileSystem.protocol
+
 
 class HfClient(Client):
-    FS_CLASS = AsyncFileSystemWrapper.wrap_class(HfFileSystem)
+    FS_CLASS = AsyncHfFileSystem
     PREFIX = "hf://"
     protocol = "hf"
 

--- a/src/datachain/client/hf.py
+++ b/src/datachain/client/hf.py
@@ -1,31 +1,50 @@
-import os
+import functools
 import posixpath
 from typing import Any
-
-from fsspec import AbstractFileSystem
-from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
-from huggingface_hub import HfFileSystem
 
 from datachain.lib.file import File
 
 from .fsspec import Client
 
-AsyncHfFileSystem = AsyncFileSystemWrapper.wrap_class(HfFileSystem)
-# AsyncFileSystemWrapper does not set class properties, so we need to set them back.
-AsyncHfFileSystem.protocol = HfFileSystem.protocol
+
+class classproperty:  # noqa: N801
+    def __init__(self, func):
+        self.fget = func
+
+    def __get__(self, instance, owner):
+        return self.fget(owner)
+
+
+@functools.cache
+def get_hf_filesystem_cls():
+    import fsspec
+    from packaging.version import Version, parse
+
+    fsspec_version = parse(fsspec.__version__)
+    minver = Version("2024.12.0")
+
+    if fsspec_version < minver:
+        raise ImportError(
+            f"datachain requires 'fsspec>={minver}' but version "
+            f"{fsspec_version} is installed."
+        )
+
+    from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+    from huggingface_hub import HfFileSystem
+
+    fs_cls = AsyncFileSystemWrapper.wrap_class(HfFileSystem)
+    # AsyncFileSystemWrapper does not set class properties, so we need to set them back.
+    fs_cls.protocol = HfFileSystem.protocol
+    return fs_cls
 
 
 class HfClient(Client):
-    FS_CLASS = AsyncHfFileSystem
     PREFIX = "hf://"
     protocol = "hf"
 
-    @classmethod
-    def create_fs(cls, **kwargs) -> AbstractFileSystem:
-        if os.environ.get("HF_TOKEN"):
-            kwargs["token"] = os.environ["HF_TOKEN"]
-
-        return super().create_fs(**kwargs)
+    @classproperty
+    def FS_CLASS(cls):  # noqa: N802, N805
+        return get_hf_filesystem_cls()
 
     def info_to_file(self, v: dict[str, Any], path: str) -> File:
         return File(
@@ -36,9 +55,6 @@ class HfClient(Client):
             etag=v.get("blob_id", ""),
             last_modified=v["last_commit"].date,
         )
-
-    async def ls_dir(self, path):
-        return await self.fs._ls(path, detail=True)
 
     def rel_path(self, path):
         return posixpath.relpath(path, self.name)

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -374,15 +374,10 @@ class File(DataModel):
         client.download(self, callback=self._download_cb)
 
     async def _prefetch(self, download_cb: Optional["Callback"] = None) -> bool:
-        from datachain.client.hf import HfClient
-
         if self._catalog is None:
             raise RuntimeError("cannot prefetch file because catalog is not setup")
 
         client = self._catalog.get_client(self.source)
-        if client.protocol == HfClient.protocol:
-            return False
-
         await client._download(self, callback=download_cb or self._download_cb)
         self._set_stream(
             self._catalog, caching_enabled=True, download_cb=DEFAULT_CALLBACK


### PR DESCRIPTION
This commit wraps the HfFileSystem class to convert to an async filesystem. This is done by using the `AsyncFileSystemWrapper` class from the `fsspec` library, which requires `fsspec>=2024.12.0`. 

With the wrapper, all the functions will run in a separate thread in an executor, and won't block the main event-loop.

This will now support all the async APIs that the `Client` expects and, hence, will support file caching.

The alternative here is to have two different implementations, one async and another sync, but that is too much of an effort at this time for huggingface.

Fixes #661.

