### PR TITLE
Rename 'export_files' to 'to_storage' in quick-start docs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -138,7 +138,7 @@ chain = (
 )
 
 successful_chain = chain.filter(Column("is_success") == True)
-successful_chain.export_files("./output_mistral")
+successful_chain.to_storage("./output_mistral")
 
 print(f"{successful_chain.count()} files were exported")
 ```


### PR DESCRIPTION
Follow-up for the https://github.com/iterative/datachain/pull/922

Missing renaming `export_files` to `to_storage` in docs.