### PR TITLE
Revert "Fix ffmpeg setup in GitHub CI"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,14 +80,6 @@ jobs:
 
       - name: Set up FFmpeg
         uses: AnimMouse/setup-ffmpeg@v1
-        id: ffmpeg-install
-        continue-on-error: ${{ runner.os == 'macOS' }}
-
-      # https://github.com/AnimMouse/setup-ffmpeg/issues/5
-      - if: steps.ffmpeg-install.outcome == 'failure' && runner.os == 'macOS'
-        run: brew install ffmpeg
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
 
       - name: Set up Python ${{ matrix.pyv }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Reverts iterative/datachain#942.

It looks like the issue has been fixed with https://github.com/AnimMouse/setup-ffmpeg/releases/tag/v1.2.1, and hasn't happened since then.
 

https://github.com/iterative/datachain/actions/runs/13779766244/job/38535781568
https://github.com/iterative/datachain/actions/runs/13779766244/job/38535781253


We can revert this if it happens in the future again.