### PR TITLE
refactor(client): drop support for uppercased scheme URLs

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -95,8 +95,6 @@ class Client(ABC):
 
         if not protocol or _is_win_local_path(str(url)):
             return FileClient
-
-        protocol = protocol.lower()
         if protocol == ClientS3.protocol:
             return ClientS3
         if protocol == GCSClient.protocol:

--- a/src/datachain/client/local.py
+++ b/src/datachain/client/local.py
@@ -67,10 +67,7 @@ class FileClient(Client):
     @classmethod
     def split_url(cls, url: str) -> tuple[str, str]:
         parsed = urlparse(url)
-        if parsed.scheme == "file":
-            scheme, rest = url.split(":", 1)
-            url = f"{scheme.lower()}:{rest}"
-        else:
+        if parsed.scheme != "file":
             url = cls.path_to_uri(url)
 
         fill_path = url[len(cls.PREFIX) :]

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -97,11 +97,6 @@ def _isfile(client: "Client", path: str) -> bool:
     Returns True if uri points to a file
     """
     try:
-        if "://" in path:
-            # This makes sure that the uppercase scheme is converted to lowercase
-            scheme, path = path.split("://", 1)
-            path = f"{scheme.lower()}://{path}"
-
         if os.name == "nt" and "*" in path:
             # On Windows, the glob pattern "*" is not supported
             return False

--- a/tests/func/test_client.py
+++ b/tests/func/test_client.py
@@ -12,7 +12,6 @@ from tqdm import tqdm
 from datachain.asyn import get_loop
 from datachain.client import Client
 from tests.data import ENTRIES
-from tests.utils import uppercase_scheme
 
 _non_null_text = st.text(
     alphabet=st.characters(blacklist_categories=["Cc", "Cs"]), min_size=1
@@ -128,24 +127,6 @@ def test_get_client(cloud_test_catalog, rel_path, cloud_type):
     client = Client.get_client(url, catalog.cache)
     assert client
     assert client.uri
-
-
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
-@given(rel_path=_non_null_text)
-def test_parse_url_uppercase_scheme(cloud_test_catalog, rel_path, cloud_type):
-    if cloud_type == "file":
-        assume(not rel_path.startswith("/"))
-    bucket_uri = cloud_test_catalog.src_uri
-    bucket_uri_upper = uppercase_scheme(bucket_uri)
-    url = f"{bucket_uri_upper}/{rel_path}"
-    uri, rel_part = Client.parse_url(url)
-    if cloud_type == "file":
-        url = f"{bucket_uri}/{rel_path}"
-        assert uri == url.rsplit("/", 1)[0]
-        assert rel_part == url.rsplit("/", 1)[1]
-    else:
-        assert uri == bucket_uri
-        assert rel_part == rel_path
 
 
 @pytest.mark.parametrize("cloud_type", ["file"], indirect=True)

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -12,7 +12,6 @@ from datachain.cli import ls
 from datachain.config import Config, ConfigLevel
 from datachain.lib.dc import DataChain
 from datachain.lib.listing import LISTING_PREFIX
-from tests.utils import uppercase_scheme
 
 
 @pytest.fixture
@@ -69,14 +68,6 @@ dog4
 
 def test_ls_sources(cloud_test_catalog, cloud_type, capsys):
     src = cloud_test_catalog.src_uri
-    ls([src], catalog=cloud_test_catalog.catalog)
-    ls([f"{src}/dogs/*"], catalog=cloud_test_catalog.catalog)
-    captured = capsys.readouterr()
-    assert same_lines(captured.out, ls_sources_output(src))
-
-
-def test_ls_sources_scheme_uppercased(cloud_test_catalog, cloud_type, capsys):
-    src = uppercase_scheme(cloud_test_catalog.src_uri)
     ls([src], catalog=cloud_test_catalog.catalog)
     ls([f"{src}/dogs/*"], catalog=cloud_test_catalog.catalog)
     captured = capsys.readouterr()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,14 +60,6 @@ def tree_from_path(path, binary=False):
     return tree
 
 
-def uppercase_scheme(uri: str) -> str:
-    """
-    Makes scheme (or protocol) of an url uppercased
-    e.g s3://bucket_name -> S3://bucket_name
-    """
-    return f"{uri.split(':')[0].upper()}:{':'.join(uri.split(':')[1:])}"
-
-
 def make_tar(tree) -> bytes:
     with io.BytesIO() as tmp:
         with tarfile.open(fileobj=tmp, mode="w") as archive:


### PR DESCRIPTION
fsspec does not support this at all, and I don't think it's important for us to support this.

The goal here is to simplify and remove manual parsing of paths as much as possible.
Related: https://github.com/iterative/dvcx/pull/402