### PR TITLE
refactor(listing): reraise any exception as ClientError on `isdir` check

### DIFF
--- a/src/datachain/error.py
+++ b/src/datachain/error.py
@@ -1,15 +1,3 @@
-import botocore.errorfactory
-import botocore.exceptions
-import gcsfs.retry
-
-REMOTE_ERRORS = (
-    gcsfs.retry.HttpError,  # GCS
-    OSError,  # GCS
-    botocore.exceptions.BotoCoreError,  # S3
-    ValueError,  # Azure
-)
-
-
 class DataChainError(RuntimeError):
     pass
 

--- a/src/datachain/fs/utils.py
+++ b/src/datachain/fs/utils.py
@@ -1,0 +1,30 @@
+from typing import TYPE_CHECKING
+
+from fsspec.implementations.local import LocalFileSystem
+
+if TYPE_CHECKING:
+    from fsspec import AbstractFileSystem
+
+
+def _isdir(fs: "AbstractFileSystem", path: str) -> bool:
+    info = fs.info(path)
+    return info["type"] == "directory" or (
+        info["size"] == 0 and info["type"] == "file" and info["name"].endswith("/")
+    )
+
+
+def isfile(fs: "AbstractFileSystem", path: str) -> bool:
+    """
+    Returns True if uri points to a file.
+
+    Supports special directories on object storages, e.g.:
+    Google creates a zero byte file with the same name as the directory with a trailing
+    slash at the end.
+    """
+    if isinstance(fs, LocalFileSystem):
+        return fs.isfile(path)
+
+    try:
+        return not _isdir(fs, path)
+    except FileNotFoundError:
+        return False

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -3,14 +3,16 @@ import logging
 import os
 import posixpath
 from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union
 
 from fsspec.asyn import get_loop
 from sqlalchemy.sql.expression import true
 
+import datachain.fs.utils as fsutils
 from datachain.asyn import iter_over_async
 from datachain.client import Client
-from datachain.error import REMOTE_ERRORS, ClientError
+from datachain.error import ClientError
 from datachain.lib.file import File
 from datachain.query.schema import Column
 from datachain.sql.functions import path as pathfunc
@@ -93,29 +95,6 @@ def ls(
     return dc.filter(pathfunc.parent(_file_c("path")) == path.lstrip("/").rstrip("/*"))
 
 
-def _isfile(client: "Client", path: str) -> bool:
-    """
-    Returns True if uri points to a file
-    """
-    try:
-        info = client.fs.info(path)
-        name = info.get("name")
-        # case for special simulated directories on some clouds
-        # e.g. Google creates a zero byte file with the same name as the
-        # directory with a trailing slash at the end
-        if not name or name.endswith("/"):
-            return False
-
-        return info["type"] == "file"
-    except FileNotFoundError:
-        return False
-    except REMOTE_ERRORS as e:
-        raise ClientError(
-            message=str(e),
-            error_code=getattr(e, "code", None),
-        ) from e
-
-
 def parse_listing_uri(uri: str, client_config) -> tuple[str, str, str]:
     """
     Parsing uri and returns listing dataset name, listing uri and listing path
@@ -148,6 +127,14 @@ def listing_uri_from_name(dataset_name: str) -> str:
     return dataset_name.removeprefix(LISTING_PREFIX)
 
 
+@contextmanager
+def _reraise_as_client_error() -> Iterator[None]:
+    try:
+        yield
+    except Exception as e:
+        raise ClientError(message=str(e), error_code=getattr(e, "code", None)) from e
+
+
 def get_listing(
     uri: Union[str, os.PathLike[str]], session: "Session", update: bool = False
 ) -> tuple[Optional[str], str, str, bool]:
@@ -167,12 +154,13 @@ def get_listing(
     client = Client.get_client(uri, cache, **client_config)
     telemetry.log_param("client", client.PREFIX)
     if not isinstance(uri, str):
-        uri = str(uri)
+        uri = os.fspath(uri)
 
     # we don't want to use cached dataset (e.g. for a single file listing)
-    if not glob.has_magic(uri) and not uri.endswith("/") and _isfile(client, uri):
-        storage_uri, path = Client.parse_url(uri)
-        return None, f"{storage_uri}/{path.lstrip('/')}", path, False
+    isfile = _reraise_as_client_error()(fsutils.isfile)
+    if not glob.has_magic(uri) and not uri.endswith("/") and isfile(client.fs, uri):
+        _, path = Client.parse_url(uri)
+        return None, uri, path, False
 
     ds_name, list_uri, list_path = parse_listing_uri(uri, client_config)
     listing = None

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -6,7 +6,6 @@ import os
 import os.path as osp
 import random
 import re
-import stat
 import sys
 import time
 from collections.abc import Iterable, Iterator, Sequence
@@ -193,14 +192,6 @@ def suffix_to_number(num_str: str) -> int:
         raise ValueError(f"Invalid number/suffix for: {num_str}") from None
 
 
-def force_create_dir(name):
-    if not os.path.exists(name):
-        os.mkdir(name)
-    elif not os.path.isdir(name):
-        os.remove(name)
-        os.mkdir(name)
-
-
 def datachain_paths_join(source_path: str, file_paths: Iterable[str]) -> Iterable[str]:
     source_parts = source_path.rstrip("/").split("/")
     if glob.has_magic(source_parts[-1]):
@@ -208,13 +199,6 @@ def datachain_paths_join(source_path: str, file_paths: Iterable[str]) -> Iterabl
         source_parts.pop()
     source_stripped = "/".join(source_parts)
     return (f"{source_stripped}/{path.lstrip('/')}" for path in file_paths)
-
-
-# From: https://docs.python.org/3/library/shutil.html#rmtree-example
-def remove_readonly(func, path, _):
-    "Clear the readonly bit and reattempt the removal"
-    os.chmod(path, stat.S_IWRITE)
-    func(path)
 
 
 def sql_escape_like(search: str, escape: str = "\\") -> str:


### PR DESCRIPTION
- Reraises any exception as `ClientError` in `datachain.lib.listing.get_listing` when checking if a path is a directory. This helps us remove the imports of two libraries, `gcsfs` and `botocore`  which reduces import time: #947.
- Move `isfile` to `datachain.fs.utils`.
- Remove unused utilities from `datachain.utils`