### PR TITLE
make some imports lazy

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -25,7 +25,6 @@ from typing import (
 )
 from uuid import uuid4
 
-import requests
 import sqlalchemy as sa
 from sqlalchemy import Column
 from tqdm.auto import tqdm
@@ -54,7 +53,6 @@ from datachain.error import (
 from datachain.lib.listing import get_listing
 from datachain.node import DirType, Node, NodeWithPath
 from datachain.nodes_thread_pool import NodesThreadPool
-from datachain.remote.studio import StudioClient
 from datachain.sql.types import DateTime, SQLType
 from datachain.utils import DataChainDir
 
@@ -162,6 +160,8 @@ class DatasetRowsFetcher(NodesThreadPool):
         max_threads: int = PULL_DATASET_MAX_THREADS,
         progress_bar=None,
     ):
+        from datachain.remote.studio import StudioClient
+
         super().__init__(max_threads)
         self._check_dependencies()
         self.metastore = metastore
@@ -234,6 +234,8 @@ class DatasetRowsFetcher(NodesThreadPool):
         return df.drop("sys__id", axis=1)
 
     def get_parquet_content(self, url: str):
+        import requests
+
         while True:
             if self.should_check_for_status():
                 self.check_for_status()
@@ -1130,6 +1132,8 @@ class Catalog:
         raise DatasetNotFoundError(f"Dataset with version uuid {uuid} not found.")
 
     def get_remote_dataset(self, name: str) -> DatasetRecord:
+        from datachain.remote.studio import StudioClient
+
         studio_client = StudioClient()
 
         info_response = studio_client.dataset_info(name)
@@ -1344,6 +1348,8 @@ class Catalog:
 
         if cp and not output:
             raise ValueError("Please provide output directory for instantiation")
+
+        from datachain.remote.studio import StudioClient
 
         studio_client = StudioClient()
 

--- a/src/datachain/catalog/loader.py
+++ b/src/datachain/catalog/loader.py
@@ -1,14 +1,12 @@
 import os
 from importlib import import_module
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from datachain.catalog import Catalog
-from datachain.data_storage import (
-    AbstractMetastore,
-    AbstractWarehouse,
-)
-from datachain.data_storage.serializer import deserialize
 from datachain.utils import get_envs_by_prefix
+
+if TYPE_CHECKING:
+    from datachain.catalog import Catalog
+    from datachain.data_storage import AbstractMetastore, AbstractWarehouse
 
 METASTORE_SERIALIZED = "DATACHAIN__METASTORE"
 METASTORE_IMPORT_PATH = "DATACHAIN_METASTORE"
@@ -23,6 +21,9 @@ IN_MEMORY_ERROR_MESSAGE = "In-memory is only supported on SQLite"
 
 
 def get_metastore(in_memory: bool = False) -> "AbstractMetastore":
+    from datachain.data_storage import AbstractMetastore
+    from datachain.data_storage.serializer import deserialize
+
     metastore_serialized = os.environ.get(METASTORE_SERIALIZED)
     if metastore_serialized:
         metastore_obj = deserialize(metastore_serialized)
@@ -60,6 +61,9 @@ def get_metastore(in_memory: bool = False) -> "AbstractMetastore":
 
 
 def get_warehouse(in_memory: bool = False) -> "AbstractWarehouse":
+    from datachain.data_storage import AbstractWarehouse
+    from datachain.data_storage.serializer import deserialize
+
     warehouse_serialized = os.environ.get(WAREHOUSE_SERIALIZED)
     if warehouse_serialized:
         warehouse_obj = deserialize(warehouse_serialized)
@@ -121,7 +125,7 @@ def get_distributed_class(**kwargs):
 
 def get_catalog(
     client_config: Optional[dict[str, Any]] = None, in_memory: bool = False
-) -> Catalog:
+) -> "Catalog":
     """
     Function that creates Catalog instance with appropriate metastore
     and warehouse classes. Metastore class can be provided with env variable
@@ -133,6 +137,8 @@ def get_catalog(
     and name of variable after, e.g. if it accepts team_id as kwargs
     we can provide DATACHAIN_METASTORE_ARG_TEAM_ID=12345 env variable.
     """
+    from datachain.catalog import Catalog
+
     return Catalog(
         metastore=get_metastore(in_memory=in_memory),
         warehouse=get_warehouse(in_memory=in_memory),

--- a/src/datachain/cli/__init__.py
+++ b/src/datachain/cli/__init__.py
@@ -6,7 +6,6 @@ from multiprocessing import freeze_support
 from typing import Optional
 
 from datachain.cli.utils import get_logging_level
-from datachain.telemetry import telemetry
 
 from .commands import (
     clear_cache,
@@ -70,6 +69,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         error, return_code = handle_general_exception(exc, args, logging_level)
         return return_code
     finally:
+        from datachain.telemetry import telemetry
+
         telemetry.send_cli_call(args.command, error=error)
 
 

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -39,13 +39,6 @@ if TYPE_CHECKING:
     from datachain.data_storage.schema import DataTable
     from datachain.lib.file import File
 
-try:
-    import numpy as np
-
-    numpy_imported = True
-except ImportError:
-    numpy_imported = False
-
 
 logger = logging.getLogger("datachain")
 
@@ -96,7 +89,9 @@ class AbstractWarehouse(ABC, Serializable):
         If value is a list or some other iterable, it tries to convert sub elements
         as well
         """
-        if numpy_imported and isinstance(val, (np.ndarray, np.generic)):
+        import numpy as np
+
+        if isinstance(val, (np.ndarray, np.generic)):
             val = val.tolist()
 
         # Optimization: Precompute all the column type variables.

--- a/src/datachain/func/func.py
+++ b/src/datachain/func/func.py
@@ -3,7 +3,6 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from sqlalchemy import BindParameter, Case, ColumnElement, Integer, cast, desc
-from sqlalchemy.ext.hybrid import Comparator
 from sqlalchemy.sql import func as sa_func
 
 from datachain.lib.convert.python_to_sql import python_to_sql
@@ -75,6 +74,8 @@ class Func(Function):
 
     @property
     def _db_cols(self) -> Sequence[ColT]:
+        from sqlalchemy.ext.hybrid import Comparator
+
         return (
             [
                 col

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -22,7 +22,6 @@ import orjson
 import sqlalchemy
 from pydantic import BaseModel
 from sqlalchemy.sql.functions import GenericFunction
-from sqlalchemy.sql.sqltypes import NullType
 from tqdm import tqdm
 
 from datachain.dataset import DatasetRecord
@@ -55,7 +54,6 @@ from datachain.query import Session
 from datachain.query.dataset import DatasetQuery, PartitionByType
 from datachain.query.schema import DEFAULT_DELIMITER, Column, ColumnMeta
 from datachain.sql.functions import path as pathfunc
-from datachain.telemetry import telemetry
 from datachain.utils import batched_it, inside_notebook, row_to_nested_dict
 
 if TYPE_CHECKING:
@@ -550,6 +548,8 @@ class DataChain:
             )
             ```
         """
+        from datachain.telemetry import telemetry
+
         query = DatasetQuery(
             name=name,
             version=version,
@@ -1195,6 +1195,8 @@ class DataChain:
         )
         ```
         """
+        from sqlalchemy.sql.sqltypes import NullType
+
         primitives = (bool, str, int, float)
 
         for col_name, expr in kwargs.items():

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -18,7 +18,6 @@ from urllib.request import url2pathname
 
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from fsspec.utils import stringify_path
-from PIL import Image as PilImage
 from pydantic import Field, field_validator
 
 from datachain.client.fileslice import FileSlice
@@ -550,6 +549,8 @@ class ImageFile(File):
 
     def read(self):
         """Returns `PIL.Image.Image` object."""
+        from PIL import Image as PilImage
+
         fobj = super().read()
         return PilImage.open(BytesIO(fobj))
 

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -16,7 +16,6 @@ from datachain.error import ClientError
 from datachain.lib.file import File
 from datachain.query.schema import Column
 from datachain.sql.functions import path as pathfunc
-from datachain.telemetry import telemetry
 from datachain.utils import uses_glob
 
 if TYPE_CHECKING:
@@ -146,6 +145,7 @@ def get_listing(
     be used to find rows based on uri.
     """
     from datachain.client.local import FileClient
+    from datachain.telemetry import telemetry
 
     catalog = session.catalog
     cache = catalog.cache

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -22,7 +22,6 @@ from typing import (
 )
 
 import attrs
-import psutil
 import sqlalchemy
 import sqlalchemy as sa
 from attrs import frozen
@@ -52,7 +51,6 @@ from datachain.lib.udf import UDFAdapter, _get_cache
 from datachain.progress import CombinedDownloadCallback, TqdmCombinedDownloadCallback
 from datachain.query.schema import C, UDFParamSpec, normalize_param
 from datachain.query.session import Session
-from datachain.remote.studio import is_token_set
 from datachain.sql.functions.random import rand
 from datachain.utils import (
     batched,
@@ -333,6 +331,8 @@ def process_udf_outputs(
     batch_size: int = INSERT_BATCH_SIZE,
     cb: Callback = DEFAULT_CALLBACK,
 ) -> None:
+    import psutil
+
     rows: list[UDFResult] = []
     # Optimization: Compute row types once, rather than for every row.
     udf_col_types = get_udf_col_types(warehouse, udf)
@@ -1087,6 +1087,8 @@ class DatasetQuery:
         in_memory: bool = False,
         fallback_to_studio: bool = True,
     ) -> None:
+        from datachain.remote.studio import is_token_set
+
         self.session = Session.get(session, catalog=catalog, in_memory=in_memory)
         self.catalog = catalog or self.session.catalog
         self.steps: list[Step] = []


### PR DESCRIPTION
Overall, this now reduces the total import time to <400ms.

```fish
for i in (seq 10)
  python -c 'import timeit; print(timeit.timeit("import datachain", number=1))'
end
```

```
0.39508233399828896
0.37911972802248783
0.383127932989737
0.37568117599585094
0.37784146700869314
0.37930534698534757
0.3757595890201628
0.3764792810252402
0.38182323198998347
0.37827736599138007
```