### PR TITLE
tests: add an unit test for catching import time regressions in the future

### DIFF
--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -1,0 +1,48 @@
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+from datachain import C, DataChain
+
+logger = logging.getLogger(__name__)
+
+MAX_ATTEMPTS = 3
+MAX_IMPORT_TIME_MS = 700
+
+
+def _import_time_chain(test_session):
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, "-X", "importtime", "-c", "import datachain"],
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    out = proc.stderr.replace(b"import time:", b"").strip()
+    Path("import_time.csv").write_bytes(out)
+
+    dc = DataChain.from_csv("import_time.csv", session=test_session, delimiter="|")
+    dc = dc.save("import_time")
+    # columns are: cumulative_ms, self_ms, import
+    # TODO: use `mutate` instead of `map`
+    return (
+        dc.map(cumulative_ms=lambda cumulative: cumulative // 1000, output=int)
+        .map(self_ms=lambda self_us: self_us // 1000, output=int)
+        .map(**{"import": lambda imported_package: imported_package.lstrip()})
+    )
+
+
+def test_import_time(catalog, test_session):
+    import_timings = []
+    for attempt in range(MAX_ATTEMPTS):
+        dc = _import_time_chain(test_session)
+        (import_time_ms,) = dc.filter(
+            C("import") == "datachain",
+        ).collect("cumulative_ms")
+        import_timings.append((dc, import_time_ms))
+        # pass `--log-cli-level=info` to see these logs live
+        logger.info("attempt %d, import time: %dms", attempt + 1, import_time_ms)
+
+    dc, min_import_time = min(import_timings, key=lambda x: x[1])
+    assert min_import_time < MAX_IMPORT_TIME_MS, (
+        f"Possible import time regression; took {min_import_time}ms"
+    )

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -3,12 +3,27 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from datachain import C, DataChain
 
 logger = logging.getLogger(__name__)
 
 MAX_ATTEMPTS = 3
 MAX_IMPORT_TIME_MS = 700
+
+lazy_modules = [
+    "adlfs",
+    "boto3",
+    "botocore",
+    "gcsfs",
+    "google",
+    "numpy",
+    "pyarrow",
+    "requests",
+    "s3fs",
+    "torch",
+]
 
 
 def _import_time_chain(test_session):
@@ -22,16 +37,24 @@ def _import_time_chain(test_session):
 
     dc = DataChain.from_csv("import_time.csv", session=test_session, delimiter="|")
     dc = dc.save("import_time")
-    # columns are: cumulative_ms, self_ms, import
     # TODO: use `mutate` instead of `map`
     return (
         dc.map(cumulative_ms=lambda cumulative: cumulative // 1000, output=int)
         .map(self_ms=lambda self_us: self_us // 1000, output=int)
         .map(**{"import": lambda imported_package: imported_package.lstrip()})
+        .select("self_ms", "cumulative_ms", "import")
+        .order_by("cumulative_ms", descending=True)
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="not reliable on Windows")
 def test_import_time(catalog, test_session):
+    """
+    Outside of the test, you can measure the import time with:
+        python -Ximporttime -c 'import datachain'
+
+    To visualize the import profile, consider using `tuna`: https://github.com/nschloe/tuna.
+    """
     import_timings = []
     for attempt in range(MAX_ATTEMPTS):
         dc = _import_time_chain(test_session)
@@ -43,6 +66,12 @@ def test_import_time(catalog, test_session):
         logger.info("attempt %d, import time: %dms", attempt + 1, import_time_ms)
 
     dc, min_import_time = min(import_timings, key=lambda x: x[1])
+    # If there is a regression, uncomment the following to find the culprit:
+    # dc.show(limit=30)
+    for module in lazy_modules:
+        assert not list(dc.filter(C("import").startswith(module)).collect()), (
+            f"found {module} at import time"
+        )
     assert min_import_time < MAX_IMPORT_TIME_MS, (
         f"Possible import time regression; took {min_import_time}ms"
     )


### PR DESCRIPTION
Part of https://github.com/iterative/datachain/issues/947.

Taken an inspiration from https://github.com/pola-rs/polars/blob/63acc86ef657f1b404355ee8b6d4ed9786a8ed1a/py-polars/tests/unit/test_polars_import.py.