### PR TITLE
Check UDF params types in SignalSchema

### DIFF
--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -20,8 +20,8 @@ class DialogEval(DataModel):
 # DataChain is using types for inputs, results to automatically infer schema.
 def eval_dialog(
     client: InferenceClient,
-    user_input: Optional[str],
-    bot_response: Optional[str],
+    user_input: str,
+    bot_response: str,
 ) -> DialogEval:
     try:
         completion = client.chat_completion(

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from huggingface_hub import InferenceClient
 from requests import HTTPError
 
@@ -18,7 +20,7 @@ class DialogEval(DataModel):
 # DataChain is using types for inputs, results to automatically infer schema.
 def eval_dialog(
     client: InferenceClient,
-    user_input: str,
+    user_input: Optional[str],
     bot_response: str,
 ) -> DialogEval:
     try:

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from huggingface_hub import InferenceClient
 from requests import HTTPError
 

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -21,7 +21,7 @@ class DialogEval(DataModel):
 def eval_dialog(
     client: InferenceClient,
     user_input: Optional[str],
-    bot_response: str,
+    bot_response: Optional[str],
 ) -> DialogEval:
     try:
         completion = client.chat_completion(

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -629,7 +629,8 @@ class DataChain:
                 model_name=model_name,
                 jmespath=jmespath,
                 nrows=nrows,
-            )
+            ),
+            "params": {"file": File},
         }
         # disable prefetch if nrows is set
         settings = {"prefetch": 0} if nrows else {}

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -952,9 +952,7 @@ class DataChain:
             chain.save("new_dataset")
             ```
         """
-        udf_obj = self._udf_to_obj(
-            Aggregator, func, params, output, signal_map, is_batch=True
-        )
+        udf_obj = self._udf_to_obj(Aggregator, func, params, output, signal_map)
         return self._evolve(
             query=self._query.generate(
                 udf_obj.to_udf_wrapper(),
@@ -990,9 +988,7 @@ class DataChain:
             chain.save("new_dataset")
             ```
         """
-        udf_obj = self._udf_to_obj(
-            BatchMapper, func, params, output, signal_map, is_batch=True
-        )
+        udf_obj = self._udf_to_obj(BatchMapper, func, params, output, signal_map)
         return self._evolve(
             query=self._query.add_signals(
                 udf_obj.to_udf_wrapper(batch),
@@ -1008,8 +1004,8 @@ class DataChain:
         params: Union[None, str, Sequence[str]],
         output: OutputType,
         signal_map: dict[str, Callable],
-        is_batch: bool = False,
     ) -> UDFObjT:
+        is_batch = target_class.is_input_batched
         is_generator = target_class.is_output_batched
         name = self.name or ""
 

--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -952,7 +952,9 @@ class DataChain:
             chain.save("new_dataset")
             ```
         """
-        udf_obj = self._udf_to_obj(Aggregator, func, params, output, signal_map)
+        udf_obj = self._udf_to_obj(
+            Aggregator, func, params, output, signal_map, is_batch=True
+        )
         return self._evolve(
             query=self._query.generate(
                 udf_obj.to_udf_wrapper(),
@@ -988,7 +990,9 @@ class DataChain:
             chain.save("new_dataset")
             ```
         """
-        udf_obj = self._udf_to_obj(BatchMapper, func, params, output, signal_map)
+        udf_obj = self._udf_to_obj(
+            BatchMapper, func, params, output, signal_map, is_batch=True
+        )
         return self._evolve(
             query=self._query.add_signals(
                 udf_obj.to_udf_wrapper(batch),
@@ -1003,7 +1007,8 @@ class DataChain:
         func: Optional[Union[Callable, UDFObjT]],
         params: Union[None, str, Sequence[str]],
         output: OutputType,
-        signal_map,
+        signal_map: dict[str, Callable],
+        is_batch: bool = False,
     ) -> UDFObjT:
         is_generator = target_class.is_output_batched
         name = self.name or ""
@@ -1015,7 +1020,9 @@ class DataChain:
         if self._sys:
             signals_schema = SignalSchema({"sys": Sys}) | signals_schema
 
-        params_schema = signals_schema.slice(sign.params, self._setup)
+        params_schema = signals_schema.slice(
+            sign.params, self._setup, is_batch=is_batch
+        )
 
         return target_class._create(sign, params_schema)
 

--- a/src/datachain/lib/meta_formats.py
+++ b/src/datachain/lib/meta_formats.py
@@ -10,7 +10,7 @@ import jmespath as jsp
 from pydantic import BaseModel, ConfigDict, Field, ValidationError  # noqa: F401
 
 from datachain.lib.data_model import DataModel  # noqa: F401
-from datachain.lib.file import File
+from datachain.lib.file import TextFile
 
 
 class UserModel(BaseModel):
@@ -130,7 +130,7 @@ def read_meta(  # noqa: C901
     #
 
     def parse_data(
-        file: File,
+        file: TextFile,
         data_model=spec,
         format=format,
         jmespath=jmespath,

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -472,16 +472,16 @@ class SignalSchema:
         """
         Returns new schema that combines current schema and setup signals.
         """
-        setup = setup or {}
-        setup_no_types = dict.fromkeys(setup.keys(), str)
-        union = SignalSchema(self.values | setup_no_types)
-
-        # Slice combined schema by keys
+        setup_params = setup.keys() if setup else []
         schema: dict[str, DataType] = {}
 
         for param, param_type in params.items():
+            if param in setup_params:
+                schema[param] = str
+                continue
+
             try:
-                schema_type = union._find_in_tree(param.split("."))
+                schema_type = self._find_in_tree(param.split("."))
             except SignalResolvingError:
                 continue
 

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -154,9 +154,9 @@ class SignalSchema:
             if not callable(func):
                 raise SetupError(key, "value must be function or callable class")
 
-    def _init_setup_values(self):
+    def _init_setup_values(self) -> None:
         if self.setup_values is not None:
-            return self.setup_values
+            return
 
         res = {}
         for key, func in self.setup_func.items():
@@ -398,7 +398,7 @@ class SignalSchema:
         return SignalSchema(signals)
 
     @staticmethod
-    def get_flatten_hidden_fields(schema):
+    def get_flatten_hidden_fields(schema: dict):
         custom_types = schema.get("_custom_types", {})
         if not custom_types:
             return []
@@ -476,14 +476,12 @@ class SignalSchema:
         schema: dict[str, DataType] = {}
 
         for param, param_type in params.items():
+            # This is special case for setup params, they are always treated as strings
             if param in setup_params:
                 schema[param] = str
                 continue
 
-            try:
-                schema_type = self._find_in_tree(param.split("."))
-            except SignalResolvingError:
-                continue
+            schema_type = self._find_in_tree(param.split("."))
 
             if param_type is Any:
                 schema[param] = schema_type

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -489,19 +489,23 @@ class SignalSchema:
                 schema[param] = schema_type
                 continue
 
+            schema_origin = get_origin(schema_type)
+            param_origin = get_origin(param_type)
+
+            if schema_origin is Union and type(None) in get_args(schema_type):
+                schema_type = get_args(schema_type)[0]
+                if param_origin is Union and type(None) in get_args(param_type):
+                    param_type = get_args(param_type)[0]
+
             if is_batch:
                 if param_type is list:
                     schema[param] = schema_type
                     continue
 
-                if get_origin(param_type) is not list:
+                if param_origin is not list:
                     raise SignalResolvingError(param.split("."), "is not a list")
 
                 param_type = get_args(param_type)[0]
-
-            if param_type == schema_type:
-                schema[param] = schema_type
-                continue
 
             if param_type == schema_type or (
                 isclass(param_type)

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -159,6 +159,7 @@ class UDFBase(AbstractUDF):
         ```
     """
 
+    is_input_batched = False
     is_output_batched = False
     prefetch: int = 0
 
@@ -395,6 +396,7 @@ class Mapper(UDFBase):
 class BatchMapper(UDFBase):
     """Inherit from this class to pass to `DataChain.batch_map()`."""
 
+    is_input_batched = True
     is_output_batched = True
 
     def run(
@@ -481,6 +483,7 @@ class Generator(UDFBase):
 class Aggregator(UDFBase):
     """Inherit from this class to pass to `DataChain.agg()`."""
 
+    is_input_batched = True
     is_output_batched = True
 
     def run(

--- a/src/datachain/lib/udf_signature.py
+++ b/src/datachain/lib/udf_signature.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Generator, Iterator, Sequence
 from dataclasses import dataclass
-from typing import Callable, Optional, Union, get_args, get_origin
+from typing import Any, Callable, Union, get_args, get_origin
 
 from datachain.lib.data_model import DataType, DataTypeNames, is_chain_type
 from datachain.lib.signal_schema import SignalSchema
@@ -18,7 +18,7 @@ class UdfSignatureError(DataChainParamsError):
 @dataclass
 class UdfSignature:
     func: Union[Callable, UDFBase]
-    params: dict[str, Optional[type]]
+    params: dict[str, Union[DataType, Any]]
     output_schema: SignalSchema
 
     DEFAULT_RETURN_TYPE = str
@@ -62,15 +62,15 @@ class UdfSignature:
             chain, udf_func
         )
 
-        udf_params: dict[str, Optional[DataType]] = {}
+        udf_params: dict[str, Union[DataType, Any]] = {}
         if params:
             udf_params = (
-                {params: None} if isinstance(params, str) else dict.fromkeys(params)
+                {params: Any} if isinstance(params, str) else dict.fromkeys(params, Any)
             )
         elif func_params_map_sign:
             udf_params = {
                 param: (
-                    param_type if param_type is not inspect.Parameter.empty else None
+                    param_type if param_type is not inspect.Parameter.empty else Any
                 )
                 for param, param_type in func_params_map_sign.items()
             }

--- a/src/datachain/lib/udf_signature.py
+++ b/src/datachain/lib/udf_signature.py
@@ -62,13 +62,18 @@ class UdfSignature:
             chain, udf_func
         )
 
-        udf_params: dict[str, Optional[type]] = {}
+        udf_params: dict[str, Optional[DataType]] = {}
         if params:
             udf_params = (
                 {params: None} if isinstance(params, str) else dict.fromkeys(params)
             )
         elif func_params_map_sign:
-            udf_params = dict(func_params_map_sign)
+            udf_params = {
+                param: (
+                    param_type if param_type is not inspect.Parameter.empty else None
+                )
+                for param, param_type in func_params_map_sign.items()
+            }
 
         if output:
             udf_output_map = UdfSignature._validate_output(

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -707,7 +707,7 @@ def test_udf_parallel_boostrap(test_session_tmpfile):
             self.value = MyMapper.DEFAULT_VALUE
             self._had_teardown = False
 
-        def process(self, *args) -> int:
+        def process(self, key) -> int:
             return self.value
 
         def setup(self):

--- a/tests/unit/lib/test_datachain_bootstrap.py
+++ b/tests/unit/lib/test_datachain_bootstrap.py
@@ -15,7 +15,7 @@ def test_udf():
             self.value = MyMapper.DEFAULT_VALUE
             self._had_teardown = False
 
-        def process(self, *args) -> int:
+        def process(self, key) -> int:
             return self.value
 
         def setup(self):
@@ -40,7 +40,7 @@ def test_no_bootstrap_for_callable():
             self._had_bootstrap = False
             self._had_teardown = False
 
-        def __call__(self, *args):
+        def __call__(self, key):
             return None
 
         def bootstrap(self):

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -943,7 +943,7 @@ def test_setup_not_callable():
 
 def test_slice():
     schema = {"name": str, "age": float, "address": str}
-    keys = ["age", "name"]
+    keys = {"age": Any, "name": Any}
     sliced = SignalSchema(schema).slice(keys)
     assert list(sliced.values.items()) == [("age", float), ("name", str)]
 
@@ -953,7 +953,7 @@ def test_slice_nested():
         "name": str,
         "feature": MyType1,
     }
-    keys = ["feature.aa"]
+    keys = {"feature.aa": Any}
     sliced = SignalSchema(schema).slice(keys)
     assert list(sliced.values.items()) == [("feature.aa", int)]
 

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Final, List, Literal, Optional, Union  # noqa: UP0
 
 import pytest
 
-from datachain import Column, DataModel
+from datachain import Column, DataModel, Sys, func
 from datachain.lib.convert.flatten import flatten
 from datachain.lib.file import File, TextFile
 from datachain.lib.model_store import ModelStore
@@ -434,15 +434,12 @@ def test_serialize_from_column_error():
 
 
 def test_to_udf_spec():
-    signals = SignalSchema.deserialize(
-        {
-            "age": "float",
-            "address": "str",
-            "f": "File@v1",
-        }
+    schema = SignalSchema(
+        {"age": float, "address": str, "f": File, "init": str},
+        {"init": lambda: 37},
     )
 
-    spec = SignalSchema.to_udf_spec(signals)
+    spec = schema.to_udf_spec()
 
     assert len(spec) == 2 + len(File.model_fields)
 
@@ -459,14 +456,8 @@ def test_to_udf_spec():
     assert spec["f__size"] == Int64
 
 
-def test_select():
-    schema = SignalSchema.deserialize(
-        {
-            "age": "float",
-            "address": "str",
-            "f": "MyType1@v1",
-        }
-    )
+def test_resolve():
+    schema = SignalSchema({"age": float, "address": str, "f": MyType1})
 
     new = schema.resolve("age", "f.aa", "f.bb")
     assert isinstance(new, SignalSchema)
@@ -477,6 +468,59 @@ def test_select():
     assert signals["age"] is float
     assert signals["f.aa"] is int
     assert signals["f.bb"] is str
+
+
+def test_resolve_error():
+    schema = SignalSchema({"age": float, "address": str, "f": MyType1})
+
+    with pytest.raises(SignalResolvingError):
+        schema.resolve("age", "f.aa", "f.bb", "f.cc")
+
+    with pytest.raises(SignalResolvingError):
+        schema.resolve("age", "f.aa", "f.bb", 37)
+
+
+def test_clone_without_file_signals():
+    schema = SignalSchema({**File.model_fields, "name": str, "age": float})
+
+    new = schema.clone_without_file_signals()
+    assert isinstance(new, SignalSchema)
+
+    signals = new.values
+    assert len(signals) == 2
+    assert {"name", "age"} == signals.keys()
+    assert signals["name"] is str
+    assert signals["age"] is float
+
+
+def test_clone_without_sys_signals():
+    schema = SignalSchema({"sys": Sys, "name": str, "age": float})
+
+    new = schema.clone_without_sys_signals()
+    assert isinstance(new, SignalSchema)
+
+    signals = new.values
+    assert len(signals) == 2
+    assert {"name", "age"} == signals.keys()
+    assert signals["name"] is str
+    assert signals["age"] is float
+
+
+def test_merge():
+    schema = SignalSchema({"name": str, "age": float})
+    another_schema = SignalSchema({"age": int, "address": str, "f": MyType1})
+
+    new = schema.merge(another_schema, "s2_")
+    assert isinstance(new, SignalSchema)
+
+    signals = new.values
+    assert len(signals) == 5
+    assert {"name", "age", "s2_age", "address", "f"} == signals.keys()
+    assert signals["name"] is str
+    assert signals["age"] is float
+    assert signals["s2_age"] is int
+    assert signals["address"] is str
+    assert signals["f"] is MyType1
 
 
 def test_select_custom_type_backward_compatibility():
@@ -528,6 +572,29 @@ def test_select_custom_type():
     assert signals["age"] is float
     assert signals["f.aa"] is int
     assert signals["f.bb"] is str
+
+
+def test_select_except_signals():
+    schema = SignalSchema({"age": float, "address": str, "f": MyType1})
+
+    new = schema.select_except_signals("address")
+    assert isinstance(new, SignalSchema)
+
+    signals = new.values
+    assert len(signals) == 2
+    assert {"age", "f"} == signals.keys()
+    assert signals["age"] is float
+    assert signals["f"] is MyType1
+
+
+def test_select_except_signals_error():
+    schema = SignalSchema({"age": float, "address": str, "f": MyType1})
+
+    with pytest.raises(SignalResolvingError):
+        schema.select_except_signals("address", "f.aa")
+
+    with pytest.raises(SignalResolvingError):
+        schema.select_except_signals("address", 37)
 
 
 def test_deserialize_restores_known_base_type():
@@ -910,15 +977,15 @@ def test_db_signals_as_columns():
 
 
 def test_row_to_objs():
-    spec = {"name": str, "age": float, "fr": MyType2}
+    spec = {"name": str, "age": float, "fr": MyType2, "foo": Optional[int]}
     schema = SignalSchema(spec)
 
     val = MyType2(name="Fred", deep=MyType1(aa=129, bb="qwe"))
-    row = ("myname", 12.5, *flatten(val))
+    row = ("myname", 12.5, *flatten(val), None)
 
     res = schema.row_to_objs(row)
 
-    assert res == ["myname", 12.5, val]
+    assert res == ["myname", 12.5, val, None]
 
 
 def test_row_to_objs_setup():
@@ -930,22 +997,122 @@ def test_row_to_objs_setup():
     val = MyType2(name="Fred", deep=MyType1(aa=129, bb="qwe"))
     row = ("myname", 12.5, *flatten(val))
 
+    # run twice to check that setup_values are cached
+    assert schema.setup_values is None
+    schema.row_to_objs(row)
+    assert schema.setup_values is not None
     res = schema.row_to_objs(row)
+    assert schema.setup_values is not None
+
     assert res == ["myname", 12.5, setup_value, val]
 
 
 def test_setup_not_callable():
-    spec = {"name": str, "age": float, "init_val": int, "fr": MyType2}
-    setup_dict = {"init_val": "asdfd"}
     with pytest.raises(SetupError):
-        SignalSchema(spec, setup_dict)
+        SignalSchema({"name": str}, {"init_val": "asdfd"})
+
+
+def test_setup_error():
+    schema = SignalSchema({"name": str, "value": int}, {"init": lambda: 1 / 0})
+    with pytest.raises(SetupError):
+        schema.row_to_objs(("myname", 37))
+
+
+@pytest.mark.parametrize(
+    "schema,hidden_fields",
+    [
+        ({"name": str, "value": int}, []),
+        ({"file": File}, ["file__version", "file__source"]),
+    ],
+)
+def test_get_flatten_hidden_fields(schema, hidden_fields):
+    schema_serialized = SignalSchema(schema).serialize()
+    assert SignalSchema.get_flatten_hidden_fields(schema_serialized) == hidden_fields
+
+
+@pytest.mark.parametrize(
+    "schema,result",
+    [
+        ({"name": str, "value": int}, False),
+        ({"name": str, "age": float, "f": File}, True),
+    ],
+)
+def test_contains_file(schema, result):
+    assert SignalSchema(schema).contains_file() is result
 
 
 def test_slice():
     schema = {"name": str, "age": float, "address": str}
-    keys = {"age": Any, "name": Any}
-    sliced = SignalSchema(schema).slice(keys)
-    assert list(sliced.values.items()) == [("age", float), ("name", str)]
+    setup_values = {"init": lambda: 37}
+    keys = {"age": Any, "name": Any, "init": Any}
+    sliced = SignalSchema(schema).slice(keys, setup_values)
+    assert list(sliced.values.items()) == [("age", float), ("name", str), ("init", str)]
+
+
+@pytest.mark.parametrize(
+    "schema,keys,is_batch,result",
+    [
+        (
+            {"name": str, "age": float, "address": str},
+            {"name": Any, "age": float},
+            False,
+            [("name", str), ("age", float)],
+        ),
+        (
+            {"name": Optional[str], "age": float, "address": str},
+            {"name": Any, "age": Any},
+            False,
+            [("name", Optional[str]), ("age", float)],
+        ),
+        (
+            {"name": Optional[str], "age": float, "address": str},
+            {"name": str, "age": Any},
+            False,
+            [("name", str), ("age", float)],
+        ),
+        (
+            {"name": Optional[str], "age": float, "address": str},
+            {"name": Optional[str], "age": Any},
+            False,
+            [("name", str), ("age", float)],
+        ),
+        (
+            {"name": str, "age": float, "address": str},
+            {"name": list[str], "age": Any},
+            True,
+            [("name", str), ("age", float)],
+        ),
+        (
+            {"name": str, "age": float, "address": str},
+            {"name": list, "age": Any},
+            True,
+            [("name", str), ("age", float)],
+        ),
+    ],
+)
+def test_slice_typed(schema, keys, is_batch, result):
+    sliced = SignalSchema(schema).slice(keys, is_batch=is_batch)
+    assert list(sliced.values.items()) == result
+
+
+def test_slice_error():
+    schema = {"name": str, "age": float, "address": str}
+    keys = {"age": Any, "name": Any, "init": Any}
+    with pytest.raises(SignalResolvingError):
+        SignalSchema(schema).slice(keys)
+
+
+@pytest.mark.parametrize(
+    "keys,is_batch",
+    [
+        ({"name": str, "age": str}, False),
+        ({"name": dict, "age": str}, True),
+    ],
+)
+def test_slice_typed_error(keys, is_batch):
+    schema = {"name": str, "age": float, "address": str}
+    with pytest.raises(SignalResolvingError):
+        SignalSchema(schema).slice(keys, is_batch=is_batch)
 
 
 def test_slice_nested():
@@ -979,6 +1146,12 @@ def test_mutate_change_type():
     schema = SignalSchema({"name": str, "age": float, "f": File})
     schema = schema.mutate({"age": int, "f": TextFile})
     assert schema.values == {"name": str, "age": int, "f": TextFile}
+
+
+def test_mutate_func():
+    schema = SignalSchema({"name": str, "age": float, "f": File})
+    schema = schema.mutate({"age": func.sum("age")})
+    assert schema.values == {"name": str, "age": float, "f": File}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/lib/test_udf_signature.py
+++ b/tests/unit/lib/test_udf_signature.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import pytest
 from pydantic import BaseModel
@@ -31,11 +31,15 @@ def func_args(*args):
     return 12345
 
 
+def func_typed(p1: int) -> int:
+    return p1 * 2
+
+
 def test_basic():
     sign = get_sign(s1=func_str)
 
     assert sign.func == func_str
-    assert sign.params == {"p1": None}
+    assert sign.params == {"p1": Any}
     assert sign.output_schema.values == {"s1": str}
 
 
@@ -56,7 +60,7 @@ def test_signature_overwrite():
     sign = get_sign(s1=func_str, output={"my_sign": int}, params="some_prm")
 
     assert sign.func == func_str
-    assert sign.params == {"some_prm": None}
+    assert sign.params == {"some_prm": Any}
     assert sign.output_schema.values == {"my_sign": int}
 
 
@@ -70,7 +74,7 @@ def test_output_as_value():
     sign = get_sign(s1=func_str, output="my_sign")
 
     assert sign.func == func_str
-    assert sign.params == {"p1": None}
+    assert sign.params == {"p1": Any}
     assert sign.output_schema.values == {"my_sign": str}
 
 
@@ -78,7 +82,7 @@ def test_output_as_list():
     sign = get_sign(s1=func_str, output=["my_sign"])
 
     assert sign.func == func_str
-    assert sign.params == {"p1": None}
+    assert sign.params == {"p1": Any}
     assert sign.output_schema.values == {"my_sign": str}
 
 
@@ -116,7 +120,7 @@ def test_no_params():
 
 def test_func_with_args():
     sign = get_sign(func_args, params=["prm1", "prm2"], output={"res": int})
-    assert sign.params == {"prm1": None, "prm2": None}
+    assert sign.params == {"prm1": Any, "prm2": Any}
 
 
 def test_output_type_error():
@@ -165,7 +169,7 @@ def test_udf_class():
     sign = get_sign(s1=MyTest())
 
     assert sign.output_schema.values == {"s1": int}
-    assert sign.params == {"file": None, "p2": None}
+    assert sign.params == {"file": Any, "p2": Any}
 
 
 def test_udf_flatten_value():
@@ -190,3 +194,9 @@ def test_udf_flatten_feature():
     sign = get_sign(r1=MyTest())
 
     assert sign.output_schema.values == {"r1": MyData}
+
+
+def test_udf_typed_param():
+    sign = get_sign(s1=func_typed)
+    assert sign.params == {"p1": int}
+    assert sign.output_schema.values == {"s1": int}

--- a/tests/unit/lib/test_udf_signature.py
+++ b/tests/unit/lib/test_udf_signature.py
@@ -35,7 +35,7 @@ def test_basic():
     sign = get_sign(s1=func_str)
 
     assert sign.func == func_str
-    assert sign.params == ["p1"]
+    assert sign.params == {"p1": None}
     assert sign.output_schema.values == {"s1": str}
 
 
@@ -56,7 +56,7 @@ def test_signature_overwrite():
     sign = get_sign(s1=func_str, output={"my_sign": int}, params="some_prm")
 
     assert sign.func == func_str
-    assert sign.params == ["some_prm"]
+    assert sign.params == {"some_prm": None}
     assert sign.output_schema.values == {"my_sign": int}
 
 
@@ -70,7 +70,7 @@ def test_output_as_value():
     sign = get_sign(s1=func_str, output="my_sign")
 
     assert sign.func == func_str
-    assert sign.params == ["p1"]
+    assert sign.params == {"p1": None}
     assert sign.output_schema.values == {"my_sign": str}
 
 
@@ -78,7 +78,7 @@ def test_output_as_list():
     sign = get_sign(s1=func_str, output=["my_sign"])
 
     assert sign.func == func_str
-    assert sign.params == ["p1"]
+    assert sign.params == {"p1": None}
     assert sign.output_schema.values == {"my_sign": str}
 
 
@@ -116,7 +116,7 @@ def test_no_params():
 
 def test_func_with_args():
     sign = get_sign(func_args, params=["prm1", "prm2"], output={"res": int})
-    assert sign.params == ["prm1", "prm2"]
+    assert sign.params == {"prm1": None, "prm2": None}
 
 
 def test_output_type_error():
@@ -165,7 +165,7 @@ def test_udf_class():
     sign = get_sign(s1=MyTest())
 
     assert sign.output_schema.values == {"s1": int}
-    assert sign.params == ["file", "p2"]
+    assert sign.params == {"file": None, "p2": None}
 
 
 def test_udf_flatten_value():

--- a/tests/unit/sql/test_array.py
+++ b/tests/unit/sql/test_array.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 from datachain import func
 from datachain.sql import select
@@ -14,7 +15,8 @@ def test_cosine_distance(warehouse):
         func.cosine_distance([0.0, 10.0], [1.0, 0.0]).label("cos4"),
     )
     result = tuple(warehouse.db.execute(query))
-    assert result == ((0.0, 0.0, 1.0, 1.0),)
+    assert len(result) == 1
+    assert_array_almost_equal(result[0], (0.0, 0.0, 1.0, 1.0), decimal=6)
 
 
 def test_euclidean_distance(warehouse):
@@ -25,7 +27,10 @@ def test_euclidean_distance(warehouse):
         func.euclidean_distance([1.0, 1.0, 1.0], [2.0, 2.0, 2.0]).label("eu4"),
     )
     result = tuple(warehouse.db.execute(query))
-    assert result == ((0.0, 0.0, math.sqrt(2), math.sqrt(3)),)
+    assert len(result) == 1
+    assert_array_almost_equal(
+        result[0], (0.0, 0.0, math.sqrt(2), math.sqrt(3)), decimal=6
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up for the https://github.com/iterative/datachain/pull/966

See this thread for more details: https://github.com/iterative/datachain/pull/966#discussion_r1994190977

We are now checking types of UDF arguments if they are defined. Also there is a special case for `File` signal: it will be automatically converted to `TextFile`, `ImageFile` or `VideoFile` if one of these types are used in UDF. See also my comments about implementation and examples below 🙏

## Very basic example

Let's say we have Dataset `my-ds` with two signals: `name: str` and `value: int`.

We can now define UDF to process these signals, e.g.:

```python
def process(name: str, value: int) -> float:
    return len(name) / value

DataChain.from_dataset("my-ds").map(signal=process)
```

In this PR we are adding type checking for UDF param types based on dataset, such as the following UDF:

```python
def process(name: int, value: int) -> float:
    return len(name) / value

DataChain.from_dataset("my-ds").map(signal=process)
```

will return an error:

```
SignalResolvingError: cannot resolve signal name 'name': types mismatch: <class 'int'> != <class 'str'>
```

because in dataset `my-ds` signal `name` type is `str`, not `int`.

## Another real-life example

In this example we are creating dataset from Google Storage bucket with signal `file` type `File`. Next we are going to process these files as images to get image meta from them. Since general `File` type have no methods to work with images, we need type conversion (`File` -> `ImageFile`), which can be done by using `file.as_image_file()`, but it is also possible to do it on-the-fly based on UDF signature types, which is the subject of this PR.

#### Query

```python
from datachain import DataChain, Image, ImageFile


def parse_meta(file: ImageFile) -> Image:
    return file.get_info()


(
    DataChain.from_storage("gs://datachain-test-vlad/human-pose-estimation")
    .limit(100)
    .map(meta=parse_meta)
    .show()
)
```

#### Before

```
$ python query.py
Traceback (most recent call last):
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 174, in process
    return self._func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/playground/query.py", line 5, in parse_meta
    return file.get_info()
           ^^^^^^^^^^^^^
  File "/Users/vlad/.virtualenvs/datachain/lib/python3.12/site-packages/pydantic/main.py", line 892, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'File' object has no attribute 'get_info'
==========================================================
Traceback (most recent call last):
  File "/Users/vlad/work/iterative/playground/query.py", line 12, in <module>
    .show()
     ^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/dc.py", line 1887, in show
    df = dc.to_pandas(flatten, include_hidden=include_hidden)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/dc.py", line 1864, in to_pandas
    results = self.results(include_hidden=include_hidden)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/dc.py", line 1334, in results
    return list(self.collect_flatten(include_hidden=include_hidden))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/dc.py", line 1285, in collect_flatten
    with self._query.ordered_select(*db_signals).as_iterable() as rows:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dataset.py", line 1264, in as_iterable
    query = self.apply_steps().select()
            ^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dataset.py", line 1210, in apply_steps
    result = step.apply(
             ^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dataset.py", line 602, in apply
    self.populate_udf_table(udf_table, query)
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dataset.py", line 520, in populate_udf_table
    process_udf_outputs(
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dataset.py", line 340, in process_udf_outputs
    for udf_output in udf_results:
                      ^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 100, in run
    yield from self.inner.run(
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 386, in run
    result_objs = self.process_safe(udf_args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 284, in process_safe
    raise DataChainError(
datachain.lib.utils.DataChainError: Error in user code in class 'Mapper': 'File' object has no attribute 'get_info'
$
```

#### After
```
$ python query.py
                            file     file              file      file                             file     file  meta   meta   meta
                            path     size              etag is_latest                    last_modified location width height format
0    human-pose-estimation/0.jpg   730027  CKfQgNGSyIkDEAE=         1 2024-11-06 16:39:41.795000+00:00     None  3580   5370   JPEG
1    human-pose-estimation/1.jpg  4744618  CPbpqtGSyIkDEAE=         1 2024-11-06 16:39:42.510000+00:00     None  3217   4825   JPEG
2   human-pose-estimation/10.jpg  1726248  CO2DmtGSyIkDEAE=         1 2024-11-06 16:39:42.236000+00:00     None  2792   3634   JPEG
3   human-pose-estimation/11.jpg  2257008  CPy6ndGSyIkDEAE=         1 2024-11-06 16:39:42.291000+00:00     None  3573   5242   JPEG
4   human-pose-estimation/12.jpg   792329  CNH9g9GSyIkDEAE=         1 2024-11-06 16:39:41.865000+00:00     None  5247   3498   JPEG
5   human-pose-estimation/13.jpg  2676811  CITOpdGSyIkDEAE=         1 2024-11-06 16:39:42.423000+00:00     None  2997   4496   JPEG
6   human-pose-estimation/14.jpg  1274475  CJPemdGSyIkDEAE=         1 2024-11-06 16:39:42.224000+00:00     None  5472   3648   JPEG
7   human-pose-estimation/15.jpg   993245  CPyXj9GSyIkDEAE=         1 2024-11-06 16:39:42.047000+00:00     None  2969   4453   JPEG
8   human-pose-estimation/16.jpg  2368068  CIGYotGSyIkDEAE=         1 2024-11-06 16:39:42.356000+00:00     None  2968   4016   JPEG
9   human-pose-estimation/17.jpg  1965589  CI3bmdGSyIkDEAE=         1 2024-11-06 16:39:42.225000+00:00     None  3265   4898   JPEG
10  human-pose-estimation/18.jpg  3172189  CP6g39GSyIkDEAE=         1 2024-11-06 16:39:43.337000+00:00     None  3744   5616   JPEG
11  human-pose-estimation/19.jpg  1044142  CISzkdGSyIkDEAE=         1 2024-11-06 16:39:42.072000+00:00     None  4698   7050   JPEG
12   human-pose-estimation/2.JPG  2809438  CPLPoNGSyIkDEAE=         1 2024-11-06 16:39:42.323000+00:00     None  3648   5472   JPEG
13  human-pose-estimation/20.jpg  1257389  CJiulNGSyIkDEAE=         1 2024-11-06 16:39:42.140000+00:00     None  4896   3264   JPEG
14  human-pose-estimation/21.jpg  2062542  CIKZntGSyIkDEAE=         1 2024-11-06 16:39:42.304000+00:00     None  4851   3234   JPEG
15  human-pose-estimation/22.jpg  3014260  CMPSqNGSyIkDEAE=         1 2024-11-06 16:39:42.464000+00:00     None  5461   8192   JPEG
16  human-pose-estimation/23.jpg  1778821  CJL/ltGSyIkDEAE=         1 2024-11-06 16:39:42.179000+00:00     None  3705   5557   JPEG
17  human-pose-estimation/24.jpg  3823660  CPPu49GSyIkDEAE=         1 2024-11-06 16:39:43.436000+00:00     None  3648   5472   JPEG
18  human-pose-estimation/25.jpg   779455  CP2TidGSyIkDEAE=         1 2024-11-06 16:39:41.927000+00:00     None  2829   3149   JPEG
19  human-pose-estimation/26.jpg   750505  CMDrwdGSyIkDEAE=         1 2024-11-06 16:39:42.884000+00:00     None  3456   5184   JPEG

[Limited by 20 rows]
$
```

## TODO

- [x] tests