### PR TITLE
Test if 'test_import_time' test is reliable in GitHub CI

### DIFF
--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -10,7 +10,7 @@ from datachain import C, DataChain
 logger = logging.getLogger(__name__)
 
 MAX_ATTEMPTS = 3
-MAX_IMPORT_TIME_MS = 700
+MAX_IMPORT_TIME_MS = 701
 
 lazy_modules = [
     "adlfs",


### PR DESCRIPTION
Too many failures of `test_import_time` test in my PR https://github.com/iterative/datachain/pull/973.
I just wanted to be sure if this is not relevant to my changes and only depends on GitHub CI Actions.