### PR TITLE
fix(tests): disable coverage in test_import_time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
 
       - name: Run E2E tests
-        run: nox -s tests-${{ matrix.pyv }} -- -m "e2e" --cov-append $DISABLE_REMOTES_ARG
+        run: nox -s e2e-${{ matrix.pyv }}
         shell: bash
 
       - name: Upload coverage report

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,6 +56,20 @@ def tests(session: nox.Session) -> None:
     )
 
 
+@nox.session(python=python_versions)
+def e2e(session: nox.Session) -> None:
+    session.install(".[tests]")
+    session.run(
+        "pytest",
+        "--durations=0",
+        "--numprocesses=logical",
+        "--dist=loadgroup",
+        "-m",
+        "e2e",
+        *session.posargs,
+    )
+
+
 @nox.session
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ filterwarnings = [
   "ignore::DeprecationWarning:botocore.auth",
   "ignore::DeprecationWarning:datasets.utils._dill",
   "ignore::DeprecationWarning:librosa.core.intervals",
-  "ignore:Field name .* shadows an attribute in parent:UserWarning"  # datachain.lib.feature
+  "ignore:Field name .* shadows an attribute in parent:UserWarning",  # datachain.lib.feature
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ filterwarnings = [
   "ignore::DeprecationWarning:botocore.auth",
   "ignore::DeprecationWarning:datasets.utils._dill",
   "ignore::DeprecationWarning:librosa.core.intervals",
-  "ignore:Field name .* shadows an attribute in parent:UserWarning",  # datachain.lib.feature
+  "ignore:Field name .* shadows an attribute in parent:UserWarning"  # datachain.lib.feature
 ]
 
 [tool.coverage.run]

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -52,7 +52,7 @@ def _import_time_chain(test_session):
     )
 
 
-# disable coverage for this test to avoid unpredictable results
+# disable coverage for this test to minimize import time overhead
 @pytest.mark.no_cover
 @pytest.mark.skipif(sys.platform == "win32", reason="not reliable on Windows")
 def test_import_time(catalog, test_session):

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -35,7 +35,12 @@ def _import_time_chain(test_session):
     out = proc.stderr.replace(b"import time:", b"").strip()
     Path("import_time.csv").write_bytes(out)
 
-    dc = DataChain.from_csv("import_time.csv", session=test_session, delimiter="|")
+    try:
+        dc = DataChain.from_csv("import_time.csv", session=test_session, delimiter="|")
+    except Exception:
+        logger.error("Failed to parse output: %r", proc.stderr)
+        raise
+
     dc = dc.save("import_time")
     # TODO: use `mutate` instead of `map`
     return (
@@ -47,6 +52,8 @@ def _import_time_chain(test_session):
     )
 
 
+# disable coverage for this test to avoid unpredictable results
+@pytest.mark.no_cover
 @pytest.mark.skipif(sys.platform == "win32", reason="not reliable on Windows")
 def test_import_time(catalog, test_session):
     """
@@ -67,7 +74,7 @@ def test_import_time(catalog, test_session):
 
     dc, min_import_time = min(import_timings, key=lambda x: x[1])
     # If there is a regression, uncomment the following to find the culprit:
-    # dc.show(limit=30)
+    # dc.show(limit=40)
     for module in lazy_modules:
         assert not list(dc.filter(C("import").startswith(module)).collect()), (
             f"found {module} at import time"


### PR DESCRIPTION
This commit disables coverage for the test_import_time test to avoid unpredictable results. The import usually takes  ~400ms but with coverage enabled, it was frequently going past 600ms on my machine.

Which I believe is also happening on the CI.

- Also added a log message to display the full contents of the output from `-Ximporttime` in case of a parse error in `from_csv`.

Thanks to @dreadatour for noticing this issue. Fixes #974.