### PR TITLE
Fix output of 'ls' CLI command

### DIFF
--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -62,6 +62,7 @@ def ls_local(
                 for entry in entries:
                     print(format_ls_entry(entry))
     else:
+        # Collect results in a list here to prevent interference from `tqdm` and `print`
         listing = list(DataChain.listings().collect("listing"))
         for ls in listing:
             print(format_ls_entry(f"{ls.uri}@v{ls.version}"))  # type: ignore[union-attr]

--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -38,11 +38,12 @@ def ls_local(
 ):
     from datachain import DataChain
 
-    if catalog is None:
-        from datachain.catalog import get_catalog
-
-        catalog = get_catalog(client_config=client_config)
     if sources:
+        if catalog is None:
+            from datachain.catalog import get_catalog
+
+            catalog = get_catalog(client_config=client_config)
+
         actual_sources = list(ls_urls(sources, catalog=catalog, long=long, **kwargs))
         if len(actual_sources) == 1:
             for _, entries in actual_sources:
@@ -61,8 +62,8 @@ def ls_local(
                 for entry in entries:
                     print(format_ls_entry(entry))
     else:
-        chain = DataChain.listings()
-        for ls in chain.collect("listing"):
+        listing = list(DataChain.listings().collect("listing"))
+        for ls in listing:
             print(format_ls_entry(f"{ls.uri}@v{ls.version}"))  # type: ignore[union-attr]
 
 


### PR DESCRIPTION
There is a bug with `ls` CLI command: because of `tqdm` output starts not from the beginning of the line.

I wish I can find a better fix related to `tqdm`, but I can not find any in decent amount of time :(
Using list instead of iterator looks like a reasonable temporary fix, since output of `ls` command should not be huge.

**Note**: may be related to https://github.com/iterative/datachain/issues/780

#### Before

```
$ datachain ls
                                   gs://datachain-demo/50k-laion-files/000000/@v1
gs://datachain-demo/dogs-and-cats/@v1
gs://datachain-demo/dogs-and-cats/@v2
gs://datachain-demo/dogs-and-cats/@v3
gs://datachain-demo/dogs-and-cats/@v4
gs://datachain-demo/open-images-v6/@v1
```

#### After

```
$ datachain ls
gs://datachain-demo/50k-laion-files/000000/@v1
gs://datachain-demo/dogs-and-cats/@v1
gs://datachain-demo/dogs-and-cats/@v2
gs://datachain-demo/dogs-and-cats/@v3
gs://datachain-demo/dogs-and-cats/@v4
gs://datachain-demo/open-images-v6/@v1
```
