### PR TITLE
feat(dc): add repr to show schema for DataChain instances

### DIFF
--- a/src/datachain/lib/dc.py
+++ b/src/datachain/lib/dc.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Iterator, Sequence
 from functools import wraps
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
     BinaryIO,
@@ -270,6 +271,18 @@ class DataChain:
         self._setup: dict = setup or {}
         self._sys = _sys
 
+    def __repr__(self) -> str:
+        """Return a string representation of the chain."""
+        classname = self.__class__.__name__
+        if not self._effective_signals_schema.values:
+            return f"Empty {classname}"
+
+        import io
+
+        file = io.StringIO()
+        self.print_schema(file=file)
+        return file.getvalue()
+
     @property
     def schema(self) -> dict[str, DataType]:
         """Get schema of the chain."""
@@ -323,9 +336,9 @@ class DataChain:
         """Return `self.union(other)`."""
         return self.union(other)
 
-    def print_schema(self) -> None:
+    def print_schema(self, file: Optional[IO] = None) -> None:
         """Print schema of the chain."""
-        self._effective_signals_schema.print_tree()
+        self._effective_signals_schema.print_tree(file=file)
 
     def clone(self) -> "Self":
         """Make a copy of the chain in a new table."""

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from inspect import isclass
 from typing import (  # noqa: UP035
+    IO,
     TYPE_CHECKING,
     Annotated,
     Any,
@@ -696,16 +697,20 @@ class SignalSchema:
                     substree, new_prefix, depth + 1, include_hidden
                 )
 
-    def print_tree(self, indent: int = 4, start_at: int = 0):
+    def print_tree(self, indent: int = 2, start_at: int = 0, file: Optional[IO] = None):
         for path, type_, _, depth in self.get_flat_tree():
             total_indent = start_at + depth * indent
-            print(" " * total_indent, f"{path[-1]}:", SignalSchema._type_to_str(type_))
+            col_name = " " * total_indent + path[-1]
+            col_type = SignalSchema._type_to_str(type_)
+            print(col_name, col_type, sep=": ", file=file)
 
             if get_origin(type_) is list:
                 args = get_args(type_)
                 if len(args) > 0 and ModelStore.is_pydantic(args[0]):
                     sub_schema = SignalSchema({"* list of": args[0]})
-                    sub_schema.print_tree(indent=indent, start_at=total_indent + indent)
+                    sub_schema.print_tree(
+                        indent=indent, start_at=total_indent + indent, file=file
+                    )
 
     def get_headers_with_length(self, include_hidden: bool = True):
         paths = [

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -79,6 +79,55 @@ def sort_files(files):
     return sorted(files, key=lambda f: (f.path, f.size))
 
 
+def test_repr(test_session):
+    dc = DataChain.from_values(
+        sign1=features_nested, col1=["a", "b", "c"], session=test_session
+    )
+    assert (
+        repr(dc)
+        == """\
+sign1: MyNested
+  label: str
+  fr: MyFr
+    nnn: str
+    count: int
+col1: str
+"""
+    )
+
+    # datachain without any columns
+    assert repr(dc.select_except("col1", "sign1")) == "Empty DataChain"
+
+    dc = dc.map(col2=lambda col1: col1 * 2)
+    assert (
+        repr(dc)
+        == """\
+sign1: MyNested
+  label: str
+  fr: MyFr
+    nnn: str
+    count: int
+col1: str
+col2: str
+"""
+    )
+
+    dc = dc.mutate(countplusone=dc.column("sign1.fr.count") + 1)
+    assert (
+        repr(dc)
+        == """\
+sign1: MyNested
+  label: str
+  fr: MyFr
+    nnn: str
+    count: int
+col1: str
+col2: str
+countplusone: int
+"""
+    )
+
+
 def test_pandas_conversion(test_session):
     df = pd.DataFrame(DF_DATA)
     df1 = DataChain.from_pandas(df, session=test_session)


### PR DESCRIPTION
This is a quick and dirty implementation to display `__repr__` for `DataChain` instances. The implementation uses `DataChain.print_schema()` method to capture the output and return it.

This makes working in the REPL and notebooks easier. PTAL at the tests for the output.

Also note that I changed the default indentation to `2` from `4` before. I think less indentation makes it easier on REPL to work with.

And also fixed a small bug in `SignalSchema.print_tree` that was always indenting the schema by at least a single space.

```py
>>> from datachain import DataChain
>>> dc = DataChain.from_values(col1=["a", "b", "c"])
>>> dc
col1: str
>>> dc.select_except("col1")
Empty DataChain
>>> dc.map(col2=lambda col1: col1 * 2)
col1: str
col2: str
```