### PR TITLE
Fix save logic for updated description and labels

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -795,6 +795,19 @@ class Catalog:
         try:
             dataset = self.get_dataset(name)
             default_version = dataset.next_version
+
+            if (description or labels) and (
+                dataset.description != description or dataset.labels != labels
+            ):
+                description = description or dataset.description
+                labels = labels or dataset.labels
+
+                self.update_dataset(
+                    dataset,
+                    description=description,
+                    labels=labels,
+                )
+
         except DatasetNotFoundError:
             schema = {
                 c.name: c.type.to_dict() for c in columns if isinstance(c.type, SQLType)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -461,6 +461,16 @@ def test_save(test_session):
     assert ds.description == "new description"
     assert ds.labels == ["new_label", "old_label"]
 
+    chain.save(
+        name="new_name",
+        description="updated description",
+        labels=["new_label", "old_label", "new_label2"],
+    )
+    ds = test_session.catalog.get_dataset("new_name")
+    assert ds.name == "new_name"
+    assert ds.description == "updated description"
+    assert ds.labels == ["new_label", "old_label", "new_label2"]
+
 
 def test_show_nested_empty(capsys, test_session):
     files = [File(size=s, path=p) for p, s in zip(list("abcde"), range(5))]


### PR DESCRIPTION
When we use `.save()` with new description and labels, the description
and labels were saved only when new dataset was created.

This commit changes that logic to make sure it is updated for existing
dataset as well.
