### PR TITLE
Fix test_udf_distributed_interrupt with multiple workers

### DIFF
--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1004,7 +1004,7 @@ def test_udf_distributed_interrupt(cloud_test_catalog_tmpfile, capfd, datachain_
         DataChain.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(C("file.size") < 13)
         .filter(C("file.path").glob("cats*") | (C("file.size") < 4))
-        .settings(parallel=2, workers=2)
+        .settings(parallel=2, workers=1)
         .map(name_len_interrupt, params=["file.path"], output={"name_len": int})
     )
     with pytest.raises(RuntimeError, match=r"Worker Killed \(KeyboardInterrupt\)"):

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1004,13 +1004,12 @@ def test_udf_distributed_interrupt(cloud_test_catalog_tmpfile, capfd, datachain_
         DataChain.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(C("file.size") < 13)
         .filter(C("file.path").glob("cats*") | (C("file.size") < 4))
-        .settings(parallel=2, workers=1)
+        .settings(parallel=2, workers=2)
         .map(name_len_interrupt, params=["file.path"], output={"name_len": int})
     )
     with pytest.raises(RuntimeError, match=r"Worker Killed \(KeyboardInterrupt\)"):
         dc.show()
     captured = capfd.readouterr()
-    assert "KeyboardInterrupt" in captured.err
     assert "semaphore" not in captured.err
 
 


### PR DESCRIPTION
When multiple workers are running, we don't have access to all the worker's standard error output through `captured.err` and can't see the `KeyboardInterrupt` exception name; this only works when we schedule the task to the first worker, which runs locally and allows capturing its output.

See https://github.com/iterative/studio/pull/11439#discussion_r2009089748