### PR TITLE
Introduce functional datachain API

### DIFF
--- a/docs/references/data-types/file.md
+++ b/docs/references/data-types/file.md
@@ -2,13 +2,13 @@
 
 `File` is a special [`DataModel`](index.md#datachain.lib.data_model.DataModel),
 which is automatically generated when a `DataChain` is created from files,
-such as in [`DataChain.from_storage`](../datachain.md#datachain.lib.dc.DataChain.from_storage):
+such as in [`DataChain.from_storage`](../datachain.md#datachain.lib.dc.storage.from_storage):
 
 ```python
-from datachain import DataChain
+import datachain as dc
 
-dc = DataChain.from_storage("gs://datachain-demo/dogs-and-cats")
-dc.print_schema()
+chain = dc.from_storage("gs://datachain-demo/dogs-and-cats")
+chain.print_schema()
 ```
 
 Output:

--- a/docs/references/data-types/imagefile.md
+++ b/docs/references/data-types/imagefile.md
@@ -2,12 +2,12 @@
 
 `ImageFile` is inherited from [`File`](file.md) with additional methods for working with image files.
 
-`ImageFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.DataChain.from_storage), using `type="image"` param:
+`ImageFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.storage.from_storage), using `type="image"` param:
 
 ```python
-from datachain import DataChain
+import datachain as dc
 
-dc = DataChain.from_storage("s3://bucket-name/", type="image")
+chain = dc.from_storage("s3://bucket-name/", type="image")
 ```
 
 ::: datachain.lib.file.ImageFile

--- a/docs/references/data-types/textfile.md
+++ b/docs/references/data-types/textfile.md
@@ -2,12 +2,12 @@
 
 `TextFile` is inherited from [`File`](file.md) with additional methods for working with text files.
 
-`TextFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.DataChain.from_storage), using `type="text"` param:
+`TextFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.storage.from_storage), using `type="text"` param:
 
 ```python
-from datachain import DataChain
+import datachain as dc
 
-dc = DataChain.from_storage("s3://bucket-name/", type="text")
+chain = dc.from_storage("s3://bucket-name/", type="text")
 ```
 
 ::: datachain.lib.file.TextFile

--- a/docs/references/data-types/videofile.md
+++ b/docs/references/data-types/videofile.md
@@ -2,12 +2,12 @@
 
 `VideoFile` extends [`File`](file.md) and provides additional methods for working with video files.
 
-`VideoFile` instances are created when a `DataChain` is initialized [from storage](../datachain.md#datachain.lib.dc.DataChain.from_storage) with the `type="video"` parameter:
+`VideoFile` instances are created when a `DataChain` is initialized [from storage](../datachain.md#datachain.lib.dc.storage.from_storage) with the `type="video"` parameter:
 
 ```python
-from datachain import DataChain
+import datachain as dc
 
-dc = DataChain.from_storage("s3://bucket-name/", type="video")
+chain = dc.from_storage("s3://bucket-name/", type="video")
 ```
 
 There are additional models for working with video files:

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -9,6 +9,28 @@ for examples of how to create a chain.
 
 ::: datachain.query.schema.Column
 
+::: datachain.lib.dc.csv.from_csv
+
+::: datachain.lib.dc.datasets.from_dataset
+
+::: datachain.lib.dc.datasets.datasets
+
+::: datachain.lib.dc.hf.from_hf
+
+::: datachain.lib.dc.json.from_json
+
+::: datachain.lib.dc.listings.listings
+
+::: datachain.lib.dc.pandas.from_pandas
+
+::: datachain.lib.dc.parquet.from_parquet
+
+::: datachain.lib.dc.records.from_records
+
+::: datachain.lib.dc.storage.from_storage
+
+::: datachain.lib.dc.values.from_values
+
 ::: datachain.lib.dc.DataChain
 
 ::: datachain.lib.utils.DataChainError

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -1,5 +1,21 @@
 from datachain.lib.data_model import DataModel, DataType, is_chain_type
-from datachain.lib.dc import C, Column, DataChain, Sys
+from datachain.lib.dc import (
+    C,
+    Column,
+    DataChain,
+    Sys,
+    datasets,
+    from_csv,
+    from_dataset,
+    from_hf,
+    from_json,
+    from_pandas,
+    from_parquet,
+    from_records,
+    from_storage,
+    from_values,
+    listings,
+)
 from datachain.lib.file import (
     ArrowRow,
     File,
@@ -44,7 +60,18 @@ __all__ = [
     "VideoFile",
     "VideoFragment",
     "VideoFrame",
+    "datasets",
+    "from_csv",
+    "from_dataset",
+    "from_hf",
+    "from_json",
+    "from_pandas",
+    "from_parquet",
+    "from_records",
+    "from_storage",
+    "from_values",
     "is_chain_type",
+    "listings",
     "metrics",
     "param",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -1,0 +1,32 @@
+from .csv import from_csv
+from .datachain import C, Column, DataChain
+from .datasets import datasets, from_dataset
+from .hf import from_hf
+from .json import from_json
+from .listings import listings
+from .pandas import from_pandas
+from .parquet import from_parquet
+from .records import from_records
+from .storage import from_storage
+from .utils import DatasetMergeError, DatasetPrepareError, Sys
+from .values import from_values
+
+__all__ = [
+    "C",
+    "Column",
+    "DataChain",
+    "DatasetMergeError",
+    "DatasetPrepareError",
+    "Sys",
+    "datasets",
+    "from_csv",
+    "from_dataset",
+    "from_hf",
+    "from_json",
+    "from_pandas",
+    "from_parquet",
+    "from_records",
+    "from_storage",
+    "from_values",
+    "listings",
+]

--- a/src/datachain/lib/dc/csv.py
+++ b/src/datachain/lib/dc/csv.py
@@ -1,0 +1,127 @@
+from collections.abc import Sequence
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Optional,
+    Union,
+)
+
+from datachain.lib.dc.utils import DatasetPrepareError, OutputType
+from datachain.lib.model_store import ModelStore
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from pyarrow import DataType as ArrowDataType
+
+    from .datachain import DataChain
+
+
+def from_csv(
+    path,
+    delimiter: Optional[str] = None,
+    header: bool = True,
+    output: OutputType = None,
+    object_name: str = "",
+    model_name: str = "",
+    source: bool = True,
+    nrows=None,
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    column_types: Optional[dict[str, "Union[str, ArrowDataType]"]] = None,
+    parse_options: Optional[dict[str, "Union[str, Union[bool, Callable]]"]] = None,
+    **kwargs,
+) -> "DataChain":
+    """Generate chain from csv files.
+
+    Parameters:
+        path : Storage URI with directory. URI must start with storage prefix such
+            as `s3://`, `gs://`, `az://` or "file:///".
+        delimiter : Character for delimiting columns. Takes precedence if also
+            specified in `parse_options`. Defaults to ",".
+        header : Whether the files include a header row.
+        output : Dictionary or feature class defining column names and their
+            corresponding types. List of column names is also accepted, in which
+            case types will be inferred.
+        object_name : Created object column name.
+        model_name : Generated model name.
+        source : Whether to include info about the source file.
+        nrows : Optional row limit.
+        session : Session to use for the chain.
+        settings : Settings to use for the chain.
+        column_types : Dictionary of column names and their corresponding types.
+            It is passed to CSV reader and for each column specified type auto
+            inference is disabled.
+        parse_options: Tells the parser how to process lines.
+            See https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html
+
+    Example:
+        Reading a csv file:
+        ```py
+        import datachain as dc
+        chain = dc.from_csv("s3://mybucket/file.csv")
+        ```
+
+        Reading csv files from a directory as a combined dataset:
+        ```py
+        import datachain as dc
+        chain = dc.from_csv("s3://mybucket/dir")
+        ```
+    """
+    from pandas.io.parsers.readers import STR_NA_VALUES
+    from pyarrow.csv import ConvertOptions, ParseOptions, ReadOptions
+    from pyarrow.dataset import CsvFileFormat
+    from pyarrow.lib import type_for_alias
+
+    from .datachain import DataChain
+
+    parse_options = parse_options or {}
+    if "delimiter" not in parse_options:
+        parse_options["delimiter"] = ","
+    if delimiter:
+        parse_options["delimiter"] = delimiter
+
+    if column_types:
+        column_types = {
+            name: type_for_alias(typ) if isinstance(typ, str) else typ
+            for name, typ in column_types.items()
+        }
+    else:
+        column_types = {}
+
+    chain = DataChain.from_storage(path, session=session, settings=settings, **kwargs)
+
+    column_names = None
+    if not header:
+        if not output:
+            msg = "error parsing csv - provide output if no header"
+            raise DatasetPrepareError(chain.name, msg)
+        if isinstance(output, Sequence):
+            column_names = output  # type: ignore[assignment]
+        elif isinstance(output, dict):
+            column_names = list(output.keys())
+        elif (fr := ModelStore.to_pydantic(output)) is not None:
+            column_names = list(fr.model_fields.keys())
+        else:
+            msg = f"error parsing csv - incompatible output type {type(output)}"
+            raise DatasetPrepareError(chain.name, msg)
+
+    parse_options = ParseOptions(**parse_options)
+    read_options = ReadOptions(column_names=column_names)
+    convert_options = ConvertOptions(
+        strings_can_be_null=True,
+        null_values=STR_NA_VALUES,
+        column_types=column_types,
+    )
+    format = CsvFileFormat(
+        parse_options=parse_options,
+        read_options=read_options,
+        convert_options=convert_options,
+    )
+    return chain.parse_tabular(
+        output=output,
+        object_name=object_name,
+        model_name=model_name,
+        source=source,
+        nrows=nrows,
+        format=format,
+    )

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1,10 +1,9 @@
 import copy
 import os
 import os.path
-import re
 import sys
+import warnings
 from collections.abc import Iterator, Sequence
-from functools import wraps
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -22,7 +21,6 @@ from typing import (
 import orjson
 import sqlalchemy
 from pydantic import BaseModel
-from sqlalchemy.sql.functions import GenericFunction
 from tqdm import tqdm
 
 from datachain.dataset import DatasetRecord
@@ -30,22 +28,13 @@ from datachain.func import literal
 from datachain.func.base import Function
 from datachain.func.func import Func
 from datachain.lib.convert.python_to_sql import python_to_sql
-from datachain.lib.convert.values_to_tuples import values_to_tuples
 from datachain.lib.data_model import DataModel, DataType, DataValue, dict_to_data_model
-from datachain.lib.dataset_info import DatasetInfo
 from datachain.lib.file import (
     EXPORT_FILES_MAX_THREADS,
     ArrowRow,
-    File,
     FileExporter,
-    FileType,
-    get_file_type,
 )
 from datachain.lib.file import ExportPlacement as FileExportPlacement
-from datachain.lib.listing import get_file_info, get_listing, list_bucket, ls
-from datachain.lib.listing_info import ListingInfo
-from datachain.lib.meta_formats import read_meta
-from datachain.lib.model_store import ModelStore
 from datachain.lib.settings import Settings
 from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.udf import Aggregator, BatchMapper, Generator, Mapper, UDFBase
@@ -57,124 +46,29 @@ from datachain.query.schema import DEFAULT_DELIMITER, Column, ColumnMeta
 from datachain.sql.functions import path as pathfunc
 from datachain.utils import batched_it, inside_notebook, row_to_nested_dict
 
-if TYPE_CHECKING:
-    import pandas as pd
-    from pyarrow import DataType as ArrowDataType
-    from typing_extensions import Concatenate, ParamSpec, Self
-
-    from datachain.lib.hf import HFDatasetType
-
-    P = ParamSpec("P")
+from .utils import (
+    DatasetMergeError,
+    DatasetPrepareError,
+    MergeColType,
+    OutputType,
+    Sys,
+    _get_merge_error_str,
+    _validate_merge_on,
+    resolve_columns,
+)
 
 C = Column
 
 _T = TypeVar("_T")
-D = TypeVar("D", bound="DataChain")
 UDFObjT = TypeVar("UDFObjT", bound=UDFBase)
 
 DEFAULT_PARQUET_CHUNK_SIZE = 100_000
 
+if TYPE_CHECKING:
+    import pandas as pd
+    from typing_extensions import ParamSpec, Self
 
-def resolve_columns(
-    method: "Callable[Concatenate[D, P], D]",
-) -> "Callable[Concatenate[D, P], D]":
-    """Decorator that resolvs input column names to their actual DB names. This is
-    specially important for nested columns as user works with them by using dot
-    notation e.g (file.name) but are actually defined with default delimiter
-    in DB, e.g file__name.
-    If there are any sql functions in arguments, they will just be transferred as is
-    to a method.
-    """
-
-    @wraps(method)
-    def _inner(self: D, *args: "P.args", **kwargs: "P.kwargs") -> D:
-        resolved_args = self.signals_schema.resolve(
-            *[arg for arg in args if not isinstance(arg, GenericFunction)]  # type: ignore[arg-type]
-        ).db_signals()
-
-        for idx, arg in enumerate(args):
-            if isinstance(arg, GenericFunction):
-                resolved_args.insert(idx, arg)  # type: ignore[arg-type]
-
-        return method(self, *resolved_args, **kwargs)
-
-    return _inner
-
-
-class DatasetPrepareError(DataChainParamsError):  # noqa: D101
-    def __init__(self, name, msg, output=None):  # noqa: D107
-        name = f" '{name}'" if name else ""
-        output = f" output '{output}'" if output else ""
-        super().__init__(f"Dataset{name}{output} processing prepare error: {msg}")
-
-
-class DatasetFromValuesError(DataChainParamsError):  # noqa: D101
-    def __init__(self, name, msg):  # noqa: D107
-        name = f" '{name}'" if name else ""
-        super().__init__(f"Dataset{name} from values error: {msg}")
-
-
-MergeColType = Union[str, Function, sqlalchemy.ColumnElement]
-
-
-def _validate_merge_on(
-    on: Union[MergeColType, Sequence[MergeColType]],
-    ds: "DataChain",
-) -> Sequence[MergeColType]:
-    if isinstance(on, (str, sqlalchemy.ColumnElement)):
-        return [on]
-    if isinstance(on, Function):
-        return [on.get_column(table=ds._query.table)]
-    if isinstance(on, Sequence):
-        return [
-            c.get_column(table=ds._query.table) if isinstance(c, Function) else c
-            for c in on
-        ]
-
-
-def _get_merge_error_str(col: MergeColType) -> str:
-    if isinstance(col, str):
-        return col
-    if isinstance(col, Function):
-        return f"{col.name}()"
-    if isinstance(col, sqlalchemy.Column):
-        return col.name.replace(DEFAULT_DELIMITER, ".")
-    if isinstance(col, sqlalchemy.ColumnElement) and hasattr(col, "name"):
-        return f"{col.name} expression"
-    return str(col)
-
-
-class DatasetMergeError(DataChainParamsError):  # noqa: D101
-    def __init__(  # noqa: D107
-        self,
-        on: Union[MergeColType, Sequence[MergeColType]],
-        right_on: Optional[Union[MergeColType, Sequence[MergeColType]]],
-        msg: str,
-    ):
-        def _get_str(
-            on: Union[MergeColType, Sequence[MergeColType]],
-        ) -> str:
-            if not isinstance(on, Sequence):
-                return str(on)  # type: ignore[unreachable]
-            return ", ".join([_get_merge_error_str(col) for col in on])
-
-        on_str = _get_str(on)
-        right_on_str = (
-            ", right_on='" + _get_str(right_on) + "'"
-            if right_on and isinstance(right_on, Sequence)
-            else ""
-        )
-        super().__init__(f"Merge error on='{on_str}'{right_on_str}: {msg}")
-
-
-OutputType = Union[None, DataType, Sequence[str], dict[str, DataType]]
-
-
-class Sys(DataModel):
-    """Model for internal DataChain signals `id` and `rand`."""
-
-    id: int
-    rand: int
+    P = ParamSpec("P")
 
 
 class DataChain:
@@ -190,22 +84,22 @@ class DataChain:
     underlyind library `Pydantic`.
 
     See Also:
-        `DataChain.from_storage("s3://my-bucket/my-dir/")` - reading unstructured
+        `from_storage("s3://my-bucket/my-dir/")` - reading unstructured
             data files from storages such as S3, gs or Azure ADLS.
 
         `DataChain.save("name")` - saving to a dataset.
 
-        `DataChain.from_dataset("name")` - reading from a dataset.
+        `from_dataset("name")` - reading from a dataset.
 
-        `DataChain.from_values(fib=[1, 2, 3, 5, 8])` - generating from values.
+        `from_values(fib=[1, 2, 3, 5, 8])` - generating from values.
 
-        `DataChain.from_pandas(pd.DataFrame(...))` - generating from pandas.
+        `from_pandas(pd.DataFrame(...))` - generating from pandas.
 
-        `DataChain.from_json("file.json")` - generating from json.
+        `from_json("file.json")` - generating from json.
 
-        `DataChain.from_csv("file.csv")` - generating from csv.
+        `from_csv("file.csv")` - generating from csv.
 
-        `DataChain.from_parquet("file.parquet")` - generating from parquet.
+        `from_parquet("file.parquet")` - generating from parquet.
 
     Example:
         ```py
@@ -213,8 +107,7 @@ class DataChain:
 
         from mistralai.client import MistralClient
         from mistralai.models.chat_completion import ChatMessage
-
-        from datachain import DataChain, Column
+        import datachain as dc
 
         PROMPT = (
             "Was this bot dialog successful? "
@@ -225,7 +118,7 @@ class DataChain:
         api_key = os.environ["MISTRAL_API_KEY"]
 
         chain = (
-            DataChain.from_storage("gs://datachain-demo/chatbot-KiT/")
+            dc.from_storage("gs://datachain-demo/chatbot-KiT/")
             .limit(5)
             .settings(cache=True, parallel=5)
             .map(
@@ -408,246 +301,57 @@ class DataChain:
         self._settings = settings if settings else Settings()
         return self
 
-    def reset_schema(self, signals_schema: SignalSchema) -> "Self":  # noqa: D102
+    def reset_schema(self, signals_schema: SignalSchema) -> "Self":
         self.signals_schema = signals_schema
         return self
 
-    def add_schema(self, signals_schema: SignalSchema) -> "Self":  # noqa: D102
+    def add_schema(self, signals_schema: SignalSchema) -> "Self":
         self.signals_schema |= signals_schema
         return self
 
     @classmethod
     def from_storage(
         cls,
-        uri: Union[str, os.PathLike[str]],
-        *,
-        type: FileType = "binary",
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        in_memory: bool = False,
-        recursive: Optional[bool] = True,
-        object_name: str = "file",
-        update: bool = False,
-        anon: bool = False,
-        client_config: Optional[dict] = None,
-    ) -> "Self":
-        """Get data from a storage as a list of file with all file attributes.
-        It returns the chain itself as usual.
+        *args,
+        **kwargs,
+    ) -> "DataChain":
+        from .storage import from_storage
 
-        Parameters:
-            uri : storage URI with directory. URI must start with storage prefix such
-                as `s3://`, `gs://`, `az://` or "file:///"
-            type : read file as "binary", "text", or "image" data. Default is "binary".
-            recursive : search recursively for the given path.
-            object_name : Created object column name.
-            update : force storage reindexing. Default is False.
-            anon : If True, we will treat cloud bucket as public one
-            client_config : Optional client configuration for the storage client.
-
-        Example:
-            Simple call from s3
-            ```py
-            chain = DataChain.from_storage("s3://my-bucket/my-dir")
-            ```
-
-            With AWS S3-compatible storage
-            ```py
-            chain = DataChain.from_storage(
-                "s3://my-bucket/my-dir",
-                client_config = {"aws_endpoint_url": "<minio-endpoint-url>"}
-            )
-            ```
-
-            Pass existing session
-            ```py
-            session = Session.get()
-            chain = DataChain.from_storage("s3://my-bucket/my-dir", session=session)
-            ```
-        """
-        file_type = get_file_type(type)
-
-        if anon:
-            client_config = (client_config or {}) | {"anon": True}
-        session = Session.get(session, client_config=client_config, in_memory=in_memory)
-        cache = session.catalog.cache
-        client_config = session.catalog.client_config
-
-        list_ds_name, list_uri, list_path, list_ds_exists = get_listing(
-            uri, session, update=update
+        warnings.warn(
+            "Class method `from_storage` is deprecated. "
+            "Use `from_storage` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-        # ds_name is None if object is a file, we don't want to use cache
-        # or do listing in that case - just read that single object
-        if not list_ds_name:
-            dc = cls.from_values(
-                session=session,
-                settings=settings,
-                in_memory=in_memory,
-                file=[get_file_info(list_uri, cache, client_config=client_config)],
-            )
-            dc.signals_schema = dc.signals_schema.mutate({f"{object_name}": file_type})
-            return dc
-
-        if update or not list_ds_exists:
-            # disable prefetch for listing, as it pre-downloads all files
-            (
-                cls.from_records(
-                    DataChain.DEFAULT_FILE_RECORD,
-                    session=session,
-                    settings=settings,
-                    in_memory=in_memory,
-                )
-                .settings(prefetch=0)
-                .gen(
-                    list_bucket(list_uri, cache, client_config=client_config),
-                    output={f"{object_name}": File},
-                )
-                .save(list_ds_name, listing=True)
-            )
-
-        dc = cls.from_dataset(list_ds_name, session=session, settings=settings)
-        dc.signals_schema = dc.signals_schema.mutate({f"{object_name}": file_type})
-
-        return ls(dc, list_path, recursive=recursive, object_name=object_name)
+        return from_storage(*args, **kwargs)
 
     @classmethod
-    def from_dataset(
-        cls,
-        name: str,
-        version: Optional[int] = None,
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        fallback_to_studio: bool = True,
-    ) -> "Self":
-        """Get data from a saved Dataset. It returns the chain itself.
-        If dataset or version is not found locally, it will try to pull it from Studio.
+    def from_dataset(cls, *args, **kwargs) -> "DataChain":
+        from .datasets import from_dataset
 
-        Parameters:
-            name : dataset name
-            version : dataset version
-            session : Session to use for the chain.
-            settings : Settings to use for the chain.
-            fallback_to_studio : Try to pull dataset from Studio if not found locally.
-                Default is True.
-
-        Example:
-            ```py
-            chain = DataChain.from_dataset("my_cats")
-            ```
-
-            ```py
-            chain = DataChain.from_dataset("my_cats", fallback_to_studio=False)
-            ```
-
-            ```py
-            chain = DataChain.from_dataset("my_cats", version=1)
-            ```
-
-            ```py
-            session = Session.get(client_config={"aws_endpoint_url": "<minio-url>"})
-            settings = {
-                "cache": True,
-                "parallel": 4,
-                "workers": 4,
-                "min_task_size": 1000,
-                "prefetch": 10,
-            }
-            chain = DataChain.from_dataset(
-                name="my_cats",
-                version=1,
-                session=session,
-                settings=settings,
-                fallback_to_studio=True,
-            )
-            ```
-        """
-        from datachain.telemetry import telemetry
-
-        query = DatasetQuery(
-            name=name,
-            version=version,
-            session=session,
-            indexing_column_types=File._datachain_column_types,
-            fallback_to_studio=fallback_to_studio,
+        warnings.warn(
+            "Class method `from_dataset` is deprecated. "
+            "Use `from_dataset` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        telemetry.send_event_once("class", "datachain_init", name=name, version=version)
-        if settings:
-            _settings = Settings(**settings)
-        else:
-            _settings = Settings()
-
-        signals_schema = SignalSchema({"sys": Sys})
-        if query.feature_schema:
-            signals_schema |= SignalSchema.deserialize(query.feature_schema)
-        else:
-            signals_schema |= SignalSchema.from_column_types(query.column_types or {})
-        return cls(query, _settings, signals_schema)
+        return from_dataset(*args, **kwargs)
 
     @classmethod
     def from_json(
         cls,
-        path: Union[str, os.PathLike[str]],
-        type: FileType = "text",
-        spec: Optional[DataType] = None,
-        schema_from: Optional[str] = "auto",
-        jmespath: Optional[str] = None,
-        object_name: Optional[str] = "",
-        model_name: Optional[str] = None,
-        format: Optional[str] = "json",
-        nrows=None,
+        *args,
         **kwargs,
     ) -> "DataChain":
-        """Get data from JSON. It returns the chain itself.
+        from .json import from_json
 
-        Parameters:
-            path : storage URI with directory. URI must start with storage prefix such
-                as `s3://`, `gs://`, `az://` or "file:///"
-            type : read file as "binary", "text", or "image" data. Default is "text".
-            spec : optional Data Model
-            schema_from : path to sample to infer spec (if schema not provided)
-            object_name : generated object column name
-            model_name : optional generated model name
-            format: "json", "jsonl"
-            jmespath : optional JMESPATH expression to reduce JSON
-            nrows : optional row limit for jsonl and JSON arrays
-
-        Example:
-            infer JSON schema from data, reduce using JMESPATH
-            ```py
-            chain = DataChain.from_json("gs://json", jmespath="key1.key2")
-            ```
-
-            infer JSON schema from a particular path
-            ```py
-            chain = DataChain.from_json("gs://json_ds", schema_from="gs://json/my.json")
-            ```
-        """
-        if schema_from == "auto":
-            schema_from = str(path)
-
-        def jmespath_to_name(s: str):
-            name_end = re.search(r"\W", s).start() if re.search(r"\W", s) else len(s)  # type: ignore[union-attr]
-            return s[:name_end]
-
-        if (not object_name) and jmespath:
-            object_name = jmespath_to_name(jmespath)
-        if not object_name:
-            object_name = format
-        chain = DataChain.from_storage(uri=path, type=type, **kwargs)
-        signal_dict = {
-            object_name: read_meta(
-                schema_from=schema_from,
-                format=format,
-                spec=spec,
-                model_name=model_name,
-                jmespath=jmespath,
-                nrows=nrows,
-            ),
-            "params": {"file": File},
-        }
-        # disable prefetch if nrows is set
-        settings = {"prefetch": 0} if nrows else {}
-        return chain.settings(**settings).gen(**signal_dict)  # type: ignore[misc, arg-type]
+        warnings.warn(
+            "Class method `from_json` is deprecated. "
+            "Use `from_json` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return from_json(*args, **kwargs)
 
     def explode(
         self,
@@ -710,81 +414,34 @@ class DataChain:
     @classmethod
     def datasets(
         cls,
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        in_memory: bool = False,
-        object_name: str = "dataset",
-        include_listing: bool = False,
-        studio: bool = False,
+        *args,
+        **kwargs,
     ) -> "DataChain":
-        """Generate chain with list of registered datasets.
+        from .datasets import datasets
 
-        Args:
-            session: Optional session instance. If not provided, uses default session.
-            settings: Optional dictionary of settings to configure the chain.
-            in_memory: If True, creates an in-memory session. Defaults to False.
-            object_name: Name of the output object in the chain. Defaults to "dataset".
-            include_listing: If True, includes listing datasets. Defaults to False.
-            studio: If True, returns datasets from Studio only,
-                otherwise returns all local datasets. Defaults to False.
-
-        Returns:
-            DataChain: A new DataChain instance containing dataset information.
-
-        Example:
-            ```py
-            from datachain import DataChain
-
-            chain = DataChain.datasets()
-            for ds in chain.collect("dataset"):
-                print(f"{ds.name}@v{ds.version}")
-            ```
-        """
-        session = Session.get(session, in_memory=in_memory)
-        catalog = session.catalog
-
-        datasets = [
-            DatasetInfo.from_models(d, v, j)
-            for d, v, j in catalog.list_datasets_versions(
-                include_listing=include_listing, studio=studio
-            )
-        ]
-
-        return cls.from_values(
-            session=session,
-            settings=settings,
-            in_memory=in_memory,
-            output={object_name: DatasetInfo},
-            **{object_name: datasets},  # type: ignore[arg-type]
+        warnings.warn(
+            "Class method `datasets` is deprecated. "
+            "Use `datasets` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return datasets(*args, **kwargs)
 
     @classmethod
     def listings(
         cls,
-        session: Optional[Session] = None,
-        in_memory: bool = False,
-        object_name: str = "listing",
+        *args,
         **kwargs,
     ) -> "DataChain":
-        """Generate chain with list of cached listings.
-        Listing is a special kind of dataset which has directory listing data of
-        some underlying storage (e.g S3 bucket).
+        from .listings import listings
 
-        Example:
-            ```py
-            from datachain import DataChain
-            DataChain.listings().show()
-            ```
-        """
-        session = Session.get(session, in_memory=in_memory)
-        catalog = kwargs.get("catalog") or session.catalog
-
-        return cls.from_values(
-            session=session,
-            in_memory=in_memory,
-            output={object_name: ListingInfo},
-            **{object_name: catalog.listings()},  # type: ignore[arg-type]
+        warnings.warn(
+            "Class method `listings` is deprecated. "
+            "Use `listings` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return listings(*args, **kwargs)
 
     def save(  # type: ignore[override]
         self,
@@ -822,6 +479,7 @@ class DataChain:
 
         Example:
             ```py
+            import datachain as dc
             def parse_stem(chain):
                 return chain.map(
                     lambda file: file.get_file_stem()
@@ -829,7 +487,7 @@ class DataChain:
                 )
 
             chain = (
-                DataChain.from_storage("s3://my-bucket")
+                dc.from_storage("s3://my-bucket")
                 .apply(parse_stem)
                 .filter(C("stem").glob("*cat*"))
             )
@@ -1358,7 +1016,7 @@ class DataChain:
     @overload
     def results(self, *, include_hidden: bool) -> list[tuple[Any, ...]]: ...
 
-    def results(self, *, row_factory=None, include_hidden=True):  # noqa: D102
+    def results(self, *, row_factory=None, include_hidden=True):
         if row_factory is None:
             return list(self.collect_flatten(include_hidden=include_hidden))
         return list(
@@ -1468,7 +1126,7 @@ class DataChain:
             remove_prefetched=remove_prefetched,
         )
 
-    def remove_file_signals(self) -> "Self":  # noqa: D102
+    def remove_file_signals(self) -> "Self":
         schema = self.signals_schema.clone_without_file_signals()
         return self.select(*schema.values.keys())
 
@@ -1805,73 +1463,34 @@ class DataChain:
     @classmethod
     def from_values(
         cls,
-        ds_name: str = "",
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        in_memory: bool = False,
-        output: OutputType = None,
-        object_name: str = "",
-        **fr_map,
-    ) -> "Self":
-        """Generate chain from list of values.
+        *args,
+        **kwargs,
+    ) -> "DataChain":
+        from .values import from_values
 
-        Example:
-            ```py
-            DataChain.from_values(fib=[1, 2, 3, 5, 8])
-            ```
-        """
-        tuple_type, output, tuples = values_to_tuples(ds_name, output, **fr_map)
-
-        def _func_fr() -> Iterator[tuple_type]:  # type: ignore[valid-type]
-            yield from tuples
-
-        chain = cls.from_records(
-            DataChain.DEFAULT_FILE_RECORD,
-            session=session,
-            settings=settings,
-            in_memory=in_memory,
+        warnings.warn(
+            "Class method `from_values` is deprecated. "
+            "Use `from_values` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        if object_name:
-            output = {object_name: dict_to_data_model(object_name, output)}  # type: ignore[arg-type]
-        return chain.gen(_func_fr, output=output)
+        return from_values(*args, **kwargs)
 
     @classmethod
-    def from_pandas(  # type: ignore[override]
+    def from_pandas(
         cls,
-        df: "pd.DataFrame",
-        name: str = "",
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        in_memory: bool = False,
-        object_name: str = "",
+        *args,
+        **kwargs,
     ) -> "DataChain":
-        """Generate chain from pandas data-frame.
+        from .pandas import from_pandas
 
-        Example:
-            ```py
-            import pandas as pd
-
-            df = pd.DataFrame({"fib": [1, 2, 3, 5, 8]})
-            DataChain.from_pandas(df)
-            ```
-        """
-        fr_map = {col.lower(): df[col].tolist() for col in df.columns}
-
-        for column in fr_map:
-            if not column.isidentifier():
-                raise DatasetPrepareError(
-                    name,
-                    f"import from pandas error - '{column}' cannot be a column name",
-                )
-
-        return cls.from_values(
-            name,
-            session,
-            settings=settings,
-            object_name=object_name,
-            in_memory=in_memory,
-            **fr_map,
+        warnings.warn(
+            "Class method `from_pandas` is deprecated. "
+            "Use `from_pandas` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return from_pandas(*args, **kwargs)
 
     def to_pandas(self, flatten=False, include_hidden=True) -> "pd.DataFrame":
         """Return a pandas DataFrame from the chain.
@@ -1953,56 +1572,18 @@ class DataChain:
     @classmethod
     def from_hf(
         cls,
-        dataset: Union[str, "HFDatasetType"],
         *args,
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        object_name: str = "",
-        model_name: str = "",
         **kwargs,
     ) -> "DataChain":
-        """Generate chain from huggingface hub dataset.
+        from .hf import from_hf
 
-        Parameters:
-            dataset : Path or name of the dataset to read from Hugging Face Hub,
-                or an instance of `datasets.Dataset`-like object.
-            session : Session to use for the chain.
-            settings : Settings to use for the chain.
-            object_name : Generated object column name.
-            model_name : Generated model name.
-            kwargs : Parameters to pass to datasets.load_dataset.
-
-        Example:
-            Load from Hugging Face Hub:
-            ```py
-            DataChain.from_hf("beans", split="train")
-            ```
-
-            Generate chain from loaded dataset:
-            ```py
-            from datasets import load_dataset
-            ds = load_dataset("beans", split="train")
-            DataChain.from_hf(ds)
-            ```
-        """
-        from datachain.lib.hf import HFGenerator, get_output_schema, stream_splits
-
-        output: dict[str, DataType] = {}
-        ds_dict = stream_splits(dataset, *args, **kwargs)
-        if len(ds_dict) > 1:
-            output = {"split": str}
-
-        model_name = model_name or object_name or ""
-        hf_features = next(iter(ds_dict.values())).features
-        output = output | get_output_schema(hf_features)
-        model = dict_to_data_model(model_name, output)
-        if object_name:
-            output = {object_name: model}
-
-        chain = DataChain.from_values(
-            split=list(ds_dict.keys()), session=session, settings=settings
+        warnings.warn(
+            "Class method `from_hf` is deprecated. "
+            "Use `from_hf` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return chain.gen(HFGenerator(dataset, model, *args, **kwargs), output=output)
+        return from_hf(*args, **kwargs)
 
     def parse_tabular(
         self,
@@ -2093,161 +1674,34 @@ class DataChain:
     @classmethod
     def from_csv(
         cls,
-        path,
-        delimiter: Optional[str] = None,
-        header: bool = True,
-        output: OutputType = None,
-        object_name: str = "",
-        model_name: str = "",
-        source: bool = True,
-        nrows=None,
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        column_types: Optional[dict[str, "Union[str, ArrowDataType]"]] = None,
-        parse_options: Optional[dict[str, "Union[str, Union[bool, Callable]]"]] = None,
+        *args,
         **kwargs,
     ) -> "DataChain":
-        """Generate chain from csv files.
+        from .csv import from_csv
 
-        Parameters:
-            path : Storage URI with directory. URI must start with storage prefix such
-                as `s3://`, `gs://`, `az://` or "file:///".
-            delimiter : Character for delimiting columns. Takes precedence if also
-                specified in `parse_options`. Defaults to ",".
-            header : Whether the files include a header row.
-            output : Dictionary or feature class defining column names and their
-                corresponding types. List of column names is also accepted, in which
-                case types will be inferred.
-            object_name : Created object column name.
-            model_name : Generated model name.
-            source : Whether to include info about the source file.
-            nrows : Optional row limit.
-            session : Session to use for the chain.
-            settings : Settings to use for the chain.
-            column_types : Dictionary of column names and their corresponding types.
-                It is passed to CSV reader and for each column specified type auto
-                inference is disabled.
-            parse_options: Tells the parser how to process lines.
-                See https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html
-
-        Example:
-            Reading a csv file:
-            ```py
-            dc = DataChain.from_csv("s3://mybucket/file.csv")
-            ```
-
-            Reading csv files from a directory as a combined dataset:
-            ```py
-            dc = DataChain.from_csv("s3://mybucket/dir")
-            ```
-        """
-        from pandas.io.parsers.readers import STR_NA_VALUES
-        from pyarrow.csv import ConvertOptions, ParseOptions, ReadOptions
-        from pyarrow.dataset import CsvFileFormat
-        from pyarrow.lib import type_for_alias
-
-        parse_options = parse_options or {}
-        if "delimiter" not in parse_options:
-            parse_options["delimiter"] = ","
-        if delimiter:
-            parse_options["delimiter"] = delimiter
-
-        if column_types:
-            column_types = {
-                name: type_for_alias(typ) if isinstance(typ, str) else typ
-                for name, typ in column_types.items()
-            }
-        else:
-            column_types = {}
-
-        chain = DataChain.from_storage(
-            path, session=session, settings=settings, **kwargs
+        warnings.warn(
+            "Class method `from_csv` is deprecated. "
+            "Use `from_csv` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-        column_names = None
-        if not header:
-            if not output:
-                msg = "error parsing csv - provide output if no header"
-                raise DatasetPrepareError(chain.name, msg)
-            if isinstance(output, Sequence):
-                column_names = output  # type: ignore[assignment]
-            elif isinstance(output, dict):
-                column_names = list(output.keys())
-            elif (fr := ModelStore.to_pydantic(output)) is not None:
-                column_names = list(fr.model_fields.keys())
-            else:
-                msg = f"error parsing csv - incompatible output type {type(output)}"
-                raise DatasetPrepareError(chain.name, msg)
-
-        parse_options = ParseOptions(**parse_options)
-        read_options = ReadOptions(column_names=column_names)
-        convert_options = ConvertOptions(
-            strings_can_be_null=True,
-            null_values=STR_NA_VALUES,
-            column_types=column_types,
-        )
-        format = CsvFileFormat(
-            parse_options=parse_options,
-            read_options=read_options,
-            convert_options=convert_options,
-        )
-        return chain.parse_tabular(
-            output=output,
-            object_name=object_name,
-            model_name=model_name,
-            source=source,
-            nrows=nrows,
-            format=format,
-        )
+        return from_csv(*args, **kwargs)
 
     @classmethod
     def from_parquet(
         cls,
-        path,
-        partitioning: Any = "hive",
-        output: Optional[dict[str, DataType]] = None,
-        object_name: str = "",
-        model_name: str = "",
-        source: bool = True,
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
+        *args,
         **kwargs,
     ) -> "DataChain":
-        """Generate chain from parquet files.
+        from .parquet import from_parquet
 
-        Parameters:
-            path : Storage URI with directory. URI must start with storage prefix such
-                as `s3://`, `gs://`, `az://` or "file:///".
-            partitioning : Any pyarrow partitioning schema.
-            output : Dictionary defining column names and their corresponding types.
-            object_name : Created object column name.
-            model_name : Generated model name.
-            source : Whether to include info about the source file.
-            session : Session to use for the chain.
-            settings : Settings to use for the chain.
-
-        Example:
-            Reading a single file:
-            ```py
-            dc = DataChain.from_parquet("s3://mybucket/file.parquet")
-            ```
-
-            Reading a partitioned dataset from a directory:
-            ```py
-            dc = DataChain.from_parquet("s3://mybucket/dir")
-            ```
-        """
-        chain = DataChain.from_storage(
-            path, session=session, settings=settings, **kwargs
+        warnings.warn(
+            "Class method `from_parquet` is deprecated. "
+            "Use `from_parquet` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return chain.parse_tabular(
-            output=output,
-            object_name=object_name,
-            model_name=model_name,
-            source=source,
-            format="parquet",
-            partitioning=partitioning,
-        )
+        return from_parquet(*args, **kwargs)
 
     def to_parquet(
         self,
@@ -2470,69 +1924,18 @@ class DataChain:
     @classmethod
     def from_records(
         cls,
-        to_insert: Optional[Union[dict, list[dict]]],
-        session: Optional[Session] = None,
-        settings: Optional[dict] = None,
-        in_memory: bool = False,
-        schema: Optional[dict[str, DataType]] = None,
-    ) -> "Self":
-        """Create a DataChain from the provided records. This method can be used for
-        programmatically generating a chain in contrast of reading data from storages
-        or other sources.
+        *args,
+        **kwargs,
+    ) -> "DataChain":
+        from .records import from_records
 
-        Parameters:
-            to_insert : records (or a single record) to insert. Each record is
-                        a dictionary of signals and theirs values.
-            schema : describes chain signals and their corresponding types
-
-        Example:
-            ```py
-            single_record = DataChain.from_records(DataChain.DEFAULT_FILE_RECORD)
-            ```
-        """
-        session = Session.get(session, in_memory=in_memory)
-        catalog = session.catalog
-
-        name = session.generate_temp_dataset_name()
-        signal_schema = None
-        columns: list[sqlalchemy.Column] = []
-
-        if schema:
-            signal_schema = SignalSchema(schema)
-            columns = [
-                sqlalchemy.Column(c.name, c.type)  # type: ignore[union-attr]
-                for c in signal_schema.db_signals(as_columns=True)  # type: ignore[assignment]
-            ]
-        else:
-            columns = [
-                sqlalchemy.Column(name, typ)
-                for name, typ in File._datachain_column_types.items()
-            ]
-
-        dsr = catalog.create_dataset(
-            name,
-            columns=columns,
-            feature_schema=(
-                signal_schema.clone_without_sys_signals().serialize()
-                if signal_schema
-                else None
-            ),
+        warnings.warn(
+            "Class method `from_records` is deprecated. "
+            "Use `from_records` function instead from top_module.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-        session.add_dataset_version(dsr, dsr.latest_version)
-
-        if isinstance(to_insert, dict):
-            to_insert = [to_insert]
-        elif not to_insert:
-            to_insert = []
-
-        warehouse = catalog.warehouse
-        dr = warehouse.dataset_rows(dsr)
-        db = warehouse.db
-        insert_q = dr.get_table().insert()
-        for record in to_insert:
-            db.execute(insert_q.values(**record))
-        return cls.from_dataset(name=dsr.name, session=session, settings=settings)
+        return from_records(*args, **kwargs)
 
     def sum(self, fr: DataType):  # type: ignore[override]
         """Compute the sum of a column."""

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -1,0 +1,149 @@
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+)
+
+from datachain.lib.dataset_info import DatasetInfo
+from datachain.lib.file import (
+    File,
+)
+from datachain.lib.settings import Settings
+from datachain.lib.signal_schema import SignalSchema
+from datachain.query import Session
+from datachain.query.dataset import DatasetQuery
+
+from .utils import Sys
+from .values import from_values
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_dataset(
+    name: str,
+    version: Optional[int] = None,
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    fallback_to_studio: bool = True,
+) -> "DataChain":
+    """Get data from a saved Dataset. It returns the chain itself.
+    If dataset or version is not found locally, it will try to pull it from Studio.
+
+    Parameters:
+        name : dataset name
+        version : dataset version
+        session : Session to use for the chain.
+        settings : Settings to use for the chain.
+        fallback_to_studio : Try to pull dataset from Studio if not found locally.
+            Default is True.
+
+    Example:
+        ```py
+        import datachain as dc
+        chain = dc.from_dataset("my_cats")
+        ```
+
+        ```py
+        chain = dc.from_dataset("my_cats", fallback_to_studio=False)
+        ```
+
+        ```py
+        chain = dc.from_dataset("my_cats", version=1)
+        ```
+
+        ```py
+        session = Session.get(client_config={"aws_endpoint_url": "<minio-url>"})
+        settings = {
+            "cache": True,
+            "parallel": 4,
+            "workers": 4,
+            "min_task_size": 1000,
+            "prefetch": 10,
+        }
+        chain = dc.from_dataset(
+            name="my_cats",
+            version=1,
+            session=session,
+            settings=settings,
+            fallback_to_studio=True,
+        )
+        ```
+    """
+    from datachain.telemetry import telemetry
+
+    from .datachain import DataChain
+
+    query = DatasetQuery(
+        name=name,
+        version=version,
+        session=session,
+        indexing_column_types=File._datachain_column_types,
+        fallback_to_studio=fallback_to_studio,
+    )
+    telemetry.send_event_once("class", "datachain_init", name=name, version=version)
+    if settings:
+        _settings = Settings(**settings)
+    else:
+        _settings = Settings()
+
+    signals_schema = SignalSchema({"sys": Sys})
+    if query.feature_schema:
+        signals_schema |= SignalSchema.deserialize(query.feature_schema)
+    else:
+        signals_schema |= SignalSchema.from_column_types(query.column_types or {})
+    return DataChain(query, _settings, signals_schema)
+
+
+def datasets(
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    in_memory: bool = False,
+    object_name: str = "dataset",
+    include_listing: bool = False,
+    studio: bool = False,
+) -> "DataChain":
+    """Generate chain with list of registered datasets.
+
+    Args:
+        session: Optional session instance. If not provided, uses default session.
+        settings: Optional dictionary of settings to configure the chain.
+        in_memory: If True, creates an in-memory session. Defaults to False.
+        object_name: Name of the output object in the chain. Defaults to "dataset".
+        include_listing: If True, includes listing datasets. Defaults to False.
+        studio: If True, returns datasets from Studio only,
+            otherwise returns all local datasets. Defaults to False.
+
+    Returns:
+        DataChain: A new DataChain instance containing dataset information.
+
+    Example:
+        ```py
+        import datachain as dc
+
+        chain = dc.datasets()
+        for ds in chain.collect("dataset"):
+            print(f"{ds.name}@v{ds.version}")
+        ```
+    """
+
+    session = Session.get(session, in_memory=in_memory)
+    catalog = session.catalog
+
+    datasets_values = [
+        DatasetInfo.from_models(d, v, j)
+        for d, v, j in catalog.list_datasets_versions(
+            include_listing=include_listing, studio=studio
+        )
+    ]
+
+    return from_values(
+        session=session,
+        settings=settings,
+        in_memory=in_memory,
+        output={object_name: DatasetInfo},
+        **{object_name: datasets_values},  # type: ignore[arg-type]
+    )

--- a/src/datachain/lib/dc/hf.py
+++ b/src/datachain/lib/dc/hf.py
@@ -1,0 +1,75 @@
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    Union,
+)
+
+from datachain.lib.data_model import dict_to_data_model
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from datachain.lib.data_model import DataType
+    from datachain.lib.hf import HFDatasetType
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_hf(
+    dataset: Union[str, "HFDatasetType"],
+    *args,
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    object_name: str = "",
+    model_name: str = "",
+    **kwargs,
+) -> "DataChain":
+    """Generate chain from huggingface hub dataset.
+
+    Parameters:
+        dataset : Path or name of the dataset to read from Hugging Face Hub,
+            or an instance of `datasets.Dataset`-like object.
+        session : Session to use for the chain.
+        settings : Settings to use for the chain.
+        object_name : Generated object column name.
+        model_name : Generated model name.
+        kwargs : Parameters to pass to datasets.load_dataset.
+
+    Example:
+        Load from Hugging Face Hub:
+        ```py
+        import datachain as dc
+        chain = dc.from_hf("beans", split="train")
+        ```
+
+        Generate chain from loaded dataset:
+        ```py
+        from datasets import load_dataset
+        ds = load_dataset("beans", split="train")
+        import datachain as dc
+        chain = dc.from_hf(ds)
+        ```
+    """
+    from datachain.lib.hf import HFGenerator, get_output_schema, stream_splits
+
+    from .datachain import DataChain
+
+    output: dict[str, DataType] = {}
+    ds_dict = stream_splits(dataset, *args, **kwargs)
+    if len(ds_dict) > 1:
+        output = {"split": str}
+
+    model_name = model_name or object_name or ""
+    hf_features = next(iter(ds_dict.values())).features
+    output = output | get_output_schema(hf_features)
+    model = dict_to_data_model(model_name, output)
+    if object_name:
+        output = {object_name: model}
+
+    chain = DataChain.from_values(
+        split=list(ds_dict.keys()), session=session, settings=settings
+    )
+    return chain.gen(HFGenerator(dataset, model, *args, **kwargs), output=output)

--- a/src/datachain/lib/dc/json.py
+++ b/src/datachain/lib/dc/json.py
@@ -1,0 +1,91 @@
+import os
+import os.path
+import re
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    Union,
+)
+
+from datachain.lib.data_model import DataType
+from datachain.lib.file import (
+    File,
+    FileType,
+)
+from datachain.lib.meta_formats import read_meta
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_json(
+    path: Union[str, os.PathLike[str]],
+    type: FileType = "text",
+    spec: Optional[DataType] = None,
+    schema_from: Optional[str] = "auto",
+    jmespath: Optional[str] = None,
+    object_name: Optional[str] = "",
+    model_name: Optional[str] = None,
+    format: Optional[str] = "json",
+    nrows=None,
+    **kwargs,
+) -> "DataChain":
+    """Get data from JSON. It returns the chain itself.
+
+    Parameters:
+        path : storage URI with directory. URI must start with storage prefix such
+            as `s3://`, `gs://`, `az://` or "file:///"
+        type : read file as "binary", "text", or "image" data. Default is "text".
+        spec : optional Data Model
+        schema_from : path to sample to infer spec (if schema not provided)
+        object_name : generated object column name
+        model_name : optional generated model name
+        format: "json", "jsonl"
+        jmespath : optional JMESPATH expression to reduce JSON
+        nrows : optional row limit for jsonl and JSON arrays
+
+    Example:
+        infer JSON schema from data, reduce using JMESPATH
+        ```py
+        import datachain as dc
+        chain = dc.from_json("gs://json", jmespath="key1.key2")
+        ```
+
+        infer JSON schema from a particular path
+        ```py
+        import datachain as dc
+        chain = dc.from_json("gs://json_ds", schema_from="gs://json/my.json")
+        ```
+    """
+    from .datachain import DataChain
+
+    if schema_from == "auto":
+        schema_from = str(path)
+
+    def jmespath_to_name(s: str):
+        name_end = re.search(r"\W", s).start() if re.search(r"\W", s) else len(s)  # type: ignore[union-attr]
+        return s[:name_end]
+
+    if (not object_name) and jmespath:
+        object_name = jmespath_to_name(jmespath)
+    if not object_name:
+        object_name = format
+    chain = DataChain.from_storage(uri=path, type=type, **kwargs)
+    signal_dict = {
+        object_name: read_meta(
+            schema_from=schema_from,
+            format=format,
+            spec=spec,
+            model_name=model_name,
+            jmespath=jmespath,
+            nrows=nrows,
+        ),
+        "params": {"file": File},
+    }
+    # disable prefetch if nrows is set
+    settings = {"prefetch": 0} if nrows else {}
+    return chain.settings(**settings).gen(**signal_dict)  # type: ignore[misc, arg-type]

--- a/src/datachain/lib/dc/listings.py
+++ b/src/datachain/lib/dc/listings.py
@@ -1,0 +1,43 @@
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+)
+
+from datachain.lib.listing_info import ListingInfo
+from datachain.query import Session
+
+from .values import from_values
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def listings(
+    session: Optional[Session] = None,
+    in_memory: bool = False,
+    object_name: str = "listing",
+    **kwargs,
+) -> "DataChain":
+    """Generate chain with list of cached listings.
+    Listing is a special kind of dataset which has directory listing data of
+    some underlying storage (e.g S3 bucket).
+
+    Example:
+        ```py
+        import datachain as dc
+        dc.listings().show()
+        ```
+    """
+    session = Session.get(session, in_memory=in_memory)
+    catalog = kwargs.get("catalog") or session.catalog
+
+    return from_values(
+        session=session,
+        in_memory=in_memory,
+        output={object_name: ListingInfo},
+        **{object_name: catalog.listings()},  # type: ignore[arg-type]
+    )

--- a/src/datachain/lib/dc/pandas.py
+++ b/src/datachain/lib/dc/pandas.py
@@ -1,0 +1,56 @@
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+)
+
+from datachain.query import Session
+
+from .values import from_values
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_pandas(  # type: ignore[override]
+    df: "pd.DataFrame",
+    name: str = "",
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    in_memory: bool = False,
+    object_name: str = "",
+) -> "DataChain":
+    """Generate chain from pandas data-frame.
+
+    Example:
+        ```py
+        import pandas as pd
+        import datachain as dc
+
+        df = pd.DataFrame({"fib": [1, 2, 3, 5, 8]})
+        dc.from_pandas(df)
+        ```
+    """
+    from .utils import DatasetPrepareError
+
+    fr_map = {col.lower(): df[col].tolist() for col in df.columns}
+
+    for column in fr_map:
+        if not column.isidentifier():
+            raise DatasetPrepareError(
+                name,
+                f"import from pandas error - '{column}' cannot be a column name",
+            )
+
+    return from_values(
+        name,
+        session,
+        settings=settings,
+        object_name=object_name,
+        in_memory=in_memory,
+        **fr_map,
+    )

--- a/src/datachain/lib/dc/parquet.py
+++ b/src/datachain/lib/dc/parquet.py
@@ -1,0 +1,65 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+)
+
+from datachain.lib.data_model import DataType
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_parquet(
+    path,
+    partitioning: Any = "hive",
+    output: Optional[dict[str, DataType]] = None,
+    object_name: str = "",
+    model_name: str = "",
+    source: bool = True,
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    **kwargs,
+) -> "DataChain":
+    """Generate chain from parquet files.
+
+    Parameters:
+        path : Storage URI with directory. URI must start with storage prefix such
+            as `s3://`, `gs://`, `az://` or "file:///".
+        partitioning : Any pyarrow partitioning schema.
+        output : Dictionary defining column names and their corresponding types.
+        object_name : Created object column name.
+        model_name : Generated model name.
+        source : Whether to include info about the source file.
+        session : Session to use for the chain.
+        settings : Settings to use for the chain.
+
+    Example:
+        Reading a single file:
+        ```py
+        import datachain as dc
+        dc.from_parquet("s3://mybucket/file.parquet")
+        ```
+
+        Reading a partitioned dataset from a directory:
+        ```py
+        import datachain as dc
+        dc.from_parquet("s3://mybucket/dir")
+        ```
+    """
+    from .datachain import DataChain
+
+    chain = DataChain.from_storage(path, session=session, settings=settings, **kwargs)
+    return chain.parse_tabular(
+        output=output,
+        object_name=object_name,
+        model_name=model_name,
+        source=source,
+        format="parquet",
+        partitioning=partitioning,
+    )

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -1,0 +1,90 @@
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    Union,
+)
+
+import sqlalchemy
+
+from datachain.lib.data_model import DataType
+from datachain.lib.file import (
+    File,
+)
+from datachain.lib.signal_schema import SignalSchema
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_records(
+    to_insert: Optional[Union[dict, list[dict]]],
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    in_memory: bool = False,
+    schema: Optional[dict[str, DataType]] = None,
+) -> "DataChain":
+    """Create a DataChain from the provided records. This method can be used for
+    programmatically generating a chain in contrast of reading data from storages
+    or other sources.
+
+    Parameters:
+        to_insert : records (or a single record) to insert. Each record is
+                    a dictionary of signals and theirs values.
+        schema : describes chain signals and their corresponding types
+
+    Example:
+        ```py
+        import datachain as dc
+        single_record = dc.from_records(dc.DEFAULT_FILE_RECORD)
+        ```
+    """
+    from .datasets import from_dataset
+
+    session = Session.get(session, in_memory=in_memory)
+    catalog = session.catalog
+
+    name = session.generate_temp_dataset_name()
+    signal_schema = None
+    columns: list[sqlalchemy.Column] = []
+
+    if schema:
+        signal_schema = SignalSchema(schema)
+        columns = [
+            sqlalchemy.Column(c.name, c.type)  # type: ignore[union-attr]
+            for c in signal_schema.db_signals(as_columns=True)  # type: ignore[assignment]
+        ]
+    else:
+        columns = [
+            sqlalchemy.Column(name, typ)
+            for name, typ in File._datachain_column_types.items()
+        ]
+
+    dsr = catalog.create_dataset(
+        name,
+        columns=columns,
+        feature_schema=(
+            signal_schema.clone_without_sys_signals().serialize()
+            if signal_schema
+            else None
+        ),
+    )
+
+    session.add_dataset_version(dsr, dsr.latest_version)
+
+    if isinstance(to_insert, dict):
+        to_insert = [to_insert]
+    elif not to_insert:
+        to_insert = []
+
+    warehouse = catalog.warehouse
+    dr = warehouse.dataset_rows(dsr)
+    db = warehouse.db
+    insert_q = dr.get_table().insert()
+    for record in to_insert:
+        db.execute(insert_q.values(**record))
+    return from_dataset(name=dsr.name, session=session, settings=settings)

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -1,0 +1,118 @@
+import os.path
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    Union,
+)
+
+from datachain.lib.file import (
+    File,
+    FileType,
+    get_file_type,
+)
+from datachain.lib.listing import get_file_info, get_listing, list_bucket, ls
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from .datachain import DataChain
+
+
+def from_storage(
+    uri: Union[str, os.PathLike[str]],
+    *,
+    type: FileType = "binary",
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    in_memory: bool = False,
+    recursive: Optional[bool] = True,
+    object_name: str = "file",
+    update: bool = False,
+    anon: bool = False,
+    client_config: Optional[dict] = None,
+) -> "DataChain":
+    """Get data from a storage as a list of file with all file attributes.
+    It returns the chain itself as usual.
+
+    Parameters:
+        uri : storage URI with directory. URI must start with storage prefix such
+            as `s3://`, `gs://`, `az://` or "file:///"
+        type : read file as "binary", "text", or "image" data. Default is "binary".
+        recursive : search recursively for the given path.
+        object_name : Created object column name.
+        update : force storage reindexing. Default is False.
+        anon : If True, we will treat cloud bucket as public one
+        client_config : Optional client configuration for the storage client.
+
+    Example:
+        Simple call from s3
+        ```py
+        import datachain as dc
+        chain = dc.from_storage("s3://my-bucket/my-dir")
+        ```
+
+        With AWS S3-compatible storage
+        ```py
+        import datachain as dc
+        chain = dc.from_storage(
+            "s3://my-bucket/my-dir",
+            client_config = {"aws_endpoint_url": "<minio-endpoint-url>"}
+        )
+        ```
+
+        Pass existing session
+        ```py
+        session = Session.get()
+        import datachain as dc
+        chain = dc.from_storage("s3://my-bucket/my-dir", session=session)
+        ```
+    """
+    from .datachain import DataChain
+    from .datasets import from_dataset
+    from .records import from_records
+    from .values import from_values
+
+    file_type = get_file_type(type)
+
+    if anon:
+        client_config = (client_config or {}) | {"anon": True}
+    session = Session.get(session, client_config=client_config, in_memory=in_memory)
+    cache = session.catalog.cache
+    client_config = session.catalog.client_config
+
+    list_ds_name, list_uri, list_path, list_ds_exists = get_listing(
+        uri, session, update=update
+    )
+
+    # ds_name is None if object is a file, we don't want to use cache
+    # or do listing in that case - just read that single object
+    if not list_ds_name:
+        dc = from_values(
+            session=session,
+            settings=settings,
+            in_memory=in_memory,
+            file=[get_file_info(list_uri, cache, client_config=client_config)],
+        )
+        dc.signals_schema = dc.signals_schema.mutate({f"{object_name}": file_type})
+        return dc
+
+    if update or not list_ds_exists:
+        # disable prefetch for listing, as it pre-downloads all files
+        (
+            from_records(
+                DataChain.DEFAULT_FILE_RECORD,
+                session=session,
+                settings=settings,
+                in_memory=in_memory,
+            )
+            .settings(prefetch=0)
+            .gen(
+                list_bucket(list_uri, cache, client_config=client_config),
+                output={f"{object_name}": File},
+            )
+            .save(list_ds_name, listing=True)
+        )
+
+    dc = from_dataset(list_ds_name, session=session, settings=settings)
+    dc.signals_schema = dc.signals_schema.mutate({f"{object_name}": file_type})
+
+    return ls(dc, list_path, recursive=recursive, object_name=object_name)

--- a/src/datachain/lib/dc/utils.py
+++ b/src/datachain/lib/dc/utils.py
@@ -1,0 +1,128 @@
+from collections.abc import Sequence
+from functools import wraps
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Optional,
+    TypeVar,
+    Union,
+)
+
+import sqlalchemy
+from sqlalchemy.sql.functions import GenericFunction
+
+from datachain.func.base import Function
+from datachain.lib.data_model import DataModel, DataType
+from datachain.lib.utils import DataChainParamsError
+from datachain.query.schema import DEFAULT_DELIMITER
+
+if TYPE_CHECKING:
+    from typing_extensions import Concatenate, ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+D = TypeVar("D", bound="DataChain")
+
+
+def resolve_columns(
+    method: "Callable[Concatenate[D, P], D]",
+) -> "Callable[Concatenate[D, P], D]":
+    """Decorator that resolvs input column names to their actual DB names. This is
+    specially important for nested columns as user works with them by using dot
+    notation e.g (file.name) but are actually defined with default delimiter
+    in DB, e.g file__name.
+    If there are any sql functions in arguments, they will just be transferred as is
+    to a method.
+    """
+
+    @wraps(method)
+    def _inner(self: D, *args: "P.args", **kwargs: "P.kwargs") -> D:
+        resolved_args = self.signals_schema.resolve(
+            *[arg for arg in args if not isinstance(arg, GenericFunction)]  # type: ignore[arg-type]
+        ).db_signals()
+
+        for idx, arg in enumerate(args):
+            if isinstance(arg, GenericFunction):
+                resolved_args.insert(idx, arg)  # type: ignore[arg-type]
+
+        return method(self, *resolved_args, **kwargs)
+
+    return _inner
+
+
+class DatasetPrepareError(DataChainParamsError):
+    def __init__(self, name, msg, output=None):
+        name = f" '{name}'" if name else ""
+        output = f" output '{output}'" if output else ""
+        super().__init__(f"Dataset{name}{output} processing prepare error: {msg}")
+
+
+class DatasetFromValuesError(DataChainParamsError):
+    def __init__(self, name, msg):
+        name = f" '{name}'" if name else ""
+        super().__init__(f"Dataset{name} from values error: {msg}")
+
+
+MergeColType = Union[str, Function, sqlalchemy.ColumnElement]
+
+
+def _validate_merge_on(
+    on: Union[MergeColType, Sequence[MergeColType]],
+    ds: "DataChain",
+) -> Sequence[MergeColType]:
+    if isinstance(on, (str, sqlalchemy.ColumnElement)):
+        return [on]
+    if isinstance(on, Function):
+        return [on.get_column(table=ds._query.table)]
+    if isinstance(on, Sequence):
+        return [
+            c.get_column(table=ds._query.table) if isinstance(c, Function) else c
+            for c in on
+        ]
+
+
+def _get_merge_error_str(col: MergeColType) -> str:
+    if isinstance(col, str):
+        return col
+    if isinstance(col, Function):
+        return f"{col.name}()"
+    if isinstance(col, sqlalchemy.Column):
+        return col.name.replace(DEFAULT_DELIMITER, ".")
+    if isinstance(col, sqlalchemy.ColumnElement) and hasattr(col, "name"):
+        return f"{col.name} expression"
+    return str(col)
+
+
+class DatasetMergeError(DataChainParamsError):
+    def __init__(
+        self,
+        on: Union[MergeColType, Sequence[MergeColType]],
+        right_on: Optional[Union[MergeColType, Sequence[MergeColType]]],
+        msg: str,
+    ):
+        def _get_str(
+            on: Union[MergeColType, Sequence[MergeColType]],
+        ) -> str:
+            if not isinstance(on, Sequence):
+                return str(on)  # type: ignore[unreachable]
+            return ", ".join([_get_merge_error_str(col) for col in on])
+
+        on_str = _get_str(on)
+        right_on_str = (
+            ", right_on='" + _get_str(right_on) + "'"
+            if right_on and isinstance(right_on, Sequence)
+            else ""
+        )
+        super().__init__(f"Merge error on='{on_str}'{right_on_str}: {msg}")
+
+
+OutputType = Union[None, DataType, Sequence[str], dict[str, DataType]]
+
+
+class Sys(DataModel):
+    """Model for internal DataChain signals `id` and `rand`."""
+
+    id: int
+    rand: int

--- a/src/datachain/lib/dc/values.py
+++ b/src/datachain/lib/dc/values.py
@@ -1,0 +1,53 @@
+from collections.abc import Iterator
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+)
+
+from datachain.lib.convert.values_to_tuples import values_to_tuples
+from datachain.lib.data_model import dict_to_data_model
+from datachain.lib.dc.records import from_records
+from datachain.lib.dc.utils import OutputType
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    from .datachain import DataChain
+
+    P = ParamSpec("P")
+
+
+def from_values(
+    ds_name: str = "",
+    session: Optional[Session] = None,
+    settings: Optional[dict] = None,
+    in_memory: bool = False,
+    output: OutputType = None,
+    object_name: str = "",
+    **fr_map,
+) -> "DataChain":
+    """Generate chain from list of values.
+
+    Example:
+        ```py
+        import datachain as dc
+        dc.from_values(fib=[1, 2, 3, 5, 8])
+        ```
+    """
+    from .datachain import DataChain
+
+    tuple_type, output, tuples = values_to_tuples(ds_name, output, **fr_map)
+
+    def _func_fr() -> Iterator[tuple_type]:  # type: ignore[valid-type]
+        yield from tuples
+
+    chain = from_records(
+        DataChain.DEFAULT_FILE_RECORD,
+        session=session,
+        settings=settings,
+        in_memory=in_memory,
+    )
+    if object_name:
+        output = {object_name: dict_to_data_model(object_name, output)}  # type: ignore[arg-type]
+    return chain.gen(_func_fr, output=output)

--- a/tests/scripts/feature_class.py
+++ b/tests/scripts/feature_class.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from datachain.lib.dc import C, DataChain
+import datachain as dc
 
 
 class Embedding(BaseModel):
@@ -9,8 +9,8 @@ class Embedding(BaseModel):
 
 ds_name = "feature_class"
 ds = (
-    DataChain.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
-    .filter(C("file.path").glob("*cat*.jpg"))
+    dc.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    .filter(dc.C("file.path").glob("*cat*.jpg"))
     .order_by("file.path")
     .limit(5)
     .map(emd=lambda file: Embedding(value=512), output=Embedding)

--- a/tests/scripts/feature_class_parallel.py
+++ b/tests/scripts/feature_class_parallel.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel
 
-from datachain.lib.dc import C, DataChain
+import datachain as dc
 
 
 class NestedFeature(BaseModel):
@@ -17,8 +17,8 @@ class Embedding(BaseModel):
 
 ds_name = "feature_class"
 ds = (
-    DataChain.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
-    .filter(C("file.path").glob("*cat*.jpg"))  # type: ignore [attr-defined]
+    dc.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    .filter(dc.C("file.path").glob("*cat*.jpg"))  # type: ignore [attr-defined]
     .order_by("file.path")
     .limit(5)
     .settings(cache=True, parallel=2)

--- a/tests/scripts/feature_class_parallel_data_model.py
+++ b/tests/scripts/feature_class_parallel_data_model.py
@@ -1,7 +1,8 @@
 from typing import Literal, Optional
 
+import datachain as dc
+from datachain import C
 from datachain.lib.data_model import DataModel
-from datachain.lib.dc import C, DataChain
 
 
 class NestedFeature(DataModel):
@@ -16,7 +17,7 @@ class Embedding(DataModel):
 
 ds_name = "feature_class"
 ds = (
-    DataChain.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    dc.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
     .filter(C("file.path").glob("*cat*.jpg"))  # type: ignore [attr-defined]
     .order_by("file.path")
     .limit(5)

--- a/tests/scripts/name_len_slow.py
+++ b/tests/scripts/name_len_slow.py
@@ -1,7 +1,7 @@
 import sys
 from time import sleep
 
-from datachain.lib.dc import C, DataChain
+import datachain as dc
 
 if sys.platform == "win32":
     # This is needed for this process to accept a Ctrl-C event in Windows,
@@ -32,9 +32,9 @@ def name_len(file):
 
 
 # Save as a new dataset.
-DataChain.from_storage(
+dc.from_storage(
     "gs://dvcx-datalakes/dogs-and-cats/",
     anon=True,
-).filter(C("file.path").glob("*cat*")).limit(3).settings(parallel=1).map(
+).filter(dc.C("file.path").glob("*cat*")).limit(3).settings(parallel=1).map(
     name_len, params=["file"], output={"name_len": int}
 ).save("name_len")


### PR DESCRIPTION
- Updated import statements to use `import datachain as dc` for consistency across examples and documentation.
- Refactored example code snippets in `examples.md` and `quick-start.md` to reflect the new import style.
- Enhanced documentation in `datachain.md`, `file.md`, `imagefile.md`, `textfile.md`, and `videofile.md` to clarify usage of `from_storage` and other methods.
- Introduced new utility functions in `dc` module for CSV, JSON, and other data formats to streamline data ingestion processes.
- Added new methods for handling datasets and listings, improving the overall functionality of the DataChain library.

Closes #984
