### PR TITLE
Update `s3://noaa-bathymetry-pds` bucket name

### DIFF
--- a/tests/benchmarks/test_ls.py
+++ b/tests/benchmarks/test_ls.py
@@ -2,5 +2,5 @@ from datachain.cli import ls
 
 
 def test_ls(benchmark, tmp_dir):
-    bucket = "s3://noaa-bathymetry-pds/"
+    bucket = "s3://noaa-dcdb-bathymetry-pds/"
     benchmark.pedantic(ls, args=([bucket],), kwargs={"client_config": {"anon": True}})


### PR DESCRIPTION
Apparently, someone at AWS silently renamed[^1] the bucket from `noaa-bathymetry-pds` to `noaa-dcdb-bathymetry-pds` — https://github.com/awslabs/open-data-registry/pull/1828 (!)

### [Failed run](https://github.com/iterative/datachain/actions/runs/14072549519/job/39409585538)
```
=================================== FAILURES ===================================
___________________________________ test_ls ____________________________________

...
    def test_ls(benchmark, tmp_dir):
        bucket = "s3://noaa-bathymetry-pds/"
>       benchmark.pedantic(ls, args=([bucket],), kwargs={"client_config": {"anon": True}})

...
E           botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the ListObjectVersions operation: The specified bucket does not exist
...
```

(See also [this Slack thread](https://iterativeai.slack.com/archives/C04A9RWEZBN/p1742957493009369))

[^1]: i.e. created a new bucket, copied the data over, and deleted the previous one.