### PR TITLE
Rename from_x to read_x for dc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ high confidence scores.
     import datachain as dc
 
     meta = dc.from_json("gs://datachain-demo/dogs-and-cats/*json", object_name="meta", anon=True)
-    images = dc.from_storage("gs://datachain-demo/dogs-and-cats/*jpg", anon=True)
+    images = dc.read_storage("gs://datachain-demo/dogs-and-cats/*jpg", anon=True)
 
     images_id = images.map(id=lambda file: file.path.split('.')[-2])
     annotated = images_id.merge(meta, on="id", right_on="meta.id")
@@ -102,7 +102,7 @@ Python code:
          return result.lower().startswith("success")
 
     chain = (
-       dc.from_storage("gs://datachain-demo/chatbot-KiT/", object_name="file", anon=True)
+       dc.read_storage("gs://datachain-demo/chatbot-KiT/", object_name="file", anon=True)
        .settings(parallel=4, cache=True)
        .map(is_success=eval_dialogue)
        .save("mistral_files")

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ high confidence scores.
 
     import datachain as dc
 
-    meta = dc.from_json("gs://datachain-demo/dogs-and-cats/*json", object_name="meta", anon=True)
+    meta = dc.read_json("gs://datachain-demo/dogs-and-cats/*json", object_name="meta", anon=True)
     images = dc.read_storage("gs://datachain-demo/dogs-and-cats/*jpg", anon=True)
 
     images_id = images.map(id=lambda file: file.path.split('.')[-2])

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -145,7 +145,7 @@ The cost of 5 calls to Mixtral 8x22b : $0.0142
 The “save” operation makes chain dataset persistent in the current (working) directory of the query. A hidden folder `.datachain/` holds the records. A persistent dataset can be accessed later to start a derivative chain:
 
 ```python
-dc.from_dataset("rating").limit(2).save("dialog-rating")
+dc.read_dataset("rating").limit(2).save("dialog-rating")
 ```
 
 Persistent datasets are immutable and automatically versioned. Here is how to access the dataset registry:
@@ -167,7 +167,7 @@ dialog-rating@v2
 By default, when a saved dataset is loaded, the latest version is fetched but another version can be requested:
 
 ```python
-ds = dc.from_dataset("dialog-rating", version = 1)
+ds = dc.read_dataset("dialog-rating", version=1)
 ```
 
 ### Chain execution, optimization and parallelism

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -111,8 +111,8 @@ chain = (
     .save("dialog-rating")
 )
 
-** iter = chain.collect("mistral")
-** print(*map(lambda chat_response: chat_response.choices[0].message.content, iter))
+**iter = chain.collect("mistral")
+**print(*map(lambda chat_response: chat_response.choices[0].message.content, iter))
 ```
 
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -237,8 +237,8 @@ images_uri = "gs://datachain-demo/coco2017/images/val/"
 captions_uri = "gs://datachain-demo/coco2017/annotations/captions_val2017.json"
 
 images = dc.read_storage(images_uri)
-meta = dc.from_json(captions_uri, jmespath="images")
-captions = dc.from_json(captions_uri, jmespath="annotations")
+meta = dc.read_json(captions_uri, jmespath="images")
+captions = dc.read_json(captions_uri, jmespath="annotations")
 
 images_meta = images.merge(meta, on="file.name", right_on="images.file_name")
 captioned_images = images_meta.merge(captions, on="images.id", right_on="annotations.image_id")

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -189,8 +189,8 @@ Here is an example of reading a simple CSV file where schema is heuristically de
 ```python
 from datachain import DataChain
 
-uri="gs://datachain-demo/chatbot-csv/"
-csv_dataset = dc.from_csv(uri)
+uri = "gs://datachain-demo/chatbot-csv/"
+csv_dataset = dc.read_csv(uri)
 
 print(csv_dataset.to_pandas())
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,7 +16,7 @@ title: Examples
     import datachain as dc # (1)!
     from transformers import AutoProcessor, PaliGemmaForConditionalGeneration # (2)!
 
-    images = dc.from_storage("gs://datachain-demo/newyorker_caption_contest/images", type="image")
+    images = dc.read_storage("gs://datachain-demo/newyorker_caption_contest/images", type="image")
 
     model = PaliGemmaForConditionalGeneration.from_pretrained("google/paligemma-3b-mix-224")
     processor = AutoProcessor.from_pretrained("google/paligemma-3b-mix-224")
@@ -93,26 +93,26 @@ dc.DataModel.register(MistralModel)
 
 chain = (
     dc
-    .from_storage("gs://datachain-demo/chatbot-KiT/", type="text")
+    .read_storage("gs://datachain-demo/chatbot-KiT/", type="text")
     .filter(dc.Column("file.name").glob("*.txt"))
     .limit(5)
     .settings(parallel=4, cache=True)
     .map(
-       mistral=lambda file: MistralClient(api_key=api_key).chat(
-                                          model="open-mixtral-8x22b",
-                                          response_format={"type": "json_object"},
-                                          messages= [
-                                             ChatMessage(role="system", content=f"{prompt}"),
-                                             ChatMessage(role="user", content=f"{file.read()}")
-                                          ]
-                            ),
-       output=MistralModel
+        mistral=lambda file: MistralClient(api_key=api_key).chat(
+            model="open-mixtral-8x22b",
+            response_format={"type": "json_object"},
+            messages=[
+                ChatMessage(role="system", content=f"{prompt}"),
+                ChatMessage(role="user", content=f"{file.read()}")
+            ]
+        ),
+        output=MistralModel
     )
     .save("dialog-rating")
 )
 
-**iter = chain.collect("mistral")
-**print(*map(lambda chat_response: chat_response.choices[0].message.content, iter))
+** iter = chain.collect("mistral")
+** print(*map(lambda chat_response: chat_response.choices[0].message.content, iter))
 ```
 
 ```
@@ -233,12 +233,12 @@ However, Datachain can easily parse the entire COCO structure via several readin
 ```python
 import datachain as dc
 
-images_uri="gs://datachain-demo/coco2017/images/val/"
-captions_uri="gs://datachain-demo/coco2017/annotations/captions_val2017.json"
+images_uri = "gs://datachain-demo/coco2017/images/val/"
+captions_uri = "gs://datachain-demo/coco2017/annotations/captions_val2017.json"
 
-images = dc.from_storage(images_uri)
-meta = dc.from_json(captions_uri, jmespath = "images")
-captions = dc.from_json(captions_uri, jmespath = "annotations")
+images = dc.read_storage(images_uri)
+meta = dc.from_json(captions_uri, jmespath="images")
+captions = dc.from_json(captions_uri, jmespath="annotations")
 
 images_meta = images.merge(meta, on="file.name", right_on="images.file_name")
 captioned_images = images_meta.merge(captions, on="images.id", right_on="annotations.image_id")

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -210,14 +210,14 @@ name                  usage        usage             usage
 
 In the previous examples, datasets were saved in the embedded database
 (`SQLite` in folder `.datachain` of the working directory). These datasets were automatically versioned, and
-can be accessed using `dc.read_hf("dataset_name")`.
+can be accessed using `dc.read_dataset("dataset_name")`.
 
 Here is how to retrieve a saved dataset and iterate over the objects:
 
 ``` py
 import datachain as dc
 
-chain = dc.read_hf("response")
+chain = dc.read_dataset("response")
 
 # Iterating one-by-one: support out-of-memory workflow
 for file, response in chain.limit(5).collect("file", "response"):
@@ -248,7 +248,7 @@ output tokens:
 
 ``` py
 import datachain as dc
-chain = dc.read_hf("mistral_dataset")
+chain = dc.read_dataset("mistral_dataset")
 
 cost = chain.sum("response.usage.prompt_tokens")*0.000002 \
            + chain.sum("response.usage.completion_tokens")*0.000006

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -210,14 +210,14 @@ name                  usage        usage             usage
 
 In the previous examples, datasets were saved in the embedded database
 (`SQLite` in folder `.datachain` of the working directory). These datasets were automatically versioned, and
-can be accessed using `dc.from_dataset("dataset_name")`.
+can be accessed using `dc.read_hf("dataset_name")`.
 
 Here is how to retrieve a saved dataset and iterate over the objects:
 
 ``` py
 import datachain as dc
 
-chain = dc.from_dataset("response")
+chain = dc.read_hf("response")
 
 # Iterating one-by-one: support out-of-memory workflow
 for file, response in chain.limit(5).collect("file", "response"):
@@ -248,7 +248,7 @@ output tokens:
 
 ``` py
 import datachain as dc
-chain = dc.from_dataset("mistral_dataset")
+chain = dc.read_hf("mistral_dataset")
 
 cost = chain.sum("response.usage.prompt_tokens")*0.000002 \
            + chain.sum("response.usage.completion_tokens")*0.000006

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -40,7 +40,7 @@ using JSON metadata:
 import datachain as dc
 
 meta = dc.from_json("gs://datachain-demo/dogs-and-cats/*json", object_name="meta", anon=True)
-images = dc.from_storage("gs://datachain-demo/dogs-and-cats/*jpg", anon=True)
+images = dc.read_storage("gs://datachain-demo/dogs-and-cats/*jpg", anon=True)
 
 images_id = images.map(id=lambda file: file.path.split('.')[-2])
 annotated = images_id.merge(meta, on="id", right_on="meta.id")
@@ -77,7 +77,7 @@ def is_positive_dialogue_ending(file) -> bool:
     return classifier(dialogue_ending)[0]["label"] == "POSITIVE"
 
 chain = (
-   dc.from_storage("gs://datachain-demo/chatbot-KiT/",
+   dc.read_storage("gs://datachain-demo/chatbot-KiT/",
                           object_name="file", type="text", anon=True)
    .settings(parallel=8, cache=True)
    .map(is_positive=is_positive_dialogue_ending)
@@ -132,7 +132,7 @@ def eval_dialogue(file: dc.File) -> bool:
      return result.lower().startswith("success")
 
 chain = (
-   dc.from_storage("gs://datachain-demo/chatbot-KiT/", object_name="file", anon=True)
+   dc.read_storage("gs://datachain-demo/chatbot-KiT/", object_name="file", anon=True)
    .map(is_success=eval_dialogue)
    .save("mistral_files")
 )
@@ -177,7 +177,7 @@ def eval_dialog(file: dc.File) -> ChatCompletionResponse:
                    {"role": "user", "content": file.read()}])
 
 chain = (
-   dc.from_storage("gs://datachain-demo/chatbot-KiT/", object_name="file", anon=True)
+   dc.read_storage("gs://datachain-demo/chatbot-KiT/", object_name="file", anon=True)
    .settings(parallel=4, cache=True)
    .map(response=eval_dialog)
    .map(status=lambda response: response.choices[0].message.content.lower()[:7])
@@ -276,7 +276,7 @@ import datachain as dc
 processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
 
 chain = (
-    dc.from_storage("gs://datachain-demo/dogs-and-cats/", type="image", anon=True)
+    dc.read_storage("gs://datachain-demo/dogs-and-cats/", type="image", anon=True)
     .map(label=lambda name: name.split(".")[0], params=["file.name"])
     .select("file", "label").to_pytorch(
         transform=processor.image_processor,

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -39,7 +39,7 @@ using JSON metadata:
 ``` py
 import datachain as dc
 
-meta = dc.from_json("gs://datachain-demo/dogs-and-cats/*json", object_name="meta", anon=True)
+meta = dc.read_json("gs://datachain-demo/dogs-and-cats/*json", object_name="meta", anon=True)
 images = dc.read_storage("gs://datachain-demo/dogs-and-cats/*jpg", anon=True)
 
 images_id = images.map(id=lambda file: file.path.split('.')[-2])

--- a/docs/references/data-types/file.md
+++ b/docs/references/data-types/file.md
@@ -2,12 +2,12 @@
 
 `File` is a special [`DataModel`](index.md#datachain.lib.data_model.DataModel),
 which is automatically generated when a `DataChain` is created from files,
-such as in [`dc.from_storage`](../datachain.md#datachain.lib.dc.storage.from_storage):
+such as in [`dc.read_storage`](../datachain.md#datachain.lib.dc.storage.read_storage):
 
 ```python
 import datachain as dc
 
-chain = dc.from_storage("gs://datachain-demo/dogs-and-cats")
+chain = dc.read_storage("gs://datachain-demo/dogs-and-cats")
 chain.print_schema()
 ```
 

--- a/docs/references/data-types/imagefile.md
+++ b/docs/references/data-types/imagefile.md
@@ -2,12 +2,12 @@
 
 `ImageFile` is inherited from [`File`](file.md) with additional methods for working with image files.
 
-`ImageFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.storage.from_storage), using `type="image"` param:
+`ImageFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.storage.read_storage), using `type="image"` param:
 
 ```python
 import datachain as dc
 
-chain = dc.from_storage("s3://bucket-name/", type="image")
+chain = dc.read_storage("s3://bucket-name/", type="image")
 ```
 
 ::: datachain.lib.file.ImageFile

--- a/docs/references/data-types/textfile.md
+++ b/docs/references/data-types/textfile.md
@@ -2,12 +2,12 @@
 
 `TextFile` is inherited from [`File`](file.md) with additional methods for working with text files.
 
-`TextFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.storage.from_storage), using `type="text"` param:
+`TextFile` is generated when a `DataChain` is created [from storage](../datachain.md#datachain.lib.dc.storage.read_storage), using `type="text"` param:
 
 ```python
 import datachain as dc
 
-chain = dc.from_storage("s3://bucket-name/", type="text")
+chain = dc.read_storage("s3://bucket-name/", type="text")
 ```
 
 ::: datachain.lib.file.TextFile

--- a/docs/references/data-types/videofile.md
+++ b/docs/references/data-types/videofile.md
@@ -2,12 +2,12 @@
 
 `VideoFile` extends [`File`](file.md) and provides additional methods for working with video files.
 
-`VideoFile` instances are created when a `DataChain` is initialized [from storage](../datachain.md#datachain.lib.dc.storage.from_storage) with the `type="video"` parameter:
+`VideoFile` instances are created when a `DataChain` is initialized [from storage](../datachain.md#datachain.lib.dc.storage.read_storage) with the `type="video"` parameter:
 
 ```python
 import datachain as dc
 
-chain = dc.from_storage("s3://bucket-name/", type="video")
+chain = dc.read_storage("s3://bucket-name/", type="video")
 ```
 
 There are additional models for working with video files:

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -29,7 +29,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.storage.read_storage
 
-::: datachain.lib.dc.values.from_values
+::: datachain.lib.dc.values.read_values
 
 ::: datachain.lib.dc.DataChain
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -27,7 +27,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.records.from_records
 
-::: datachain.lib.dc.storage.from_storage
+::: datachain.lib.dc.storage.read_storage
 
 ::: datachain.lib.dc.values.from_values
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -21,7 +21,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.listings.listings
 
-::: datachain.lib.dc.pandas.from_pandas
+::: datachain.lib.dc.pandas.read_pandas
 
 ::: datachain.lib.dc.parquet.from_parquet
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -25,7 +25,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.parquet.read_parquet
 
-::: datachain.lib.dc.records.from_records
+::: datachain.lib.dc.records.read_records
 
 ::: datachain.lib.dc.storage.read_storage
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -11,7 +11,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.csv.read_csv
 
-::: datachain.lib.dc.datasets.read_hf
+::: datachain.lib.dc.hf.read_hf
 
 ::: datachain.lib.dc.datasets.datasets
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -9,7 +9,7 @@ for examples of how to create a chain.
 
 ::: datachain.query.schema.Column
 
-::: datachain.lib.dc.csv.from_csv
+::: datachain.lib.dc.csv.read_csv
 
 ::: datachain.lib.dc.datasets.from_dataset
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -15,7 +15,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.datasets.datasets
 
-::: datachain.lib.dc.hf.from_hf
+::: datachain.lib.dc.hf.read_hf
 
 ::: datachain.lib.dc.json.from_json
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -11,7 +11,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.csv.read_csv
 
-::: datachain.lib.dc.hf.read_hf
+::: datachain.lib.dc.datasets.read_dataset
 
 ::: datachain.lib.dc.datasets.datasets
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -23,7 +23,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.pandas.read_pandas
 
-::: datachain.lib.dc.parquet.from_parquet
+::: datachain.lib.dc.parquet.read_parquet
 
 ::: datachain.lib.dc.records.from_records
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -11,7 +11,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.csv.read_csv
 
-::: datachain.lib.dc.datasets.from_dataset
+::: datachain.lib.dc.datasets.read_hf
 
 ::: datachain.lib.dc.datasets.datasets
 

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -17,7 +17,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.hf.read_hf
 
-::: datachain.lib.dc.json.from_json
+::: datachain.lib.dc.json.read_json
 
 ::: datachain.lib.dc.listings.listings
 

--- a/docs/references/remotes.md
+++ b/docs/references/remotes.md
@@ -1,17 +1,17 @@
 # Interacting with remote storage
 
-DataChain supports reading and writing data from different remote storages using methods like `dc.from_storage` and `dc.to_storage`. The supported storages includes: local file system, AWS S3 storage, Google Cloud Storage, Azure Blob Storage, Hugging Face and more.
+DataChain supports reading and writing data from different remote storages using methods like `dc.read_storage` and `dc.to_storage`. The supported storages includes: local file system, AWS S3 storage, Google Cloud Storage, Azure Blob Storage, Hugging Face and more.
 
 Example implementation for reading and writing data from/to different remote storages:
 
 ```python
 import datachain as dc
 
-dc = dc.from_storage("s3://bucket-name/path/to/data")
+dc = dc.read_storage("s3://bucket-name/path/to/data")
 dc.to_storage("gs://bucket-name/path/to/data")
 ```
 
-DataChain uses [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) to interact with different remote storages. You can pass the following fsspec-supported URIs to `from_storage` and `to_storage` methods.
+DataChain uses [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) to interact with different remote storages. You can pass the following fsspec-supported URIs to `read_storage` and `to_storage` methods.
 
 - Local file system: `file://path/to/data`
 - AWS S3 storage: `s3://bucket-name/path/to/data`
@@ -134,8 +134,9 @@ DataChain uses [s3fs](https://s3fs.readthedocs.io/en/latest/) to interact with A
 
 
 Example:
+
 ```python
-chain = dc.from_storage(
+chain = dc.read_storage(
     "s3://my-bucket/my-dir",
     client_config = {
 		"endpoint_url": "<minio-endpoint-url>",

--- a/examples/computer_vision/iptc_exif_xmp_lib.py
+++ b/examples/computer_vision/iptc_exif_xmp_lib.py
@@ -67,7 +67,7 @@ def image_description(file):
 
 if __name__ == "__main__":
     (
-        dc.from_storage(source, type="image")
+        dc.read_storage(source, type="image")
         .settings(parallel=-1)
         .filter(dc.C("file.path").glob("*.jpg"))
         .limit(5000)

--- a/examples/computer_vision/llava2_image_desc_lib.py
+++ b/examples/computer_vision/llava2_image_desc_lib.py
@@ -71,7 +71,7 @@ class LLaVADescribe(dc.Mapper):
 
 if __name__ == "__main__":
     (
-        dc.from_storage(source, type="image")
+        dc.read_storage(source, type="image")
         .filter(dc.C("file.path").glob("*/cat*.jpg"))
         .map(
             desc=LLaVADescribe(

--- a/examples/computer_vision/openimage-detect.py
+++ b/examples/computer_vision/openimage-detect.py
@@ -41,7 +41,7 @@ def openimage_detect(args):
 source = "gs://datachain-demo/openimages-v6-test-jsonpairs/"
 
 (
-    dc.from_storage(source)
+    dc.read_storage(source)
     .filter(dc.C("file.path").glob("*.jpg") | dc.C("file.path").glob("*.json"))
     .agg(
         openimage_detect,

--- a/examples/computer_vision/ultralytics-bbox.py
+++ b/examples/computer_vision/ultralytics-bbox.py
@@ -10,7 +10,7 @@ def process_bboxes(yolo: YOLO, file: dc.File) -> YoloBBoxes:
 
 
 (
-    dc.from_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/")
+    dc.read_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/")
     .filter(dc.C("file.path").glob("*.jpg"))
     .limit(20)
     .setup(yolo=lambda: YOLO("yolo11n.pt"))

--- a/examples/computer_vision/ultralytics-pose.py
+++ b/examples/computer_vision/ultralytics-pose.py
@@ -10,7 +10,7 @@ def process_poses(yolo: YOLO, file: dc.File) -> YoloPoses:
 
 
 (
-    dc.from_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/")
+    dc.read_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/")
     .filter(dc.C("file.path").glob("*.jpg"))
     .limit(20)
     .setup(yolo=lambda: YOLO("yolo11n-pose.pt"))

--- a/examples/computer_vision/ultralytics-segment.py
+++ b/examples/computer_vision/ultralytics-segment.py
@@ -10,7 +10,7 @@ def process_segments(yolo: YOLO, file: dc.File) -> YoloSegments:
 
 
 (
-    dc.from_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/")
+    dc.read_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/")
     .filter(dc.C("file.path").glob("*.jpg"))
     .limit(20)
     .setup(yolo=lambda: YOLO("yolo11n-seg.pt"))

--- a/examples/get_started/common_sql_functions.py
+++ b/examples/get_started/common_sql_functions.py
@@ -9,7 +9,7 @@ def num_chars_udf(file):
     return ([],)
 
 
-chain = dc.from_storage("gs://datachain-demo/dogs-and-cats/", anon=True)
+chain = dc.read_storage("gs://datachain-demo/dogs-and-cats/", anon=True)
 chain.map(num_chars_udf, params=["file"], output={"num_chars": list[str]}).select(
     "file.path", "num_chars"
 ).show(5)

--- a/examples/get_started/json-csv-reader.py
+++ b/examples/get_started/json-csv-reader.py
@@ -47,7 +47,7 @@ def main():
     uri = "gs://datachain-demo/coco2017/annotations_captions/"
 
     # Print JSON schema in Pydantic format from main COCO annotation
-    chain = dc.from_storage(uri, anon="True").filter(dc.C("file.path").glob("*.json"))
+    chain = dc.read_storage(uri, anon="True").filter(dc.C("file.path").glob("*.json"))
     file = next(chain.limit(1).collect("file"))
     print(gen_datamodel_code(file, jmespath="@", model_name="Coco"))
 

--- a/examples/get_started/json-csv-reader.py
+++ b/examples/get_started/json-csv-reader.py
@@ -31,7 +31,7 @@ ChatFeature = ModelStore.register(ChatDialog)
 def main():
     # Dynamic JSONl schema from 2 objects
     uri = "gs://datachain-demo/jsonl/object.jsonl"
-    jsonl_ds = dc.from_json(uri, format="jsonl", anon="True")
+    jsonl_ds = dc.read_json(uri, format="jsonl", anon="True")
     jsonl_ds.show()
 
     # Dynamic JSON schema from 200 OpenImage json-pairs with validation errors
@@ -39,7 +39,7 @@ def main():
     schema_uri = (
         "gs://datachain-demo/openimages-v6-test-jsonpairs/08392c290ecc9d2a.json"
     )
-    json_pairs_ds = dc.from_json(
+    json_pairs_ds = dc.read_json(
         uri, schema_from=schema_uri, jmespath="@", model_name="OpenImage", anon="True"
     )
     json_pairs_ds.show()
@@ -52,13 +52,13 @@ def main():
     print(gen_datamodel_code(file, jmespath="@", model_name="Coco"))
 
     # Static JSON schema test parsing 3/7 objects
-    static_json_ds = dc.from_json(
+    static_json_ds = dc.read_json(
         uri, jmespath="licenses", spec=LicenseFeature, nrows=3, anon="True"
     )
     static_json_ds.show()
 
     # Dynamic JSON schema test parsing 5K objects
-    dynamic_json_ds = dc.from_json(uri, jmespath="images", anon="True")
+    dynamic_json_ds = dc.read_json(uri, jmespath="images", anon="True")
     print(dynamic_json_ds.to_pandas())
 
     # Static CSV with header schema test parsing 3.5K objects

--- a/examples/get_started/json-csv-reader.py
+++ b/examples/get_started/json-csv-reader.py
@@ -63,13 +63,13 @@ def main():
 
     # Static CSV with header schema test parsing 3.5K objects
     uri = "gs://datachain-demo/chatbot-csv/"
-    static_csv_ds = dc.from_csv(uri, output=ChatDialog, object_name="chat", anon="True")
+    static_csv_ds = dc.read_csv(uri, output=ChatDialog, object_name="chat", anon="True")
     static_csv_ds.print_schema()
     static_csv_ds.show()
 
     # Dynamic CSV with header schema test parsing 3/3M objects
     uri = "gs://datachain-demo/laion-aesthetics-csv/laion_aesthetics_1024_33M_1.csv"
-    dynamic_csv_ds = dc.from_csv(uri, object_name="laion", nrows=3, anon="True")
+    dynamic_csv_ds = dc.read_csv(uri, object_name="laion", nrows=3, anon="True")
     dynamic_csv_ds.print_schema()
     dynamic_csv_ds.show()
 

--- a/examples/get_started/torch-loader.py
+++ b/examples/get_started/torch-loader.py
@@ -55,7 +55,7 @@ class CNN(nn.Module):
 
 if __name__ == "__main__":
     ds = (
-        dc.from_storage(STORAGE, type="image")
+        dc.read_storage(STORAGE, type="image")
         .settings(prefetch=25)
         .filter(dc.C("file.path").glob("*.jpg"))
         .map(

--- a/examples/get_started/udfs/parallel.py
+++ b/examples/get_started/udfs/parallel.py
@@ -30,7 +30,7 @@ def path_len_benchmark(path):
 
 
 # Run in chain
-dc.from_storage(
+dc.read_storage(
     "gs://datachain-demo/dogs-and-cats/",
 ).settings(parallel=-1).map(
     path_len_benchmark,

--- a/examples/get_started/udfs/simple.py
+++ b/examples/get_started/udfs/simple.py
@@ -10,7 +10,7 @@ def path_len(path):
 
 if __name__ == "__main__":
     # Run in chain
-    dc.from_storage(
+    dc.read_storage(
         uri="gs://datachain-demo/dogs-and-cats/",
     ).map(
         path_len,

--- a/examples/get_started/udfs/stateful.py
+++ b/examples/get_started/udfs/stateful.py
@@ -34,7 +34,7 @@ class ImageEncoder(dc.Mapper):
 if __name__ == "__main__":
     # Run in chain
     (
-        dc.from_storage("gs://datachain-demo/dogs-and-cats/", type="image")
+        dc.read_storage("gs://datachain-demo/dogs-and-cats/", type="image")
         .filter(dc.C("file.path").glob("*cat*.jpg"))
         .settings(parallel=2)
         .limit(5)

--- a/examples/llm_and_nlp/claude-query.py
+++ b/examples/llm_and_nlp/claude-query.py
@@ -39,7 +39,7 @@ class Rating(BaseModel):
 
 
 chain = (
-    dc.from_storage(DATA, type="text")
+    dc.read_storage(DATA, type="text")
     .filter(dc.Column("file.path").glob("*.txt"))
     .limit(5)
     .settings(parallel=4, cache=True)

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -48,7 +48,7 @@ def eval_dialog(
 # Save to HF as Parquet. Dataset can be previewed here:
 # https://huggingface.co/datasets/dvcorg/test-datachain-llm-eval/viewer
 (
-    dc.from_csv("hf://datasets/infinite-dataset-hub/MobilePlanAssistant/data.csv")
+    dc.read_csv("hf://datasets/infinite-dataset-hub/MobilePlanAssistant/data.csv")
     .settings(parallel=10)
     .setup(client=lambda: InferenceClient("meta-llama/Llama-3.1-70B-Instruct"))
     .map(response=eval_dialog)

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -58,7 +58,7 @@ def eval_dialog(
 # Read it back to filter and show.
 # It restores the Pydantic model from Parquet under the hood.
 (
-    dc.from_parquet(
+    dc.read_parquet(
         "hf://datasets/dvcorg/test-datachain-llm-eval/data.parquet", source=False
     )
     .filter(dc.C("response.result") == "Failure")

--- a/examples/multimodal/clip_inference.py
+++ b/examples/multimodal/clip_inference.py
@@ -9,8 +9,8 @@ source = "gs://datachain-demo/50k-laion-files/000000/00000000*"
 
 
 def create_dataset():
-    imgs = dc.from_storage(source, type="image").filter(dc.C("file.path").glob("*.jpg"))
-    captions = dc.from_storage(source, type="text").filter(
+    imgs = dc.read_storage(source, type="image").filter(dc.C("file.path").glob("*.jpg"))
+    captions = dc.read_storage(source, type="text").filter(
         dc.C("file.path").glob("*.txt")
     )
     return imgs.merge(

--- a/examples/multimodal/hf_pipeline.py
+++ b/examples/multimodal/hf_pipeline.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     print("** HuggingFace pipeline helper model zoo demo **")
     print("\nZero-shot object detection and classification:")
     (
-        dc.from_storage(
+        dc.read_storage(
             image_source,
             anon=True,
             type="image",
@@ -72,7 +72,7 @@ if __name__ == "__main__":
 
     print("\nNot-safe-for-work image detection:")
     (
-        dc.from_storage(
+        dc.read_storage(
             image_source,
             anon=True,
             type="image",
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     try:
         subprocess.run(["ffmpeg", "-L"], check=True)  # noqa: S603, S607
         (
-            dc.from_storage(
+            dc.read_storage(
                 audio_source,
                 anon=True,
                 type="binary",
@@ -118,7 +118,7 @@ if __name__ == "__main__":
 
     print("\nLong text summarization:")
     (
-        dc.from_storage(
+        dc.read_storage(
             text_source,
             anon=True,
             type="text",

--- a/examples/multimodal/openai_image_desc_lib.py
+++ b/examples/multimodal/openai_image_desc_lib.py
@@ -72,7 +72,7 @@ def describe_image(
 
 if __name__ == "__main__":
     (
-        dc.from_storage(
+        dc.read_storage(
             SOURCE,
             anon=True,
         )

--- a/examples/multimodal/wds.py
+++ b/examples/multimodal/wds.py
@@ -22,7 +22,7 @@ wds_images = (
 )
 
 wds_with_pq = (
-    dc.from_parquet(PARQUET_METADATA)
+    dc.read_parquet(PARQUET_METADATA)
     .settings(cache=True)
     .merge(wds_images, on="uid", right_on="laion.json.uid", inner=True)
 )

--- a/examples/multimodal/wds.py
+++ b/examples/multimodal/wds.py
@@ -16,7 +16,7 @@ NPZ_METADATA = os.getenv(
 )
 
 wds_images = (
-    dc.from_storage(IMAGE_TARS, type="image")
+    dc.read_storage(IMAGE_TARS, type="image")
     .settings(cache=True)
     .gen(laion=process_webdataset(spec=WDSLaion), params="file")
 )
@@ -27,7 +27,7 @@ wds_with_pq = (
     .merge(wds_images, on="uid", right_on="laion.json.uid", inner=True)
 )
 
-wds_npz = dc.from_storage(NPZ_METADATA).settings(cache=True).gen(emd=process_laion_meta)
+wds_npz = dc.read_storage(NPZ_METADATA).settings(cache=True).gen(emd=process_laion_meta)
 
 
 res = wds_npz.merge(

--- a/examples/multimodal/wds_filtered.py
+++ b/examples/multimodal/wds_filtered.py
@@ -9,7 +9,7 @@ try:
     wds = dc.from_dataset(name=name)
 except datachain.error.DatasetNotFoundError:
     wds = (
-        dc.from_storage("gs://datachain-demo/datacomp-small/shards")
+        dc.read_storage("gs://datachain-demo/datacomp-small/shards")
         .filter(dc.C("file.path").glob("*/00000000.tar"))
         .settings(cache=True)
         .gen(laion=process_webdataset(spec=WDSLaion), params="file")

--- a/examples/multimodal/wds_filtered.py
+++ b/examples/multimodal/wds_filtered.py
@@ -6,7 +6,7 @@ from datachain.lib.webdataset_laion import WDSLaion
 
 name = "wds"
 try:
-    wds = dc.from_dataset(name=name)
+    wds = dc.read_dataset(name=name)
 except datachain.error.DatasetNotFoundError:
     wds = (
         dc.read_storage("gs://datachain-demo/datacomp-small/shards")

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -6,7 +6,6 @@ from datachain.lib.dc import (
     Sys,
     datasets,
     from_dataset,
-    from_hf,
     from_json,
     from_pandas,
     from_parquet,
@@ -14,6 +13,7 @@ from datachain.lib.dc import (
     from_values,
     listings,
     read_csv,
+    read_hf,
     read_storage,
 )
 from datachain.lib.file import (
@@ -62,7 +62,6 @@ __all__ = [
     "VideoFrame",
     "datasets",
     "from_dataset",
-    "from_hf",
     "from_json",
     "from_pandas",
     "from_parquet",
@@ -73,5 +72,6 @@ __all__ = [
     "metrics",
     "param",
     "read_csv",
+    "read_hf",
     "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -12,9 +12,9 @@ from datachain.lib.dc import (
     from_pandas,
     from_parquet,
     from_records,
-    from_storage,
     from_values,
     listings,
+    read_storage,
 )
 from datachain.lib.file import (
     ArrowRow,
@@ -68,10 +68,10 @@ __all__ = [
     "from_pandas",
     "from_parquet",
     "from_records",
-    "from_storage",
     "from_values",
     "is_chain_type",
     "listings",
     "metrics",
     "param",
+    "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_parquet,
     from_records,
     from_values,
     listings,
@@ -14,6 +13,7 @@ from datachain.lib.dc import (
     read_hf,
     read_json,
     read_pandas,
+    read_parquet,
     read_storage,
 )
 from datachain.lib.file import (
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_parquet",
     "from_records",
     "from_values",
     "is_chain_type",
@@ -73,5 +72,6 @@ __all__ = [
     "read_hf",
     "read_json",
     "read_pandas",
+    "read_parquet",
     "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_pandas,
     from_parquet,
     from_records,
     from_values,
@@ -14,6 +13,7 @@ from datachain.lib.dc import (
     read_dataset,
     read_hf,
     read_json,
+    read_pandas,
     read_storage,
 )
 from datachain.lib.file import (
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_pandas",
     "from_parquet",
     "from_records",
     "from_values",
@@ -73,5 +72,6 @@ __all__ = [
     "read_dataset",
     "read_hf",
     "read_json",
+    "read_pandas",
     "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_csv,
     from_dataset,
     from_hf,
     from_json,
@@ -14,6 +13,7 @@ from datachain.lib.dc import (
     from_records,
     from_values,
     listings,
+    read_csv,
     read_storage,
 )
 from datachain.lib.file import (
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_csv",
     "from_dataset",
     "from_hf",
     "from_json",
@@ -73,5 +72,6 @@ __all__ = [
     "listings",
     "metrics",
     "param",
+    "read_csv",
     "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_json,
     from_pandas,
     from_parquet,
     from_records,
@@ -14,6 +13,7 @@ from datachain.lib.dc import (
     read_csv,
     read_dataset,
     read_hf,
+    read_json,
     read_storage,
 )
 from datachain.lib.file import (
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_json",
     "from_pandas",
     "from_parquet",
     "from_records",
@@ -73,5 +72,6 @@ __all__ = [
     "read_csv",
     "read_dataset",
     "read_hf",
+    "read_json",
     "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_records,
     from_values,
     listings,
     read_csv,
@@ -14,6 +13,7 @@ from datachain.lib.dc import (
     read_json,
     read_pandas,
     read_parquet,
+    read_records,
     read_storage,
 )
 from datachain.lib.file import (
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_records",
     "from_values",
     "is_chain_type",
     "listings",
@@ -73,5 +72,6 @@ __all__ = [
     "read_json",
     "read_pandas",
     "read_parquet",
+    "read_records",
     "read_storage",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_values,
     listings,
     read_csv,
     read_dataset,
@@ -15,6 +14,7 @@ from datachain.lib.dc import (
     read_parquet,
     read_records,
     read_storage,
+    read_values,
 )
 from datachain.lib.file import (
     ArrowRow,
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_values",
     "is_chain_type",
     "listings",
     "metrics",
@@ -74,4 +73,5 @@ __all__ = [
     "read_parquet",
     "read_records",
     "read_storage",
+    "read_values",
 ]

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -5,7 +5,6 @@ from datachain.lib.dc import (
     DataChain,
     Sys,
     datasets,
-    from_dataset,
     from_json,
     from_pandas,
     from_parquet,
@@ -13,6 +12,7 @@ from datachain.lib.dc import (
     from_values,
     listings,
     read_csv,
+    read_dataset,
     read_hf,
     read_storage,
 )
@@ -61,7 +61,6 @@ __all__ = [
     "VideoFragment",
     "VideoFrame",
     "datasets",
-    "from_dataset",
     "from_json",
     "from_pandas",
     "from_parquet",
@@ -72,6 +71,7 @@ __all__ = [
     "metrics",
     "param",
     "read_csv",
+    "read_dataset",
     "read_hf",
     "read_storage",
 ]

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -583,10 +583,10 @@ class Catalog:
         object_name="file",
         skip_indexing=False,
     ) -> tuple[Optional["Listing"], "Client", str]:
-        from datachain import from_storage
+        from datachain import read_storage
         from datachain.listing import Listing
 
-        from_storage(
+        read_storage(
             source, session=self.session, update=update, object_name=object_name
         ).exec()
 
@@ -994,14 +994,14 @@ class Catalog:
         if not sources:
             raise ValueError("Sources needs to be non empty list")
 
-        from datachain import from_dataset, from_storage
+        from datachain import from_dataset, read_storage
 
         chains = []
         for source in sources:
             if source.startswith(DATASET_PREFIX):
                 dc = from_dataset(source[len(DATASET_PREFIX) :], session=self.session)
             else:
-                dc = from_storage(source, session=self.session, recursive=recursive)
+                dc = read_storage(source, session=self.session, recursive=recursive)
 
             chains.append(dc)
 

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -994,12 +994,12 @@ class Catalog:
         if not sources:
             raise ValueError("Sources needs to be non empty list")
 
-        from datachain import from_dataset, read_storage
+        from datachain import read_dataset, read_storage
 
         chains = []
         for source in sources:
             if source.startswith(DATASET_PREFIX):
-                dc = from_dataset(source[len(DATASET_PREFIX) :], session=self.session)
+                dc = read_dataset(source[len(DATASET_PREFIX) :], session=self.session)
             else:
                 dc = read_storage(source, session=self.session, recursive=recursive)
 

--- a/src/datachain/cli/commands/show.py
+++ b/src/datachain/cli/commands/show.py
@@ -18,7 +18,7 @@ def show(
     schema: bool = False,
     include_hidden: bool = False,
 ) -> None:
-    from datachain import Session, from_dataset
+    from datachain import Session, read_dataset
     from datachain.query.dataset import DatasetQuery
     from datachain.utils import show_records
 
@@ -51,5 +51,5 @@ def show(
     if schema and dataset_version.feature_schema:
         print("\nSchema:")
         session = Session.get(catalog=catalog)
-        dc = from_dataset(name=name, version=version, session=session)
+        dc = read_dataset(name=name, version=version, session=session)
         dc.print_schema()

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -4,7 +4,7 @@ from .datasets import datasets, read_dataset
 from .hf import read_hf
 from .json import read_json
 from .listings import listings
-from .pandas import from_pandas
+from .pandas import read_pandas
 from .parquet import from_parquet
 from .records import from_records
 from .storage import read_storage
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_pandas",
     "from_parquet",
     "from_records",
     "from_values",
@@ -28,5 +27,6 @@ __all__ = [
     "read_dataset",
     "read_hf",
     "read_json",
+    "read_pandas",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -6,7 +6,7 @@ from .json import read_json
 from .listings import listings
 from .pandas import read_pandas
 from .parquet import read_parquet
-from .records import from_records
+from .records import read_records
 from .storage import read_storage
 from .utils import DatasetMergeError, DatasetPrepareError, Sys
 from .values import from_values
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_records",
     "from_values",
     "listings",
     "read_csv",
@@ -28,5 +27,6 @@ __all__ = [
     "read_json",
     "read_pandas",
     "read_parquet",
+    "read_records",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -5,7 +5,7 @@ from .hf import read_hf
 from .json import read_json
 from .listings import listings
 from .pandas import read_pandas
-from .parquet import from_parquet
+from .parquet import read_parquet
 from .records import from_records
 from .storage import read_storage
 from .utils import DatasetMergeError, DatasetPrepareError, Sys
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_parquet",
     "from_records",
     "from_values",
     "listings",
@@ -28,5 +27,6 @@ __all__ = [
     "read_hf",
     "read_json",
     "read_pandas",
+    "read_parquet",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -9,7 +9,7 @@ from .parquet import read_parquet
 from .records import read_records
 from .storage import read_storage
 from .utils import DatasetMergeError, DatasetPrepareError, Sys
-from .values import from_values
+from .values import read_values
 
 __all__ = [
     "C",
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_values",
     "listings",
     "read_csv",
     "read_dataset",
@@ -29,4 +28,5 @@ __all__ = [
     "read_parquet",
     "read_records",
     "read_storage",
+    "read_values",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -2,7 +2,7 @@ from .csv import read_csv
 from .datachain import C, Column, DataChain
 from .datasets import datasets, read_dataset
 from .hf import read_hf
-from .json import from_json
+from .json import read_json
 from .listings import listings
 from .pandas import from_pandas
 from .parquet import from_parquet
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_json",
     "from_pandas",
     "from_parquet",
     "from_records",
@@ -28,5 +27,6 @@ __all__ = [
     "read_csv",
     "read_dataset",
     "read_hf",
+    "read_json",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -1,6 +1,6 @@
 from .csv import read_csv
 from .datachain import C, Column, DataChain
-from .datasets import datasets, from_dataset
+from .datasets import datasets, read_dataset
 from .hf import read_hf
 from .json import from_json
 from .listings import listings
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_dataset",
     "from_json",
     "from_pandas",
     "from_parquet",
@@ -27,6 +26,7 @@ __all__ = [
     "from_values",
     "listings",
     "read_csv",
+    "read_dataset",
     "read_hf",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -1,4 +1,4 @@
-from .csv import from_csv
+from .csv import read_csv
 from .datachain import C, Column, DataChain
 from .datasets import datasets, from_dataset
 from .hf import from_hf
@@ -19,7 +19,6 @@ __all__ = [
     "DatasetPrepareError",
     "Sys",
     "datasets",
-    "from_csv",
     "from_dataset",
     "from_hf",
     "from_json",
@@ -28,5 +27,6 @@ __all__ = [
     "from_records",
     "from_values",
     "listings",
+    "read_csv",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -7,7 +7,7 @@ from .listings import listings
 from .pandas import from_pandas
 from .parquet import from_parquet
 from .records import from_records
-from .storage import from_storage
+from .storage import read_storage
 from .utils import DatasetMergeError, DatasetPrepareError, Sys
 from .values import from_values
 
@@ -26,7 +26,7 @@ __all__ = [
     "from_pandas",
     "from_parquet",
     "from_records",
-    "from_storage",
     "from_values",
     "listings",
+    "read_storage",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -1,7 +1,7 @@
 from .csv import read_csv
 from .datachain import C, Column, DataChain
 from .datasets import datasets, from_dataset
-from .hf import from_hf
+from .hf import read_hf
 from .json import from_json
 from .listings import listings
 from .pandas import from_pandas
@@ -20,7 +20,6 @@ __all__ = [
     "Sys",
     "datasets",
     "from_dataset",
-    "from_hf",
     "from_json",
     "from_pandas",
     "from_parquet",
@@ -28,5 +27,6 @@ __all__ = [
     "from_values",
     "listings",
     "read_csv",
+    "read_hf",
     "read_storage",
 ]

--- a/src/datachain/lib/dc/csv.py
+++ b/src/datachain/lib/dc/csv.py
@@ -72,7 +72,7 @@ def from_csv(
     from pyarrow.dataset import CsvFileFormat
     from pyarrow.lib import type_for_alias
 
-    from .storage import from_storage
+    from .storage import read_storage
 
     parse_options = parse_options or {}
     if "delimiter" not in parse_options:
@@ -88,7 +88,7 @@ def from_csv(
     else:
         column_types = {}
 
-    chain = from_storage(path, session=session, settings=settings, **kwargs)
+    chain = read_storage(path, session=session, settings=settings, **kwargs)
 
     column_names = None
     if not header:

--- a/src/datachain/lib/dc/csv.py
+++ b/src/datachain/lib/dc/csv.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .datachain import DataChain
 
 
-def from_csv(
+def read_csv(
     path,
     delimiter: Optional[str] = None,
     header: bool = True,
@@ -58,13 +58,13 @@ def from_csv(
         Reading a csv file:
         ```py
         import datachain as dc
-        chain = dc.from_csv("s3://mybucket/file.csv")
+        chain = dc.read_csv("s3://mybucket/file.csv")
         ```
 
         Reading csv files from a directory as a combined dataset:
         ```py
         import datachain as dc
-        chain = dc.from_csv("s3://mybucket/dir")
+        chain = dc.read_csv("s3://mybucket/dir")
         ```
     """
     from pandas.io.parsers.readers import STR_NA_VALUES

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -97,7 +97,7 @@ class DataChain:
 
         `from_json("file.json")` - generating from json.
 
-        `from_csv("file.csv")` - generating from csv.
+        `read_csv("file.csv")` - generating from csv.
 
         `from_parquet("file.parquet")` - generating from parquet.
 
@@ -1680,15 +1680,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .csv import from_csv
+        from .csv import read_csv
 
         warnings.warn(
-            "Class method `from_csv` is deprecated. "
-            "Use `from_csv` function instead from top_module.",
+            "Class method `read_csv` is deprecated. "
+            "Use `read_csv` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_csv(*args, **kwargs)
+        return read_csv(*args, **kwargs)
 
     @classmethod
     def from_parquet(

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -318,7 +318,7 @@ class DataChain:
         from .storage import read_storage
 
         warnings.warn(
-            "Class method `read_storage` is deprecated. "
+            "Class method `from_storage` is deprecated. "
             "Use `read_storage` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -330,7 +330,7 @@ class DataChain:
         from .datasets import read_dataset
 
         warnings.warn(
-            "Class method `read_dataset` is deprecated. "
+            "Class method `from_dataset` is deprecated. "
             "Use `read_dataset` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -346,7 +346,7 @@ class DataChain:
         from .json import read_json
 
         warnings.warn(
-            "Class method `read_json` is deprecated. "
+            "Class method `from_json` is deprecated. "
             "Use `read_json` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -1469,7 +1469,7 @@ class DataChain:
         from .values import read_values
 
         warnings.warn(
-            "Class method `read_values` is deprecated. "
+            "Class method `from_values` is deprecated. "
             "Use `read_values` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -1485,7 +1485,7 @@ class DataChain:
         from .pandas import read_pandas
 
         warnings.warn(
-            "Class method `read_pandas` is deprecated. "
+            "Class method `from_pandas` is deprecated. "
             "Use `read_pandas` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -1578,7 +1578,7 @@ class DataChain:
         from .hf import read_hf
 
         warnings.warn(
-            "Class method `read_hf` is deprecated. "
+            "Class method `from_hf` is deprecated. "
             "Use `read_hf` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -1683,7 +1683,7 @@ class DataChain:
         from .csv import read_csv
 
         warnings.warn(
-            "Class method `read_csv` is deprecated. "
+            "Class method `from_csv` is deprecated. "
             "Use `read_csv` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -1699,7 +1699,7 @@ class DataChain:
         from .parquet import read_parquet
 
         warnings.warn(
-            "Class method `read_parquet` is deprecated. "
+            "Class method `from_parquet` is deprecated. "
             "Use `read_parquet` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
@@ -1933,7 +1933,7 @@ class DataChain:
         from .records import read_records
 
         warnings.warn(
-            "Class method `read_records` is deprecated. "
+            "Class method `from_records` is deprecated. "
             "Use `read_records` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1930,15 +1930,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .records import from_records
+        from .records import read_records
 
         warnings.warn(
-            "Class method `from_records` is deprecated. "
-            "Use `from_records` function instead from top_module.",
+            "Class method `read_records` is deprecated. "
+            "Use `read_records` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_records(*args, **kwargs)
+        return read_records(*args, **kwargs)
 
     def sum(self, fr: DataType):  # type: ignore[override]
         """Compute the sum of a column."""

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -91,7 +91,7 @@ class DataChain:
 
         `read_dataset("name")` - reading from a dataset.
 
-        `from_values(fib=[1, 2, 3, 5, 8])` - generating from values.
+        `read_values(fib=[1, 2, 3, 5, 8])` - generating from values.
 
         `read_pandas(pd.DataFrame(...))` - generating from pandas.
 
@@ -1466,15 +1466,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .values import from_values
+        from .values import read_values
 
         warnings.warn(
-            "Class method `from_values` is deprecated. "
-            "Use `from_values` function instead from top_module.",
+            "Class method `read_values` is deprecated. "
+            "Use `read_values` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_values(*args, **kwargs)
+        return read_values(*args, **kwargs)
 
     @classmethod
     def from_pandas(

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -99,7 +99,7 @@ class DataChain:
 
         `read_csv("file.csv")` - generating from csv.
 
-        `from_parquet("file.parquet")` - generating from parquet.
+        `read_parquet("file.parquet")` - generating from parquet.
 
     Example:
         ```py
@@ -1696,15 +1696,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .parquet import from_parquet
+        from .parquet import read_parquet
 
         warnings.warn(
-            "Class method `from_parquet` is deprecated. "
-            "Use `from_parquet` function instead from top_module.",
+            "Class method `read_parquet` is deprecated. "
+            "Use `read_parquet` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_parquet(*args, **kwargs)
+        return read_parquet(*args, **kwargs)
 
     def to_parquet(
         self,

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -93,7 +93,7 @@ class DataChain:
 
         `from_values(fib=[1, 2, 3, 5, 8])` - generating from values.
 
-        `from_pandas(pd.DataFrame(...))` - generating from pandas.
+        `read_pandas(pd.DataFrame(...))` - generating from pandas.
 
         `read_json("file.json")` - generating from json.
 
@@ -1482,15 +1482,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .pandas import from_pandas
+        from .pandas import read_pandas
 
         warnings.warn(
-            "Class method `from_pandas` is deprecated. "
-            "Use `from_pandas` function instead from top_module.",
+            "Class method `read_pandas` is deprecated. "
+            "Use `read_pandas` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_pandas(*args, **kwargs)
+        return read_pandas(*args, **kwargs)
 
     def to_pandas(self, flatten=False, include_hidden=True) -> "pd.DataFrame":
         """Return a pandas DataFrame from the chain.

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -84,7 +84,7 @@ class DataChain:
     underlyind library `Pydantic`.
 
     See Also:
-        `from_storage("s3://my-bucket/my-dir/")` - reading unstructured
+        `read_storage("s3://my-bucket/my-dir/")` - reading unstructured
             data files from storages such as S3, gs or Azure ADLS.
 
         `DataChain.save("name")` - saving to a dataset.
@@ -118,7 +118,7 @@ class DataChain:
         api_key = os.environ["MISTRAL_API_KEY"]
 
         chain = (
-            dc.from_storage("gs://datachain-demo/chatbot-KiT/")
+            dc.read_storage("gs://datachain-demo/chatbot-KiT/")
             .limit(5)
             .settings(cache=True, parallel=5)
             .map(
@@ -315,15 +315,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .storage import from_storage
+        from .storage import read_storage
 
         warnings.warn(
-            "Class method `from_storage` is deprecated. "
-            "Use `from_storage` function instead from top_module.",
+            "Class method `read_storage` is deprecated. "
+            "Use `read_storage` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_storage(*args, **kwargs)
+        return read_storage(*args, **kwargs)
 
     @classmethod
     def from_dataset(cls, *args, **kwargs) -> "DataChain":
@@ -487,7 +487,7 @@ class DataChain:
                 )
 
             chain = (
-                dc.from_storage("s3://my-bucket")
+                dc.read_storage("s3://my-bucket")
                 .apply(parse_stem)
                 .filter(C("stem").glob("*cat*"))
             )
@@ -1610,7 +1610,7 @@ class DataChain:
             Reading a json lines file:
             ```py
             import datachain as dc
-            chain = dc.from_storage("s3://mybucket/file.jsonl")
+            chain = dc.read_storage("s3://mybucket/file.jsonl")
             chain = chain.parse_tabular(format="json")
             ```
 
@@ -1618,7 +1618,7 @@ class DataChain:
             ```py
             import datachain as dc
 
-            chain = dc.from_storage("s3://mybucket")
+            chain = dc.read_storage("s3://mybucket")
             chain = chain.filter(dc.C("file.name").glob("*.jsonl"))
             chain = chain.parse_tabular(format="json")
             ```
@@ -1969,7 +1969,7 @@ class DataChain:
             import datachain as dc
 
             (
-                dc.from_storage(DATA, type="text")
+                dc.read_storage(DATA, type="text")
                 .settings(parallel=4, cache=True)
                 .setup(client=lambda: anthropic.Anthropic(api_key=API_KEY))
                 .map(
@@ -2021,7 +2021,7 @@ class DataChain:
             ```py
             import datachain as dc
 
-            ds = dc.from_storage("s3://mybucket")
+            ds = dc.read_storage("s3://mybucket")
             ds.to_storage("gs://mybucket", placement="filename")
             ```
         """
@@ -2139,7 +2139,7 @@ class DataChain:
             ```py
             import datachain as dc
 
-            chain = dc.from_storage(...)
+            chain = dc.read_storage(...)
             chunk_1 = query._chunk(0, 2)
             chunk_2 = query._chunk(1, 2)
             ```

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1575,15 +1575,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .hf import from_hf
+        from .hf import read_hf
 
         warnings.warn(
-            "Class method `from_hf` is deprecated. "
-            "Use `from_hf` function instead from top_module.",
+            "Class method `read_hf` is deprecated. "
+            "Use `read_hf` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_hf(*args, **kwargs)
+        return read_hf(*args, **kwargs)
 
     def parse_tabular(
         self,

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -89,7 +89,7 @@ class DataChain:
 
         `DataChain.save("name")` - saving to a dataset.
 
-        `from_dataset("name")` - reading from a dataset.
+        `read_dataset("name")` - reading from a dataset.
 
         `from_values(fib=[1, 2, 3, 5, 8])` - generating from values.
 
@@ -327,15 +327,15 @@ class DataChain:
 
     @classmethod
     def from_dataset(cls, *args, **kwargs) -> "DataChain":
-        from .datasets import from_dataset
+        from .datasets import read_dataset
 
         warnings.warn(
-            "Class method `from_dataset` is deprecated. "
-            "Use `from_dataset` function instead from top_module.",
+            "Class method `read_dataset` is deprecated. "
+            "Use `read_dataset` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_dataset(*args, **kwargs)
+        return read_dataset(*args, **kwargs)
 
     @classmethod
     def from_json(
@@ -727,7 +727,7 @@ class DataChain:
 
         Note:
             Order is not guaranteed when steps are added after an `order_by` statement.
-            I.e. when using `from_dataset` an `order_by` statement should be used if
+            I.e. when using `read_dataset` an `order_by` statement should be used if
             the order of the records in the chain is important.
             Using `order_by` directly before `limit`, `collect` and `collect_flatten`
             will give expected results.

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -95,7 +95,7 @@ class DataChain:
 
         `from_pandas(pd.DataFrame(...))` - generating from pandas.
 
-        `from_json("file.json")` - generating from json.
+        `read_json("file.json")` - generating from json.
 
         `read_csv("file.csv")` - generating from csv.
 
@@ -343,15 +343,15 @@ class DataChain:
         *args,
         **kwargs,
     ) -> "DataChain":
-        from .json import from_json
+        from .json import read_json
 
         warnings.warn(
-            "Class method `from_json` is deprecated. "
-            "Use `from_json` function instead from top_module.",
+            "Class method `read_json` is deprecated. "
+            "Use `read_json` function instead from top_module.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return from_json(*args, **kwargs)
+        return read_json(*args, **kwargs)
 
     def explode(
         self,

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -13,7 +13,7 @@ from datachain.query import Session
 from datachain.query.dataset import DatasetQuery
 
 from .utils import Sys
-from .values import from_values
+from .values import read_values
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
@@ -140,7 +140,7 @@ def datasets(
         )
     ]
 
-    return from_values(
+    return read_values(
         session=session,
         settings=settings,
         in_memory=in_memory,

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_dataset(
+def read_dataset(
     name: str,
     version: Optional[int] = None,
     session: Optional[Session] = None,
@@ -44,15 +44,15 @@ def from_dataset(
     Example:
         ```py
         import datachain as dc
-        chain = dc.from_dataset("my_cats")
+        chain = dc.read_dataset("my_cats")
         ```
 
         ```py
-        chain = dc.from_dataset("my_cats", fallback_to_studio=False)
+        chain = dc.read_dataset("my_cats", fallback_to_studio=False)
         ```
 
         ```py
-        chain = dc.from_dataset("my_cats", version=1)
+        chain = dc.read_dataset("my_cats", version=1)
         ```
 
         ```py
@@ -64,7 +64,7 @@ def from_dataset(
             "min_task_size": 1000,
             "prefetch": 10,
         }
-        chain = dc.from_dataset(
+        chain = dc.read_dataset(
             name="my_cats",
             version=1,
             session=session,

--- a/src/datachain/lib/dc/hf.py
+++ b/src/datachain/lib/dc/hf.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_hf(
+def read_hf(
     dataset: Union[str, "HFDatasetType"],
     *args,
     session: Optional[Session] = None,
@@ -42,7 +42,7 @@ def from_hf(
         Load from Hugging Face Hub:
         ```py
         import datachain as dc
-        chain = dc.from_hf("beans", split="train")
+        chain = dc.read_hf("beans", split="train")
         ```
 
         Generate chain from loaded dataset:
@@ -50,7 +50,7 @@ def from_hf(
         from datasets import load_dataset
         ds = load_dataset("beans", split="train")
         import datachain as dc
-        chain = dc.from_hf(ds)
+        chain = dc.read_hf(ds)
         ```
     """
     from datachain.lib.hf import HFGenerator, get_output_schema, stream_splits

--- a/src/datachain/lib/dc/hf.py
+++ b/src/datachain/lib/dc/hf.py
@@ -55,7 +55,7 @@ def read_hf(
     """
     from datachain.lib.hf import HFGenerator, get_output_schema, stream_splits
 
-    from .values import from_values
+    from .values import read_values
 
     output: dict[str, DataType] = {}
     ds_dict = stream_splits(dataset, *args, **kwargs)
@@ -69,5 +69,5 @@ def read_hf(
     if object_name:
         output = {object_name: model}
 
-    chain = from_values(split=list(ds_dict.keys()), session=session, settings=settings)
+    chain = read_values(split=list(ds_dict.keys()), session=session, settings=settings)
     return chain.gen(HFGenerator(dataset, model, *args, **kwargs), output=output)

--- a/src/datachain/lib/dc/json.py
+++ b/src/datachain/lib/dc/json.py
@@ -61,7 +61,7 @@ def from_json(
         chain = dc.from_json("gs://json_ds", schema_from="gs://json/my.json")
         ```
     """
-    from .storage import from_storage
+    from .storage import read_storage
 
     if schema_from == "auto":
         schema_from = os.fspath(path)
@@ -74,7 +74,7 @@ def from_json(
         object_name = jmespath_to_name(jmespath)
     if not object_name:
         object_name = format
-    chain = from_storage(uri=path, type=type, **kwargs)
+    chain = read_storage(uri=path, type=type, **kwargs)
     signal_dict = {
         object_name: read_meta(
             schema_from=schema_from,

--- a/src/datachain/lib/dc/json.py
+++ b/src/datachain/lib/dc/json.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_json(
+def read_json(
     path: Union[str, os.PathLike[str]],
     type: FileType = "text",
     spec: Optional[DataType] = None,
@@ -52,13 +52,13 @@ def from_json(
         infer JSON schema from data, reduce using JMESPATH
         ```py
         import datachain as dc
-        chain = dc.from_json("gs://json", jmespath="key1.key2")
+        chain = dc.read_json("gs://json", jmespath="key1.key2")
         ```
 
         infer JSON schema from a particular path
         ```py
         import datachain as dc
-        chain = dc.from_json("gs://json_ds", schema_from="gs://json/my.json")
+        chain = dc.read_json("gs://json_ds", schema_from="gs://json/my.json")
         ```
     """
     from .storage import read_storage

--- a/src/datachain/lib/dc/listings.py
+++ b/src/datachain/lib/dc/listings.py
@@ -6,7 +6,7 @@ from typing import (
 from datachain.lib.listing_info import ListingInfo
 from datachain.query import Session
 
-from .values import from_values
+from .values import read_values
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
@@ -35,7 +35,7 @@ def listings(
     session = Session.get(session, in_memory=in_memory)
     catalog = kwargs.get("catalog") or session.catalog
 
-    return from_values(
+    return read_values(
         session=session,
         in_memory=in_memory,
         output={object_name: ListingInfo},

--- a/src/datachain/lib/dc/pandas.py
+++ b/src/datachain/lib/dc/pandas.py
@@ -5,7 +5,7 @@ from typing import (
 
 from datachain.query import Session
 
-from .values import from_values
+from .values import read_values
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -46,7 +46,7 @@ def read_pandas(  # type: ignore[override]
                 f"import from pandas error - '{column}' cannot be a column name",
             )
 
-    return from_values(
+    return read_values(
         name,
         session,
         settings=settings,

--- a/src/datachain/lib/dc/pandas.py
+++ b/src/datachain/lib/dc/pandas.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_pandas(  # type: ignore[override]
+def read_pandas(  # type: ignore[override]
     df: "pd.DataFrame",
     name: str = "",
     session: Optional[Session] = None,
@@ -32,7 +32,7 @@ def from_pandas(  # type: ignore[override]
         import datachain as dc
 
         df = pd.DataFrame({"fib": [1, 2, 3, 5, 8]})
-        dc.from_pandas(df)
+        dc.read_pandas(df)
         ```
     """
     from .utils import DatasetPrepareError

--- a/src/datachain/lib/dc/parquet.py
+++ b/src/datachain/lib/dc/parquet.py
@@ -52,9 +52,9 @@ def from_parquet(
         dc.from_parquet("s3://mybucket/dir")
         ```
     """
-    from .storage import from_storage
+    from .storage import read_storage
 
-    chain = from_storage(path, session=session, settings=settings, **kwargs)
+    chain = read_storage(path, session=session, settings=settings, **kwargs)
     return chain.parse_tabular(
         output=output,
         object_name=object_name,

--- a/src/datachain/lib/dc/parquet.py
+++ b/src/datachain/lib/dc/parquet.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_parquet(
+def read_parquet(
     path,
     partitioning: Any = "hive",
     output: Optional[dict[str, DataType]] = None,
@@ -43,13 +43,13 @@ def from_parquet(
         Reading a single file:
         ```py
         import datachain as dc
-        dc.from_parquet("s3://mybucket/file.parquet")
+        dc.read_parquet("s3://mybucket/file.parquet")
         ```
 
         Reading a partitioned dataset from a directory:
         ```py
         import datachain as dc
-        dc.from_parquet("s3://mybucket/dir")
+        dc.read_parquet("s3://mybucket/dir")
         ```
     """
     from .storage import read_storage

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_records(
+def read_records(
     to_insert: Optional[Union[dict, list[dict]]],
     session: Optional[Session] = None,
     settings: Optional[dict] = None,
@@ -40,7 +40,7 @@ def from_records(
     Example:
         ```py
         import datachain as dc
-        single_record = dc.from_records(dc.DEFAULT_FILE_RECORD)
+        single_record = dc.read_records(dc.DEFAULT_FILE_RECORD)
         ```
     """
     from .datasets import read_dataset

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -43,7 +43,7 @@ def from_records(
         single_record = dc.from_records(dc.DEFAULT_FILE_RECORD)
         ```
     """
-    from .datasets import from_dataset
+    from .datasets import read_dataset
 
     session = Session.get(session, in_memory=in_memory)
     catalog = session.catalog
@@ -87,4 +87,4 @@ def from_records(
     insert_q = dr.get_table().insert()
     for record in to_insert:
         db.execute(insert_q.values(**record))
-    return from_dataset(name=dsr.name, session=session, settings=settings)
+    return read_dataset(name=dsr.name, session=session, settings=settings)

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -89,7 +89,7 @@ def read_storage(
     """
     from .datachain import DataChain
     from .datasets import read_dataset
-    from .records import from_records
+    from .records import read_records
     from .values import from_values
 
     file_type = get_file_type(type)
@@ -130,7 +130,7 @@ def read_storage(
             def lst_fn(ds_name, lst_uri):
                 # disable prefetch for listing, as it pre-downloads all files
                 (
-                    from_records(
+                    read_records(
                         DataChain.DEFAULT_FILE_RECORD,
                         session=session,
                         settings=settings,

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -90,7 +90,7 @@ def read_storage(
     from .datachain import DataChain
     from .datasets import read_dataset
     from .records import read_records
-    from .values import from_values
+    from .values import read_values
 
     file_type = get_file_type(type)
 
@@ -154,7 +154,7 @@ def read_storage(
         listed_ds_name.add(list_ds_name)
 
     if file_values:
-        file_chain = from_values(
+        file_chain = read_values(
             session=session,
             settings=settings,
             in_memory=in_memory,

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -88,7 +88,7 @@ def read_storage(
         avoiding redundant updates for URIs pointing to the same storage location.
     """
     from .datachain import DataChain
-    from .datasets import from_dataset
+    from .datasets import read_dataset
     from .records import from_records
     from .values import from_values
 
@@ -122,7 +122,7 @@ def read_storage(
             )
             continue
 
-        dc = from_dataset(list_ds_name, session=session, settings=settings)
+        dc = read_dataset(list_ds_name, session=session, settings=settings)
         dc.signals_schema = dc.signals_schema.mutate({f"{object_name}": file_type})
 
         if update or not list_ds_exists:

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from .datachain import DataChain
 
 
-def from_storage(
+def read_storage(
     uri: Union[str, os.PathLike[str], list[str], list[os.PathLike[str]]],
     *,
     type: FileType = "binary",
@@ -55,12 +55,12 @@ def from_storage(
         Simple call from s3:
         ```python
         import datachain as dc
-        chain = dc.from_storage("s3://my-bucket/my-dir")
+        chain = dc.read_storage("s3://my-bucket/my-dir")
         ```
 
         Multiple URIs:
         ```python
-        chain = dc.from_storage([
+        chain = dc.read_storage([
             "s3://bucket1/dir1",
             "s3://bucket2/dir2"
         ])
@@ -68,7 +68,7 @@ def from_storage(
 
         With AWS S3-compatible storage:
         ```python
-        chain = dc.from_storage(
+        chain = dc.read_storage(
             "s3://my-bucket/my-dir",
             client_config = {"aws_endpoint_url": "<minio-endpoint-url>"}
         )
@@ -77,7 +77,7 @@ def from_storage(
         Pass existing session
         ```py
         session = Session.get()
-        chain = dc.from_storage([
+        chain = dc.read_storage([
             "path/to/dir1",
             "path/to/dir2"
         ], session=session, recursive=True)

--- a/src/datachain/lib/dc/values.py
+++ b/src/datachain/lib/dc/values.py
@@ -6,7 +6,7 @@ from typing import (
 
 from datachain.lib.convert.values_to_tuples import values_to_tuples
 from datachain.lib.data_model import dict_to_data_model
-from datachain.lib.dc.records import from_records
+from datachain.lib.dc.records import read_records
 from datachain.lib.dc.utils import OutputType
 from datachain.query import Session
 
@@ -42,7 +42,7 @@ def from_values(
     def _func_fr() -> Iterator[tuple_type]:  # type: ignore[valid-type]
         yield from tuples
 
-    chain = from_records(
+    chain = read_records(
         DataChain.DEFAULT_FILE_RECORD,
         session=session,
         settings=settings,

--- a/src/datachain/lib/dc/values.py
+++ b/src/datachain/lib/dc/values.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-def from_values(
+def read_values(
     ds_name: str = "",
     session: Optional[Session] = None,
     settings: Optional[dict] = None,
@@ -32,7 +32,7 @@ def from_values(
     Example:
         ```py
         import datachain as dc
-        dc.from_values(fib=[1, 2, 3, 5, 8])
+        dc.read_values(fib=[1, 2, 3, 5, 8])
         ```
     """
     from .datachain import DataChain

--- a/src/datachain/lib/meta_formats.py
+++ b/src/datachain/lib/meta_formats.py
@@ -103,10 +103,10 @@ def read_meta(  # noqa: C901
     model_name=None,
     nrows=None,
 ) -> Callable:
-    from datachain import from_storage
+    from datachain import read_storage
 
     if schema_from:
-        file = next(from_storage(schema_from, type="text").limit(1).collect("file"))
+        file = next(read_storage(schema_from, type="text").limit(1).collect("file"))
         model_code = gen_datamodel_code(
             file, format=format, jmespath=jmespath, model_name=model_name
         )

--- a/src/datachain/lib/pytorch.py
+++ b/src/datachain/lib/pytorch.py
@@ -14,7 +14,7 @@ from torchvision.transforms import v2
 from datachain import Session
 from datachain.cache import get_temp_cache
 from datachain.catalog import Catalog, get_catalog
-from datachain.lib.dc.datasets import from_dataset
+from datachain.lib.dc.datasets import read_dataset
 from datachain.lib.settings import Settings
 from datachain.lib.text import convert_text
 from datachain.progress import CombinedDownloadCallback
@@ -122,7 +122,7 @@ class PytorchDataset(IterableDataset):
     ) -> Generator[tuple[Any, ...], None, None]:
         catalog = self._get_catalog()
         session = Session("PyTorch", catalog=catalog)
-        ds = from_dataset(
+        ds = read_dataset(
             name=self.name, version=self.version, session=session
         ).settings(cache=self.cache, prefetch=self.prefetch)
         ds = ds.remove_file_signals()

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -145,7 +145,7 @@ class UDFBase(AbstractUDF):
                 return emb[0].tolist()
 
         (
-            dc.from_storage(
+            dc.read_storage(
                 "gs://datachain-demo/fashion-product-images/images", type="image"
             )
             .limit(5)

--- a/src/datachain/toolkit/split.py
+++ b/src/datachain/toolkit/split.py
@@ -41,7 +41,7 @@ def train_test_split(
         from datachain.toolkit import train_test_split
 
         # Load a DataChain from a storage source (e.g., S3 bucket)
-        dc = dc.from_storage("s3://bucket/dir/")
+        dc = dc.read_storage("s3://bucket/dir/")
 
         # Perform a 70/30 train-test split
         train, test = train_test_split(dc, [0.7, 0.3])

--- a/tests/benchmarks/test_datachain.py
+++ b/tests/benchmarks/test_datachain.py
@@ -4,7 +4,7 @@ from datachain.lib.webdataset_laion import process_laion_meta
 
 def test_datachain(tmp_dir, test_session, datasets, benchmark):
     def run_script(uri, **kwargs):
-        dc.from_storage(uri, session=test_session, **kwargs).gen(
+        dc.read_storage(uri, session=test_session, **kwargs).gen(
             emd=process_laion_meta
         ).settings(
             # Disable `prefetch` for `map()` because `process_laion_meta` repeatedly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -712,7 +712,7 @@ def studio_datasets(requests_mock):
 def not_random_ds(test_session):
     # `sys__rand` column is carefully crafted to ensure that `train_test_split` func
     # will always return columns in the `sys__id` order if no seed is provided.
-    return dc.from_records(
+    return dc.read_records(
         [
             {"sys__id": 1, "sys__rand": 8025184816406567794, "fib": 0},
             {"sys__id": 2, "sys__rand": 8264763963075908010, "fib": 1},
@@ -732,7 +732,7 @@ def not_random_ds(test_session):
 
 @pytest.fixture
 def pseudo_random_ds(test_session):
-    return dc.from_records(
+    return dc.read_records(
         [
             {"sys__id": 1, "sys__rand": 2406827533654413759, "fib": 0},
             {"sys__id": 2, "sys__rand": 743035223448130834, "fib": 1},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -540,7 +540,7 @@ def cloud_test_catalog_tmpfile(
 @pytest.fixture
 def listed_bucket(cloud_test_catalog):
     ctc = cloud_test_catalog
-    dc.from_storage(ctc.src_uri, session=ctc.session).exec()
+    dc.read_storage(ctc.src_uri, session=ctc.session).exec()
 
 
 @pytest.fixture

--- a/tests/examples/test_wds_e2e.py
+++ b/tests/examples/test_wds_e2e.py
@@ -101,7 +101,7 @@ def test_wds_merge_with_parquet_meta(
         laion=process_webdataset(spec=WDSLaion), params="file"
     )
 
-    meta = dc.from_parquet(Path(webdataset_metadata).as_uri())
+    meta = dc.read_parquet(Path(webdataset_metadata).as_uri())
 
     res = wds.merge(meta, on="laion.json.uid", right_on="uid")
 

--- a/tests/examples/test_wds_e2e.py
+++ b/tests/examples/test_wds_e2e.py
@@ -69,7 +69,7 @@ def webdataset_metadata(tmp_path):
 
 
 def test_wds(test_session, webdataset_tars):
-    res = dc.from_storage(Path(webdataset_tars).as_uri(), session=test_session).gen(
+    res = dc.read_storage(Path(webdataset_tars).as_uri(), session=test_session).gen(
         laion=process_webdataset(spec=WDSLaion), params="file"
     )
 
@@ -97,7 +97,7 @@ def test_wds(test_session, webdataset_tars):
 def test_wds_merge_with_parquet_meta(
     test_session, webdataset_tars, webdataset_metadata
 ):
-    wds = dc.from_storage(Path(webdataset_tars).as_uri(), session=test_session).gen(
+    wds = dc.read_storage(Path(webdataset_tars).as_uri(), session=test_session).gen(
         laion=process_webdataset(spec=WDSLaion), params="file"
     )
 

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -501,7 +501,7 @@ def test_dataset_stats(test_session):
     ids = [1, 2, 3]
     values = tuple(zip(["a", "b", "c"], [1, 2, 3]))
 
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         ids=ids,
         file=[dc.File(path=name, size=size) for name, size in values],
         session=test_session,
@@ -510,7 +510,7 @@ def test_dataset_stats(test_session):
     assert dataset_version1.num_objects == 3
     assert dataset_version1.size == 6
 
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         ids=ids,
         file1=[dc.File(path=name, size=size) for name, size in values],
         file2=[dc.File(path=name, size=size * 2) for name, size in values],
@@ -527,7 +527,7 @@ def test_ls_datasets_ordered(test_session):
 
     assert not list(test_session.catalog.ls_datasets())
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         ids=ids,
         file=[dc.File(path=name, size=size) for name, size in values],
         session=test_session,
@@ -557,7 +557,7 @@ def test_ls_datasets_no_json(test_session):
     ids = [1, 2, 3]
     values = tuple(zip(["a", "b", "c"], [1, 2, 3]))
 
-    dc.from_values(
+    dc.read_values(
         ids=ids,
         file=[dc.File(path=name, size=size) for name, size in values],
         session=test_session,

--- a/tests/func/test_cloud_transfer.py
+++ b/tests/func/test_cloud_transfer.py
@@ -52,7 +52,7 @@ def test_cross_cloud_transfer(
         # Perform cross-cloud transfer
         combined_config = azure_server.client_config | gcloud_server.client_config
         with Session("testSession", client_config=combined_config):
-            datachain = dc.from_storage(source_dir)
+            datachain = dc.read_storage(source_dir)
             datachain.to_storage(dest_dir, placement="filename")
 
         # Verify transfer

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -2090,7 +2090,7 @@ def test_to_read_csv_remote(cloud_test_catalog_upload):
     path = f"{ctc.src_uri}/test.csv"
 
     df = pd.DataFrame(DF_DATA)
-    dc_to = dc.from_pandas(df, session=ctc.session)
+    dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_csv(path)
 
     dc_from = dc.read_csv(path, session=ctc.session)
@@ -2105,7 +2105,7 @@ def test_to_from_parquet_remote(cloud_test_catalog_upload, chunk_size, kwargs):
     path = f"{ctc.src_uri}/test.parquet"
 
     df = pd.DataFrame(DF_DATA)
-    dc_to = dc.from_pandas(df, session=ctc.session)
+    dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_parquet(path, chunk_size=chunk_size, **kwargs)
 
     dc_from = dc.from_parquet(path, session=ctc.session)
@@ -2119,7 +2119,7 @@ def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload):
     path = f"{ctc.src_uri}/parquets"
 
     df = pd.DataFrame(DF_DATA)
-    dc_to = dc.from_pandas(df, session=ctc.session)
+    dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_parquet(path, partition_cols=["first_name"], chunk_size=2)
 
     dc_from = dc.from_parquet(path, session=ctc.session)
@@ -2132,7 +2132,7 @@ def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload):
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
 def test_to_read_json(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
-    dc_to = dc.from_pandas(df, session=test_session)
+    dc_to = dc.read_pandas(df, session=test_session)
     path = tmp_dir / "test.json"
     dc_to.order_by("first_name", "age").to_json(path)
 
@@ -2174,7 +2174,7 @@ def test_to_read_json_remote(cloud_test_catalog_upload):
     path = f"{ctc.src_uri}/test.json"
 
     df = pd.DataFrame(DF_DATA)
-    dc_to = dc.from_pandas(df, session=ctc.session)
+    dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_json(path)
 
     dc_from = dc.read_json(path, session=ctc.session)
@@ -2190,7 +2190,7 @@ def test_to_read_jsonl_remote(cloud_test_catalog_upload):
     path = f"{ctc.src_uri}/test.jsonl"
 
     df = pd.DataFrame(DF_DATA)
-    dc_to = dc.from_pandas(df, session=ctc.session)
+    dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_jsonl(path)
 
     dc_from = dc.read_json(path, format="jsonl", session=ctc.session)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -2100,7 +2100,7 @@ def test_to_read_csv_remote(cloud_test_catalog_upload):
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 @pytest.mark.parametrize("kwargs", ({}, {"compression": "gzip"}))
-def test_to_from_parquet_remote(cloud_test_catalog_upload, chunk_size, kwargs):
+def test_to_read_parquet_remote(cloud_test_catalog_upload, chunk_size, kwargs):
     ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/test.parquet"
 
@@ -2108,13 +2108,13 @@ def test_to_from_parquet_remote(cloud_test_catalog_upload, chunk_size, kwargs):
     dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_parquet(path, chunk_size=chunk_size, **kwargs)
 
-    dc_from = dc.from_parquet(path, session=ctc.session)
+    dc_from = dc.read_parquet(path, session=ctc.session)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
 
     assert df_equal(df1, df)
 
 
-def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload):
+def test_to_read_parquet_partitioned_remote(cloud_test_catalog_upload):
     ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/parquets"
 
@@ -2122,7 +2122,7 @@ def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload):
     dc_to = dc.read_pandas(df, session=ctc.session)
     dc_to.to_parquet(path, partition_cols=["first_name"], chunk_size=2)
 
-    dc_from = dc.from_parquet(path, session=ctc.session)
+    dc_from = dc.read_parquet(path, session=ctc.session)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     df1 = df1.sort_values("first_name").reset_index(drop=True)
     assert df_equal(df1, df)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -2085,7 +2085,7 @@ def test_window_signals_random(cloud_test_catalog):
     assert len(all_dogs) == 2
 
 
-def test_to_from_csv_remote(cloud_test_catalog_upload):
+def test_to_read_csv_remote(cloud_test_catalog_upload):
     ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/test.csv"
 
@@ -2093,7 +2093,7 @@ def test_to_from_csv_remote(cloud_test_catalog_upload):
     dc_to = dc.from_pandas(df, session=ctc.session)
     dc_to.to_csv(path)
 
-    dc_from = dc.from_csv(path, session=ctc.session)
+    dc_from = dc.read_csv(path, session=ctc.session)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df)
 

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -358,7 +358,7 @@ def test_export_images_files(test_session, tmp_dir, tmp_path, use_cache):
     for img in images:
         img["data"].save(tmp_path / img["name"])
 
-    dc.from_values(
+    dc.read_values(
         file=[
             ImageFile(path=img["name"], source=f"file://{tmp_path}") for img in images
         ],
@@ -474,7 +474,7 @@ def test_to_storage_relative_path(test_session, tmp_path):
     for img in images:
         img["data"].save(tmp_path / img["name"])
 
-    dc.from_values(
+    dc.read_values(
         file=[
             ImageFile(path=img["name"], source=f"file://{tmp_path}") for img in images
         ],
@@ -507,7 +507,7 @@ def test_to_storage_files_filename_placement_not_unique_files(tmp_dir, test_sess
 
 def test_show(capsys, test_session):
     first_name = ["Alice", "Bob", "Charlie"]
-    dc.from_values(
+    dc.read_values(
         first_name=first_name,
         age=[40, 30, None],
         city=[
@@ -530,7 +530,7 @@ def test_class_method_deprecated(capsys, test_session):
 
 
 def test_save(test_session):
-    chain = dc.from_values(key=["a", "b", "c"])
+    chain = dc.read_values(key=["a", "b", "c"])
     chain.save(
         name="new_name",
         version=1,
@@ -556,7 +556,7 @@ def test_save(test_session):
 
 def test_show_nested_empty(capsys, test_session):
     files = [File(size=s, path=p) for p, s in zip(list("abcde"), range(5))]
-    dc.from_values(file=files, session=test_session).limit(0).show()
+    dc.read_values(file=files, session=test_session).limit(0).show()
 
     captured = capsys.readouterr()
     normalized_output = re.sub(r"\s+", " ", captured.out)
@@ -566,7 +566,7 @@ def test_show_nested_empty(capsys, test_session):
 
 def test_show_empty(capsys, test_session):
     first_name = ["Alice", "Bob", "Charlie"]
-    dc.from_values(first_name=first_name, session=test_session).limit(0).show()
+    dc.read_values(first_name=first_name, session=test_session).limit(0).show()
 
     captured = capsys.readouterr()
     normalized_output = re.sub(r"\s+", " ", captured.out)
@@ -576,7 +576,7 @@ def test_show_empty(capsys, test_session):
 
 def test_show_limit(capsys, test_session):
     first_name = ["Alice", "Bob", "Charlie"]
-    dc.from_values(
+    dc.read_values(
         first_name=first_name,
         age=[40, 30, None],
         city=[
@@ -594,7 +594,7 @@ def test_show_limit(capsys, test_session):
 def test_show_transpose(capsys, test_session):
     first_name = ["Alice", "Bob", "Charlie"]
     last_name = ["A", "B", "C"]
-    dc.from_values(
+    dc.read_values(
         first_name=first_name,
         last_name=last_name,
         session=test_session,
@@ -614,7 +614,7 @@ def test_show_truncate(capsys, test_session):
         "Not very nice",
     ]
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         client=client,
         details=details,
         session=test_session,
@@ -638,7 +638,7 @@ def test_show_no_truncate(capsys, test_session):
         "Not very nice",
     ]
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         client=client,
         details=details,
         session=test_session,
@@ -657,7 +657,7 @@ def test_show_ordered(capsys, test_session, ordered_by):
     numbers = [6, 2, 3, 1, 5, 7, 4]
     letters = ["u", "y", "x", "z", "v", "t", "w"]
 
-    dc.from_values(number=numbers, letter=letters, session=test_session).order_by(
+    dc.read_values(number=numbers, letter=letters, session=test_session).order_by(
         ordered_by
     ).show()
 
@@ -715,7 +715,7 @@ def test_read_storage_check_rows(tmp_dir, test_session):
 
 
 def test_mutate_existing_column(test_session):
-    ds = dc.from_values(ids=[1, 2, 3], session=test_session)
+    ds = dc.read_values(ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(ids=Column("ids") + 1)
 
     assert list(ds.order_by("ids").collect()) == [(2,), (3,), (4,)]
@@ -728,7 +728,7 @@ def test_parallel(processes, test_session_tmpfile):
     vals = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
 
     res = list(
-        dc.from_values(key=vals, session=test_session_tmpfile)
+        dc.read_values(key=vals, session=test_session_tmpfile)
         .settings(parallel=processes)
         .map(res=lambda key: prefix + key)
         .order_by("res")
@@ -819,7 +819,7 @@ def test_udf_parallel_boostrap(test_session_tmpfile):
         def teardown(self):
             self.value = MyMapper.TEARDOWN_VALUE
 
-    chain = dc.from_values(key=vals, session=test_session_tmpfile)
+    chain = dc.read_values(key=vals, session=test_session_tmpfile)
 
     res = list(chain.settings(parallel=4).map(res=MyMapper()).collect("res"))
 
@@ -1639,7 +1639,7 @@ def test_process_and_open_tar(cloud_test_catalog, cloud_type):
 
 
 def test_datachain_save_with_job(test_session, catalog, datachain_job_id):
-    dc.from_values(value=["val1", "val2"], session=test_session).save("my-ds")
+    dc.read_values(value=["val1", "val2"], session=test_session).save("my-ds")
 
     dataset = catalog.get_dataset("my-ds")
     result_job_id = dataset.get_version(dataset.latest_version).job_id
@@ -2205,7 +2205,7 @@ def test_datachain_functional_after_exceptions(test_session):
 
     keys = ["a", "b", "c"]
     values = [3, 1, 2]
-    chain = dc.from_values(key=keys, val=values, session=test_session)
+    chain = dc.read_values(key=keys, val=values, session=test_session)
     # Running a few times, since sessions closing and cleaning up
     # DB connections on errors. We need to make sure that it reconnects
     # if needed.

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1235,7 +1235,7 @@ def test_row_number_with_order_by_name_len_desc_and_name_asc(cloud_test_catalog)
     ).order_by("name_len", descending=True).order_by("file.path").save(ds_name)
 
     assert list(
-        dc.from_dataset(name=ds_name, session=session).collect("sys.id", "file.path")
+        dc.read_dataset(name=ds_name, session=session).collect("sys.id", "file.path")
     ) == [
         (1, "description"),
         (2, "cats/cat1"),
@@ -1268,7 +1268,7 @@ def test_row_number_with_order_by_before_map(cloud_test_catalog):
     # we should preserve order in final result based on order by which was added
     # before add_signals
     assert list(
-        dc.from_dataset(name=ds_name, session=session).collect("sys.id", "file.path")
+        dc.read_dataset(name=ds_name, session=session).collect("sys.id", "file.path")
     ) == [
         (1, "cats/cat1"),
         (2, "cats/cat2"),
@@ -1469,7 +1469,7 @@ def test_gen_with_new_columns_numpy(cloud_test_catalog, dogs_dataset):
         },
     ).save("dogs_with_rows_and_signals")
 
-    chain = dc.from_dataset(name="dogs_with_rows_and_signals", session=session)
+    chain = dc.read_dataset(name="dogs_with_rows_and_signals", session=session)
     for r in chain.collect(
         "int_col_32",
         "int_col_64",

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -2130,7 +2130,7 @@ def test_to_from_parquet_partitioned_remote(cloud_test_catalog_upload):
 
 # These deprecation warnings occur in the datamodel-code-generator package.
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
-def test_to_from_json(tmp_dir, test_session):
+def test_to_read_json(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     dc_to = dc.from_pandas(df, session=test_session)
     path = tmp_dir / "test.json"
@@ -2143,7 +2143,7 @@ def test_to_from_json(tmp_dir, test_session):
         for n, a, c in zip(DF_DATA["first_name"], DF_DATA["age"], DF_DATA["city"])
     ]
 
-    dc_from = dc.from_json(path.as_uri(), session=test_session)
+    dc_from = dc.read_json(path.as_uri(), session=test_session)
     df1 = dc_from.select("json.first_name", "json.age", "json.city").to_pandas()
     df1 = df1["json"]
     assert df_equal(df1, df)
@@ -2151,7 +2151,7 @@ def test_to_from_json(tmp_dir, test_session):
 
 # These deprecation warnings occur in the datamodel-code-generator package.
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
-def test_from_json_jmespath(tmp_dir, test_session):
+def test_read_json_jmespath(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     values = [
         {"first_name": n, "age": a, "city": c}
@@ -2161,7 +2161,7 @@ def test_from_json_jmespath(tmp_dir, test_session):
     with open(path, "w") as f:
         json.dump({"author": "Test User", "version": 5, "values": values}, f)
 
-    dc_from = dc.from_json(path, jmespath="values", session=test_session)
+    dc_from = dc.read_json(path, jmespath="values", session=test_session)
     df1 = dc_from.select("values.first_name", "values.age", "values.city").to_pandas()
     df1 = df1["values"]
     assert df_equal(df1, df)
@@ -2169,7 +2169,7 @@ def test_from_json_jmespath(tmp_dir, test_session):
 
 # These deprecation warnings occur in the datamodel-code-generator package.
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
-def test_to_from_json_remote(cloud_test_catalog_upload):
+def test_to_read_json_remote(cloud_test_catalog_upload):
     ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/test.json"
 
@@ -2177,7 +2177,7 @@ def test_to_from_json_remote(cloud_test_catalog_upload):
     dc_to = dc.from_pandas(df, session=ctc.session)
     dc_to.to_json(path)
 
-    dc_from = dc.from_json(path, session=ctc.session)
+    dc_from = dc.read_json(path, session=ctc.session)
     df1 = dc_from.select("json.first_name", "json.age", "json.city").to_pandas()
     df1 = df1["json"]
     assert df_equal(df1, df)
@@ -2185,7 +2185,7 @@ def test_to_from_json_remote(cloud_test_catalog_upload):
 
 # These deprecation warnings occur in the datamodel-code-generator package.
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
-def test_to_from_jsonl_remote(cloud_test_catalog_upload):
+def test_to_read_jsonl_remote(cloud_test_catalog_upload):
     ctc = cloud_test_catalog_upload
     path = f"{ctc.src_uri}/test.jsonl"
 
@@ -2193,7 +2193,7 @@ def test_to_from_jsonl_remote(cloud_test_catalog_upload):
     dc_to = dc.from_pandas(df, session=ctc.session)
     dc_to.to_jsonl(path)
 
-    dc_from = dc.from_json(path, format="jsonl", session=ctc.session)
+    dc_from = dc.read_json(path, format="jsonl", session=ctc.session)
     df1 = dc_from.select("jsonl.first_name", "jsonl.age", "jsonl.city").to_pandas()
     df1 = df1["jsonl"]
     assert df_equal(df1, df)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -62,59 +62,59 @@ def _get_listing_datasets(session):
 
 @pytest.mark.parametrize("anon", [True, False])
 def test_catalog_anon(tmp_dir, catalog, anon):
-    chain = dc.from_storage(tmp_dir.as_uri(), anon=anon)
+    chain = dc.read_storage(tmp_dir.as_uri(), anon=anon)
     assert chain.session.catalog.client_config.get("anon", False) is anon
 
 
-def test_from_storage_client_config(tmp_dir, catalog):
-    chain = dc.from_storage(tmp_dir.as_uri())
+def test_read_storage_client_config(tmp_dir, catalog):
+    chain = dc.read_storage(tmp_dir.as_uri())
     assert chain.session.catalog.client_config == {}  # Default client config is set.
 
-    chain = dc.from_storage(tmp_dir.as_uri(), client_config={"anon": True})
+    chain = dc.read_storage(tmp_dir.as_uri(), client_config={"anon": True})
     assert chain.session.catalog.client_config == {
         "anon": True
     }  # New client config is set.
 
 
-def test_from_storage(cloud_test_catalog):
+def test_read_storage(cloud_test_catalog):
     ctc = cloud_test_catalog
-    chain = dc.from_storage(ctc.src_uri, session=ctc.session)
+    chain = dc.read_storage(ctc.src_uri, session=ctc.session)
     assert chain.count() == 7
 
 
-def test_from_storage_non_recursive(cloud_test_catalog):
+def test_read_storage_non_recursive(cloud_test_catalog):
     ctc = cloud_test_catalog
-    chain = dc.from_storage(f"{ctc.src_uri}/dogs", session=ctc.session, recursive=False)
+    chain = dc.read_storage(f"{ctc.src_uri}/dogs", session=ctc.session, recursive=False)
     assert chain.count() == 3
 
 
-def test_from_storage_glob(cloud_test_catalog):
+def test_read_storage_glob(cloud_test_catalog):
     ctc = cloud_test_catalog
-    chain = dc.from_storage(f"{ctc.src_uri}/dogs*", session=ctc.session)
+    chain = dc.read_storage(f"{ctc.src_uri}/dogs*", session=ctc.session)
     assert chain.count() == 4
 
 
-def test_from_storage_as_image(cloud_test_catalog):
+def test_read_storage_as_image(cloud_test_catalog):
     ctc = cloud_test_catalog
-    chain = dc.from_storage(ctc.src_uri, session=ctc.session, type="image")
+    chain = dc.read_storage(ctc.src_uri, session=ctc.session, type="image")
     for im in chain.collect("file"):
         assert isinstance(im, ImageFile)
 
 
-def test_from_storage_reindex(tmp_dir, test_session):
+def test_read_storage_reindex(tmp_dir, test_session):
     tmp_dir = tmp_dir / "parquets"
     path = tmp_dir.as_uri()
     os.mkdir(tmp_dir)
 
     pd.DataFrame({"name": ["Alice", "Bob"]}).to_parquet(tmp_dir / "test1.parquet")
-    assert dc.from_storage(path, session=test_session).count() == 1
+    assert dc.read_storage(path, session=test_session).count() == 1
 
     pd.DataFrame({"name": ["Charlie", "David"]}).to_parquet(tmp_dir / "test2.parquet")
-    assert dc.from_storage(path, session=test_session).count() == 1
-    assert dc.from_storage(path, session=test_session, update=True).count() == 2
+    assert dc.read_storage(path, session=test_session).count() == 1
+    assert dc.read_storage(path, session=test_session, update=True).count() == 2
 
 
-def test_from_storage_reindex_expired(tmp_dir, test_session):
+def test_read_storage_reindex_expired(tmp_dir, test_session):
     catalog = test_session.catalog
     tmp_dir = tmp_dir / "parquets"
     os.mkdir(tmp_dir)
@@ -123,7 +123,7 @@ def test_from_storage_reindex_expired(tmp_dir, test_session):
     lst_ds_name = parse_listing_uri(uri, catalog.client_config)[0]
 
     pd.DataFrame({"name": ["Alice", "Bob"]}).to_parquet(tmp_dir / "test1.parquet")
-    assert dc.from_storage(uri, session=test_session).count() == 1
+    assert dc.read_storage(uri, session=test_session).count() == 1
     pd.DataFrame({"name": ["Charlie", "David"]}).to_parquet(tmp_dir / "test2.parquet")
     # mark dataset as expired
     test_session.catalog.metastore.update_dataset_version(
@@ -133,7 +133,7 @@ def test_from_storage_reindex_expired(tmp_dir, test_session):
     )
 
     # listing was updated because listing dataset was expired
-    assert dc.from_storage(uri, session=test_session).count() == 2
+    assert dc.read_storage(uri, session=test_session).count() == 2
 
 
 @pytest.mark.parametrize(
@@ -141,7 +141,7 @@ def test_from_storage_reindex_expired(tmp_dir, test_session):
     ["s3", "azure", "gs"],
     indirect=True,
 )
-def test_from_storage_partials(cloud_test_catalog):
+def test_read_storage_partials(cloud_test_catalog):
     ctc = cloud_test_catalog
     src_uri = ctc.src_uri
     session = ctc.session
@@ -153,17 +153,17 @@ def test_from_storage_partials(cloud_test_catalog):
         return name
 
     dogs_uri = f"{src_uri}/dogs"
-    dc.from_storage(dogs_uri, session=session).exec()
+    dc.read_storage(dogs_uri, session=session).exec()
     assert _get_listing_datasets(session) == [
         f"{_list_dataset_name(dogs_uri)}@v1",
     ]
 
-    dc.from_storage(f"{src_uri}/dogs/others", session=session)
+    dc.read_storage(f"{src_uri}/dogs/others", session=session)
     assert _get_listing_datasets(session) == [
         f"{_list_dataset_name(dogs_uri)}@v1",
     ]
 
-    dc.from_storage(src_uri, session=session).exec()
+    dc.read_storage(src_uri, session=session).exec()
     assert _get_listing_datasets(session) == sorted(
         [
             f"{_list_dataset_name(dogs_uri)}@v1",
@@ -171,7 +171,7 @@ def test_from_storage_partials(cloud_test_catalog):
         ]
     )
 
-    dc.from_storage(f"{src_uri}/cats", session=session).exec()
+    dc.read_storage(f"{src_uri}/cats", session=session).exec()
     assert _get_listing_datasets(session) == sorted(
         [
             f"{_list_dataset_name(dogs_uri)}@v1",
@@ -185,7 +185,7 @@ def test_from_storage_partials(cloud_test_catalog):
     ["s3", "azure", "gs"],
     indirect=True,
 )
-def test_from_storage_partials_with_update(cloud_test_catalog):
+def test_read_storage_partials_with_update(cloud_test_catalog):
     ctc = cloud_test_catalog
     src_uri = ctc.src_uri
     session = ctc.session
@@ -197,14 +197,14 @@ def test_from_storage_partials_with_update(cloud_test_catalog):
         return name
 
     uri = f"{src_uri}/cats"
-    dc.from_storage(uri, session=session).exec()
+    dc.read_storage(uri, session=session).exec()
     assert _get_listing_datasets(session) == sorted(
         [
             f"{_list_dataset_name(uri)}@v1",
         ]
     )
 
-    dc.from_storage(uri, session=session, update=True).exec()
+    dc.read_storage(uri, session=session, update=True).exec()
     assert _get_listing_datasets(session) == sorted(
         [
             f"{_list_dataset_name(uri)}@v1",
@@ -213,12 +213,12 @@ def test_from_storage_partials_with_update(cloud_test_catalog):
     )
 
 
-def test_from_storage_dependencies(cloud_test_catalog, cloud_type):
+def test_read_storage_dependencies(cloud_test_catalog, cloud_type):
     ctc = cloud_test_catalog
     src_uri = ctc.src_uri
     uri = f"{src_uri}/cats"
     ds_name = "dep"
-    dc.from_storage(uri, session=ctc.session).save(ds_name)
+    dc.read_storage(uri, session=ctc.session).save(ds_name)
     dependencies = ctc.session.catalog.get_dataset_dependencies(ds_name, 1)
     assert len(dependencies) == 1
     assert dependencies[0].type == DatasetDependencyType.STORAGE
@@ -265,7 +265,7 @@ def test_map_file(cloud_test_catalog, use_cache, prefetch):
             return file.name + " -> " + f.read().decode("utf-8")
 
     chain = (
-        dc.from_storage(ctc.src_uri, session=ctc.session)
+        dc.read_storage(ctc.src_uri, session=ctc.session)
         .settings(cache=use_cache, prefetch=prefetch)
         .map(signal=with_checks(new_signal))
         .save()
@@ -290,7 +290,7 @@ def test_map_file(cloud_test_catalog, use_cache, prefetch):
 def test_read_file(cloud_test_catalog, use_cache):
     ctc = cloud_test_catalog
 
-    chain = dc.from_storage(ctc.src_uri, session=ctc.session)
+    chain = dc.read_storage(ctc.src_uri, session=ctc.session)
     for file in chain.settings(cache=use_cache).collect("file"):
         assert file.get_local_path() is None
         file.read()
@@ -314,7 +314,7 @@ def test_to_storage(
     num_threads,
 ):
     ctc = cloud_test_catalog
-    df = dc.from_storage(ctc.src_uri, type=file_type, session=test_session)
+    df = dc.read_storage(ctc.src_uri, type=file_type, session=test_session)
     if use_map:
         df.settings(cache=use_cache).to_storage(
             tmp_dir / "output",
@@ -371,7 +371,7 @@ def test_export_images_files(test_session, tmp_dir, tmp_path, use_cache):
 
 
 @pytest.mark.parametrize("use_cache", [True, False])
-def test_from_storage_multiple_uris_files(test_session, tmp_dir, tmp_path, use_cache):
+def test_read_storage_multiple_uris_files(test_session, tmp_dir, tmp_path, use_cache):
     images = [
         {"name": "img1.jpg", "data": Image.new(mode="RGB", size=(64, 64))},
         {"name": "img2.jpg", "data": Image.new(mode="RGB", size=(128, 128))},
@@ -380,7 +380,7 @@ def test_from_storage_multiple_uris_files(test_session, tmp_dir, tmp_path, use_c
     for img in images:
         img["data"].save(tmp_path / img["name"])
 
-    dc.from_storage(
+    dc.read_storage(
         [
             f"file://{tmp_path}/img1.jpg",
             f"file://{tmp_path}/img2.jpg",
@@ -394,7 +394,7 @@ def test_from_storage_multiple_uris_files(test_session, tmp_dir, tmp_path, use_c
         exported_img = Image.open(tmp_dir / "output" / img["name"])
         assert images_equal(img["data"], exported_img)
 
-    chain = dc.from_storage(
+    chain = dc.read_storage(
         [
             f"file://{tmp_path}/img1.jpg",
             f"file://{tmp_path}/img2.jpg",
@@ -403,7 +403,7 @@ def test_from_storage_multiple_uris_files(test_session, tmp_dir, tmp_path, use_c
     )
     assert chain.count() == 4
 
-    chain = dc.from_storage([f"file://{tmp_dir}/output/*"])
+    chain = dc.read_storage([f"file://{tmp_dir}/output/*"])
     assert chain.count() == 2
 
 
@@ -412,18 +412,18 @@ def test_from_storage_multiple_uris_files(test_session, tmp_dir, tmp_path, use_c
     ["s3", "azure", "gs"],
     indirect=True,
 )
-def test_from_storage_multiple_uris_cache(cloud_test_catalog):
+def test_read_storage_multiple_uris_cache(cloud_test_catalog):
     ctc = cloud_test_catalog
     src_uri = ctc.src_uri
     session = ctc.session
 
     with pytest.raises(ValueError):
-        dc.from_storage([])  # No URIs provided
+        dc.read_storage([])  # No URIs provided
 
     with patch(
         "datachain.lib.dc.storage.get_listing", wraps=dc.lib.listing.get_listing
     ) as mock_get_listing:
-        chain = dc.from_storage(
+        chain = dc.read_storage(
             [
                 f"{src_uri}/cats",
                 f"{src_uri}/dogs",
@@ -449,7 +449,7 @@ def test_from_storage_multiple_uris_cache(cloud_test_catalog):
         assert mock_get_listing.call_count == 4  # TODO FIX THIS
 
 
-def test_from_storage_path_object(test_session, tmp_dir, tmp_path):
+def test_read_storage_path_object(test_session, tmp_dir, tmp_path):
     images = [
         {"name": "img1.jpg", "data": Image.new(mode="RGB", size=(64, 64))},
         {"name": "img2.jpg", "data": Image.new(mode="RGB", size=(128, 128))},
@@ -458,7 +458,7 @@ def test_from_storage_path_object(test_session, tmp_dir, tmp_path):
     for img in images:
         img["data"].save(tmp_path / img["name"])
 
-    dc.from_storage(tmp_path).to_storage(tmp_dir / "output", placement="filename")
+    dc.read_storage(tmp_path).to_storage(tmp_dir / "output", placement="filename")
 
     for img in images:
         exported_img = Image.open(tmp_dir / "output" / img["name"])
@@ -500,7 +500,7 @@ def test_to_storage_files_filename_placement_not_unique_files(tmp_dir, test_sess
         with open(file_path, "wb") as fd:
             fd.write(data)
 
-    df = dc.from_storage((tmp_dir / bucket_name).as_uri(), session=test_session)
+    df = dc.read_storage((tmp_dir / bucket_name).as_uri(), session=test_session)
     with pytest.raises(ValueError):
         df.to_storage(tmp_dir / "output", placement="filename")
 
@@ -676,24 +676,24 @@ def test_show_ordered(capsys, test_session, ordered_by):
         assert line == f"{i} {number} {letter}"
 
 
-def test_from_storage_dataset_stats(tmp_dir, test_session):
+def test_read_storage_dataset_stats(tmp_dir, test_session):
     for i in range(4):
         (tmp_dir / f"file{i}.txt").write_text(f"file{i}")
 
-    chain = dc.from_storage(tmp_dir.as_uri(), session=test_session).save("test-data")
+    chain = dc.read_storage(tmp_dir.as_uri(), session=test_session).save("test-data")
     version = test_session.catalog.get_dataset(chain.name).get_version(chain.version)
     assert version.num_objects == 4
     assert version.size == 20
 
 
-def test_from_storage_check_rows(tmp_dir, test_session):
+def test_read_storage_check_rows(tmp_dir, test_session):
     stats = {}
     for i in range(4):
         file = tmp_dir / f"{i}.txt"
         file.write_text(f"file{i}")
         stats[file.name] = file.stat()
 
-    chain = dc.from_storage(tmp_dir.as_uri(), session=test_session).save("test-data")
+    chain = dc.read_storage(tmp_dir.as_uri(), session=test_session).save("test-data")
 
     is_sqlite = isinstance(test_session.catalog.warehouse, SQLiteWarehouse)
     tz = timezone.utc if is_sqlite else pytz.UTC
@@ -750,7 +750,7 @@ def test_udf(cloud_test_catalog):
         return (len(posixpath.basename(path)),)
 
     chain = (
-        dc.from_storage(cloud_test_catalog.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .map(name_len, params=["file.path"], output={"name_len": int})
@@ -782,7 +782,7 @@ def test_udf_parallel(cloud_test_catalog_tmpfile):
         return (len(name),)
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .settings(parallel=-1)
         .map(name_len, params=["file.path"], output={"name_len": int})
         .select("file.path", "name_len")
@@ -847,7 +847,7 @@ def test_udf_distributed(
         return (len(name),)
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .settings(parallel=2, workers=workers)
         .map(name_len, params=["file.path"], output={"name_len": int})
         .select("file.path", "name_len")
@@ -878,7 +878,7 @@ def test_class_udf(cloud_test_catalog):
             return (self.constant + size * self.multiplier,)
 
     chain = (
-        dc.from_storage(cloud_test_catalog.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .map(
             MyUDF(5, multiplier=2),
@@ -917,7 +917,7 @@ def test_class_udf_parallel(cloud_test_catalog_tmpfile):
             return (self.constant + size * self.multiplier,)
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .settings(parallel=2)
         .map(
@@ -953,7 +953,7 @@ def test_udf_parallel_exec_error(cloud_test_catalog_tmpfile):
         raise RuntimeError("Test Error!")
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .settings(parallel=-1)
@@ -985,7 +985,7 @@ def test_udf_distributed_exec_error(
         raise RuntimeError("Test Error!")
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .settings(parallel=2, workers=workers)
@@ -1013,7 +1013,7 @@ def test_udf_reuse_on_error(cloud_test_catalog_tmpfile):
         return (len(path),)
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .map(name_len_maybe_error, params=["file.path"], output={"path_len": int})
@@ -1049,7 +1049,7 @@ def test_udf_parallel_interrupt(cloud_test_catalog_tmpfile, capfd):
         raise KeyboardInterrupt
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .settings(parallel=-1)
@@ -1083,7 +1083,7 @@ def test_udf_distributed_interrupt(
         raise KeyboardInterrupt
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .settings(parallel=2, workers=2)
@@ -1138,7 +1138,7 @@ def test_udf_distributed_cancel(
         return len(name), None
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .filter(dc.C("file.size") < 13)
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .settings(parallel=2, workers=2)
@@ -1170,7 +1170,7 @@ def test_avoid_recalculation_after_save(cloud_test_catalog):
     uri = cloud_test_catalog.src_uri
     session = cloud_test_catalog.session
     ds = (
-        dc.from_storage(uri, session=session)
+        dc.read_storage(uri, session=session)
         .filter(dc.C("file.path").glob("*/dog1"))
         .map(name_len, params=["file.path"], output={"name_len": int})
     )
@@ -1203,7 +1203,7 @@ def test_udf_after_limit(cloud_test_catalog):
 
     expected = [(f"{i:06d}", i) for i in range(100)]
     chain = (
-        dc.from_storage(ctc.src_uri, session=ctc.session)
+        dc.read_storage(ctc.src_uri, session=ctc.session)
         .mutate(name=pathfunc.name("file.path"))
         .save()
     )
@@ -1230,7 +1230,7 @@ def test_row_number_with_order_by_name_len_desc_and_name_asc(cloud_test_catalog)
     def name_len(path):
         return (len(posixpath.basename(path)),)
 
-    dc.from_storage(path, session=session).map(
+    dc.read_storage(path, session=session).map(
         name_len, params=["file.path"], output={"name_len": int}
     ).order_by("name_len", descending=True).order_by("file.path").save(ds_name)
 
@@ -1261,7 +1261,7 @@ def test_row_number_with_order_by_before_map(cloud_test_catalog):
     def name_len(path):
         return (len(posixpath.basename(path)),)
 
-    dc.from_storage(path, session=session).order_by("file.path").map(
+    dc.read_storage(path, session=session).order_by("file.path").map(
         name_len, params=["file.path"], output={"name_len": int}
     ).save(ds_name)
 
@@ -1307,7 +1307,7 @@ def test_udf_different_types(cloud_test_catalog):
         )
 
     chain = (
-        dc.from_storage(cloud_test_catalog.src_uri, session=cloud_test_catalog.session)
+        dc.read_storage(cloud_test_catalog.src_uri, session=cloud_test_catalog.session)
         .filter(dc.C("file.path").glob("*cat1"))
         .map(
             test_types,
@@ -1386,7 +1386,7 @@ def test_gen_parallel(cloud_test_catalog_tmpfile):
             yield (f"{file.path}_{i}",)
 
     chain = (
-        dc.from_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
+        dc.read_storage(cloud_test_catalog_tmpfile.src_uri, session=session)
         .settings(parallel=-1)
         .gen(gen=func, params=["file"], output={"val": str})
         .order_by("val")
@@ -1453,7 +1453,7 @@ def test_gen_with_new_columns_numpy(cloud_test_catalog, dogs_dataset):
                 np.array([], dtype=np.float32),
             )
 
-    dc.from_storage(cloud_test_catalog.src_uri, session=session).gen(
+    dc.read_storage(cloud_test_catalog.src_uri, session=session).gen(
         subobject=gen_numpy,
         output={
             "int_col_32": int,
@@ -1508,7 +1508,7 @@ def test_gen_with_new_columns_wrong_type(cloud_test_catalog, dogs_dataset):
         yield (0.5)
 
     with pytest.raises(ValueError):
-        dc.from_storage(cloud_test_catalog.src_uri, session=session).gen(
+        dc.read_storage(cloud_test_catalog.src_uri, session=session).gen(
             new_val=gen_func, output={"new_val": int}
         ).show()
 
@@ -1550,7 +1550,7 @@ def test_gen_file(cloud_test_catalog, use_cache, prefetch):
             return [file.name, f.read().decode("utf-8")]
 
     chain = (
-        dc.from_storage(ctc.src_uri, session=ctc.session)
+        dc.read_storage(ctc.src_uri, session=ctc.session)
         .settings(cache=use_cache, prefetch=prefetch)
         .gen(signal=with_checks(new_signal), output=str)
         .save()
@@ -1584,7 +1584,7 @@ def test_similarity_search(cloud_test_catalog):
         return text_embedding(text)
 
     target_embedding = next(
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .filter(dc.C("file.path").glob("*description"))
         .order_by("file.path")
         .limit(1)
@@ -1592,7 +1592,7 @@ def test_similarity_search(cloud_test_catalog):
         .collect("embedding")
     )
     chain = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(embedding=calc_emb, output={"embedding": list[float]})
         .mutate(
             cos_dist=func.cosine_distance("embedding", target_embedding),
@@ -1624,7 +1624,7 @@ def test_similarity_search(cloud_test_catalog):
 @pytest.mark.parametrize("tree", [TARRED_TREE], indirect=True)
 def test_process_and_open_tar(cloud_test_catalog, cloud_type):
     ctc = cloud_test_catalog
-    chain = dc.from_storage(ctc.src_uri, session=ctc.session).gen(file=process_tar)
+    chain = dc.read_storage(ctc.src_uri, session=ctc.session).gen(file=process_tar)
     assert chain.count() == 7
 
     assert {(file.read(), file.path) for file in chain.collect("file")} == {
@@ -1666,7 +1666,7 @@ def test_group_by_signals(cloud_test_catalog):
         )
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(file_info, params=["file"], output={"file_info": FileInfo})
         .group_by(
             cnt=func.count(),
@@ -1731,7 +1731,7 @@ def test_group_by_signals_same_model(cloud_test_catalog):
         )
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(f1=file_info)
         .map(f2=file_info)
         .group_by(
@@ -1822,7 +1822,7 @@ def test_group_by_signals_nested(cloud_test_catalog):
         )
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(f1=file_info)
         .map(f2=file_info)
         .group_by(
@@ -1915,7 +1915,7 @@ def test_group_by_known_signals(cloud_test_catalog):
         return BBox(title=file.path.split("/")[0], coords=[10, 20, 80, 90])
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(box=process)
         .group_by(
             cnt=func.count(),
@@ -1965,7 +1965,7 @@ def test_group_by_func(cloud_test_catalog):
     src_uri = cloud_test_catalog.src_uri
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .group_by(
             cnt=func.count(),
             sum=func.sum("file.size"),
@@ -2014,7 +2014,7 @@ def test_window_signals(cloud_test_catalog, partition_by, order_by):
     window = func.window(partition_by=partition_by, order_by=order_by, desc=True)
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(file_info, params=["file"], output={"file_info": FileInfo})
         .mutate(row_number=func.row_number().over(window))
         .save("my-ds")
@@ -2062,7 +2062,7 @@ def test_window_signals_random(cloud_test_catalog):
     window = func.window(partition_by="file_info.path", order_by="sys.rand")
 
     ds = (
-        dc.from_storage(src_uri, session=session)
+        dc.read_storage(src_uri, session=session)
         .map(file_info, params=["file"], output={"file_info": FileInfo})
         .mutate(row_number=func.row_number().over(window))
         .filter(dc.C("row_number") < 3)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -445,7 +445,7 @@ def test_read_storage_multiple_uris_cache(cloud_test_catalog):
             "dog4",
         }
 
-        # Verify from_records was called exactly twice
+        # Verify read_records was called exactly twice
         assert mock_get_listing.call_count == 4  # TODO FIX THIS
 
 

--- a/tests/func/test_datachain_merge.py
+++ b/tests/func/test_datachain_merge.py
@@ -16,8 +16,8 @@ def test_merge_union(cloud_test_catalog, inner, cloud_type):
 
     src = cloud_test_catalog.src_uri
 
-    dogs = dc.from_storage(f"{src}/dogs/*", session=session)
-    cats = dc.from_storage(f"{src}/cats/*", session=session)
+    dogs = dc.read_storage(f"{src}/dogs/*", session=session)
+    cats = dc.read_storage(f"{src}/cats/*", session=session)
 
     signal_default_value = Int.default_value(catalog.warehouse.db.dialect)
 
@@ -60,8 +60,8 @@ def test_merge_multiple(cloud_test_catalog, inner1, inner2, inner3):
 
     src = cloud_test_catalog.src_uri
 
-    dogs = dc.from_storage(f"{src}/dogs/*", session=session)
-    cats = dc.from_storage(f"{src}/cats/*", session=session)
+    dogs = dc.read_storage(f"{src}/dogs/*", session=session)
+    cats = dc.read_storage(f"{src}/cats/*", session=session)
 
     signal_default_value = Int.default_value(catalog.warehouse.db.dialect)
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -779,7 +779,7 @@ def test_dataset_preview_order(test_session):
     catalog = test_session.catalog
     dataset_name = "test"
 
-    dc.from_values(id=ids, order=order, session=test_session).order_by("order").save(
+    dc.read_values(id=ids, order=order, session=test_session).order_by("order").save(
         dataset_name
     )
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -792,12 +792,12 @@ def test_dataset_preview_order(test_session):
         preview_values.append((id, o))
         assert (r["id"], r["order"]) == entry
 
-    dc.from_dataset(dataset_name, session=test_session).save(dataset_name)
+    dc.read_dataset(dataset_name, session=test_session).save(dataset_name)
 
     for r in catalog.get_dataset(dataset_name).get_version(2).preview:
         assert (r["id"], r["order"]) == preview_values.pop(0)
 
-    dc.from_dataset(dataset_name, 2, session=test_session).order_by("id").save(
+    dc.read_dataset(dataset_name, 2, session=test_session).order_by("id").save(
         dataset_name
     )
 

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -668,7 +668,7 @@ def test_ls_dataset_rows_with_custom_columns(cloud_test_catalog):
         )
 
     (
-        dc.from_storage(cloud_test_catalog.src_uri, session=cloud_test_catalog.session)
+        dc.read_storage(cloud_test_catalog.src_uri, session=cloud_test_catalog.session)
         .map(
             test_types,
             params=[],
@@ -732,7 +732,7 @@ def test_dataset_preview_custom_columns(cloud_test_catalog, dogs_dataset):
         )
 
     (
-        dc.from_storage(cloud_test_catalog.src_uri, session=cloud_test_catalog.session)
+        dc.read_storage(cloud_test_catalog.src_uri, session=cloud_test_catalog.session)
         .map(
             test_types,
             params=[],
@@ -856,7 +856,7 @@ def test_dataset_storage_dependencies(cloud_test_catalog, cloud_type, indirect):
     uri = cloud_test_catalog.src_uri
 
     ds_name = "some_ds"
-    dc.from_storage(uri, session=session).save(ds_name)
+    dc.read_storage(uri, session=session).save(ds_name)
 
     lst_ds_name, _, _ = parse_listing_uri(uri, catalog.client_config)
     lst_dataset = catalog.metastore.get_dataset(lst_ds_name)

--- a/tests/func/test_feature_pickling.py
+++ b/tests/func/test_feature_pickling.py
@@ -84,7 +84,7 @@ def test_feature_udf_parallel(cloud_test_catalog_tmpfile):
     cloudpickle.register_pickle_by_value(tfp)
 
     chain = (
-        dc.from_storage(source, type="text", session=ctc.session)
+        dc.read_storage(source, type="text", session=ctc.session)
         .filter(dc.C("file.path").glob("*cat*"))
         .settings(parallel=2)
         .map(
@@ -132,7 +132,7 @@ def test_feature_udf_parallel_local(cloud_test_catalog_tmpfile):
     cloudpickle.register_pickle_by_value(tfp)
 
     chain = (
-        dc.from_storage(source, type="text", session=ctc.session)
+        dc.read_storage(source, type="text", session=ctc.session)
         .filter(dc.C("file.path").glob("*cat*"))
         .settings(parallel=2)
         .map(
@@ -189,7 +189,7 @@ def test_feature_udf_parallel_local_pydantic(cloud_test_catalog_tmpfile):
     cloudpickle.register_pickle_by_value(tfp)
 
     chain = (
-        dc.from_storage(source, type="text", session=ctc.session)
+        dc.read_storage(source, type="text", session=ctc.session)
         .filter(dc.C("file.path").glob("*cat*"))
         .settings(parallel=2)
         .map(
@@ -250,7 +250,7 @@ def test_feature_udf_parallel_local_pydantic_old(cloud_test_catalog_tmpfile):
     cloudpickle.register_pickle_by_value(tfp)
 
     chain = (
-        dc.from_storage(source, type="text", session=ctc.session)
+        dc.read_storage(source, type="text", session=ctc.session)
         .filter(dc.C("file.path").glob("*cat*"))
         .settings(parallel=2)
         .map(
@@ -322,7 +322,7 @@ def test_feature_udf_parallel_dynamic(cloud_test_catalog_tmpfile):
     cloudpickle.register_pickle_by_value(tfp)
 
     chain = (
-        dc.from_storage(source, type="text", session=session)
+        dc.read_storage(source, type="text", session=session)
         .filter(dc.C("file__path").glob("*cat*"))
         .settings(parallel=2)
         .map(

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -19,7 +19,7 @@ def test_resolve_file(cloud_test_catalog):
 
     is_sqlite = isinstance(cloud_test_catalog.catalog.warehouse, SQLiteWarehouse)
 
-    chain = dc.from_storage(ctc.src_uri, session=ctc.session)
+    chain = dc.read_storage(ctc.src_uri, session=ctc.session)
     for orig_file in chain.collect("file"):
         file = File(
             source=orig_file.source,

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -29,7 +29,7 @@ def test_datachain_show(capsys, test_session):
                inner_value
 0         1.3          1.1    1
 """
-    dc.from_values(outer=[outer], nums=[1]).show()
+    dc.read_values(outer=[outer], nums=[1]).show()
 
     captured = capsys.readouterr()
     output_lines = [line.strip() for line in captured.out.strip().split("\n")]
@@ -48,7 +48,7 @@ def test_datachain_show_include_hidden(capsys, test_session):
                           inner_value   hide_inner
 0         1.3        1.4          1.1          1.2    1
 """
-    dc.from_values(outer=[outer], nums=[1]).show(include_hidden=True)
+    dc.read_values(outer=[outer], nums=[1]).show(include_hidden=True)
 
     captured = capsys.readouterr()
     output_lines = [line.strip() for line in captured.out.strip().split("\n")]
@@ -61,7 +61,7 @@ def test_datachain_save(test_session):
     inner = InnerClass(inner_value=1.1, hide_inner=1.2)
     outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
 
-    ds = dc.from_values(outer=[outer], nums=[1], session=test_session).save()
+    ds = dc.read_values(outer=[outer], nums=[1], session=test_session).save()
 
     version = test_session.catalog.get_dataset(ds.name).get_version(1)
     feature_schema = version.feature_schema

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -11,7 +11,7 @@ def test_listing_generator(cloud_test_catalog, cloud_type):
 
     uri = f"{ctc.src_uri}/cats"
 
-    chain = dc.from_records(dc.DataChain.DEFAULT_FILE_RECORD).gen(
+    chain = dc.read_records(dc.DataChain.DEFAULT_FILE_RECORD).gen(
         file=list_bucket(uri, catalog.cache, client_config=catalog.client_config)
     )
     assert chain.count() == 2

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -32,7 +32,7 @@ def test_ls_no_args(cloud_test_catalog, cloud_type, capsys):
     catalog = session.catalog
     src = cloud_test_catalog.src_uri
 
-    dc.from_storage(src, session=session).exec()
+    dc.read_storage(src, session=session).exec()
     ls([], catalog=catalog)
     captured = capsys.readouterr()
     assert captured.out == f"{src}/@v1\n"

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -271,7 +271,7 @@ def test_pull_dataset_success(
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
 @skip_if_not_sqlite
-def test_datachain_from_dataset_pull(
+def test_datachain_read_hf_pull(
     mocker,
     cloud_test_catalog,
     remote_dataset_info,
@@ -292,7 +292,7 @@ def test_datachain_from_dataset_pull(
         catalog.get_dataset("dogs")
 
     with Session("testSession", catalog=catalog):
-        ds = dc.from_dataset(
+        ds = dc.read_dataset(
             name="dogs",
             version=1,
             fallback_to_studio=True,

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -271,7 +271,7 @@ def test_pull_dataset_success(
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)
 @skip_if_not_sqlite
-def test_datachain_read_hf_pull(
+def test_datachain_read_dataset_pull(
     mocker,
     cloud_test_catalog,
     remote_dataset_info,

--- a/tests/func/test_pytorch.py
+++ b/tests/func/test_pytorch.py
@@ -30,7 +30,7 @@ def fake_dataset(catalog, fake_image_dir):
     # Create dataset from images
     uri = fake_image_dir.as_uri()
     return (
-        dc.from_storage(uri, type="image")
+        dc.read_storage(uri, type="image")
         .settings(prefetch=0, cache=False)
         .map(text=lambda file: file.parent.split("/")[-1], output=str)
         .map(label=lambda text: int(text), output=int)

--- a/tests/func/test_pytorch.py
+++ b/tests/func/test_pytorch.py
@@ -139,7 +139,7 @@ def test_prefetch(
 
 def test_hf_to_pytorch(catalog, fake_image_dir):
     hf_ds = load_dataset("imagefolder", data_dir=fake_image_dir)
-    chain = dc.from_hf(hf_ds)
+    chain = dc.read_hf(hf_ds)
     pt_ds = chain.order_by("label").to_pytorch()
     img, label = next(iter(pt_ds))
     assert isinstance(img, Tensor)

--- a/tests/func/test_query.py
+++ b/tests/func/test_query.py
@@ -80,7 +80,7 @@ def test_query_cli(cloud_test_catalog_tmpfile, tmp_path, catalog_info_filepath, 
     import datachain as dc
     from datachain import metrics, param
 
-    chain = dc.from_storage(param("url"), session=session)
+    chain = dc.read_storage(param("url"), session=session)
 
     metrics.set("count", chain.count())
 

--- a/tests/func/test_session.py
+++ b/tests/func/test_session.py
@@ -15,7 +15,7 @@ def test_listing_dataset_lifecycle(tmp_path, catalog):
     with pytest.raises(ValueError):
         with Session(session_name, catalog=catalog):
             ds_name = "my_test_ds13"
-            dc.from_storage(str(tmp_path)).exec()
+            dc.read_storage(str(tmp_path)).exec()
             dc.from_values(key=["a", "b", "c"]).save(ds_name)
             raise ValueError("This is a test exception")
 

--- a/tests/func/test_session.py
+++ b/tests/func/test_session.py
@@ -16,7 +16,7 @@ def test_listing_dataset_lifecycle(tmp_path, catalog):
         with Session(session_name, catalog=catalog):
             ds_name = "my_test_ds13"
             dc.read_storage(str(tmp_path)).exec()
-            dc.from_values(key=["a", "b", "c"]).save(ds_name)
+            dc.read_values(key=["a", "b", "c"]).save(ds_name)
             raise ValueError("This is a test exception")
 
     with pytest.raises(DatasetNotFoundError):

--- a/tests/scripts/feature_class.py
+++ b/tests/scripts/feature_class.py
@@ -9,7 +9,7 @@ class Embedding(BaseModel):
 
 ds_name = "feature_class"
 ds = (
-    dc.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    dc.read_storage("gs://dvcx-datalakes/dogs-and-cats/")
     .filter(dc.C("file.path").glob("*cat*.jpg"))
     .order_by("file.path")
     .limit(5)

--- a/tests/scripts/feature_class_exception.py
+++ b/tests/scripts/feature_class_exception.py
@@ -7,28 +7,28 @@ logging.basicConfig(level=logging.INFO)
 
 # Dataset with variable session. Will persist.
 session = Session("asVariable")
-dv = dc.from_values(key=["a", "b", "c"], session=session)
+dv = dc.read_values(key=["a", "b", "c"], session=session)
 dv.save("passed_as_argument")
 
 # A datachain created in global context.
 # This will be reverted back due to the global exception.
-dc.from_values(key=["a", "b", "c"]).save("global_test_datachain_v1")
+dc.read_values(key=["a", "b", "c"]).save("global_test_datachain_v1")
 
 with Session("local"):
     # A datachain created in local context.
     # This will persist since error occur in global context.
-    dc.from_values(key=["a", "b", "c"]).save("local_test_datachain")
+    dc.read_values(key=["a", "b", "c"]).save("local_test_datachain")
 
 try:
     with Session("local_failure"):
         # A datachain created in local context.
         # This will not persist since error occur in local context.
-        dc.from_values(key=["a", "b", "c"]).save("local_test_datachain_v2")
+        dc.read_values(key=["a", "b", "c"]).save("local_test_datachain_v2")
         raise ValueError("Local failure class")
 except ValueError:
     pass
 
 # We return to global context. So, this will also be reverted.
-dc.from_values(key=["a", "b", "c"]).save("global_error_class_v2")
+dc.read_values(key=["a", "b", "c"]).save("global_error_class_v2")
 
 raise Exception("This is a test exception")

--- a/tests/scripts/feature_class_parallel.py
+++ b/tests/scripts/feature_class_parallel.py
@@ -17,7 +17,7 @@ class Embedding(BaseModel):
 
 ds_name = "feature_class"
 ds = (
-    dc.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    dc.read_storage("gs://dvcx-datalakes/dogs-and-cats/")
     .filter(dc.C("file.path").glob("*cat*.jpg"))  # type: ignore [attr-defined]
     .order_by("file.path")
     .limit(5)

--- a/tests/scripts/feature_class_parallel_data_model.py
+++ b/tests/scripts/feature_class_parallel_data_model.py
@@ -17,7 +17,7 @@ class Embedding(DataModel):
 
 ds_name = "feature_class"
 ds = (
-    dc.from_storage("gs://dvcx-datalakes/dogs-and-cats/")
+    dc.read_storage("gs://dvcx-datalakes/dogs-and-cats/")
     .filter(C("file.path").glob("*cat*.jpg"))  # type: ignore [attr-defined]
     .order_by("file.path")
     .limit(5)

--- a/tests/scripts/name_len_slow.py
+++ b/tests/scripts/name_len_slow.py
@@ -32,7 +32,7 @@ def name_len(file):
 
 
 # Save as a new dataset.
-dc.from_storage(
+dc.read_storage(
     "gs://dvcx-datalakes/dogs-and-cats/",
     anon=True,
 ).filter(dc.C("file.path").glob("*cat*")).limit(3).settings(parallel=1).map(

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -36,7 +36,7 @@ def _import_time_chain(test_session):
     Path("import_time.csv").write_bytes(out)
 
     try:
-        chain = dc.from_csv("import_time.csv", session=test_session, delimiter="|")
+        chain = dc.read_csv("import_time.csv", session=test_session, delimiter="|")
     except Exception:
         logger.error("Failed to parse output: %r", proc.stderr)
         raise

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -10,7 +10,7 @@ def test_telemetry_api_call(mocker, tmp_dir):
     patch_send = mocker.patch("iterative_telemetry.IterativeTelemetryLogger.send")
     telemetry._event_sent = False
 
-    dc.from_storage(tmp_dir.as_uri())
+    dc.read_storage(tmp_dir.as_uri())
     assert patch_send.call_count == 1
     args = patch_send.call_args_list[0].args[0]
     extra = args.pop("extra")

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -270,6 +270,6 @@ def test_parquet_override_column_names_invalid():
 
 def test_infer_schema_no_files(test_session):
     schema = {"file": File, "my_col": int}
-    chain = dc.from_records([], schema=schema, session=test_session, in_memory=True)
+    chain = dc.read_records([], schema=schema, session=test_session, in_memory=True)
     with pytest.raises(ValueError):
         infer_schema(chain)

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -68,7 +68,7 @@ def test_arrow_generator_output_schema(tmp_path, catalog):
     texts = ["28", "22", "we", "hello world"]
     dicts = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}, {"a": 7, "b": 8}]
     df = pd.DataFrame({"id": ids, "text": texts, "dict": dicts})
-    table = pa.Table.from_pandas(df)
+    table = pa.Table.read_pandas(df)
 
     name = "111.parquet"
     pq_path = tmp_path / name

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -68,7 +68,7 @@ def test_arrow_generator_output_schema(tmp_path, catalog):
     texts = ["28", "22", "we", "hello world"]
     dicts = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}, {"a": 7, "b": 8}]
     df = pd.DataFrame({"id": ids, "text": texts, "dict": dicts})
-    table = pa.Table.read_pandas(df)
+    table = pa.Table.from_pandas(df)
 
     name = "111.parquet"
     pq_path = tmp_path / name

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1271,59 +1271,59 @@ def test_parse_tabular_nrows_invalid(tmp_dir, test_session):
         dc.read_storage(path.as_uri(), session=test_session).parse_tabular(nrows=2)
 
 
-def test_from_csv(tmp_dir, test_session):
+def test_read_csv(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.csv"
     df.to_csv(path, index=False)
-    chain = dc.from_csv(path.as_uri(), session=test_session)
+    chain = dc.read_csv(path.as_uri(), session=test_session)
     df1 = chain.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df)
 
 
-def test_to_from_csv(tmp_dir, test_session):
+def test_to_read_csv(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     dc_to = dc.from_pandas(df, session=test_session)
     path = tmp_dir / "test.csv"
     dc_to.to_csv(path)
-    dc_from = dc.from_csv(path.as_uri(), session=test_session)
+    dc_from = dc.read_csv(path.as_uri(), session=test_session)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df)
 
 
 @skip_if_not_sqlite
-def test_from_csv_in_memory(tmp_dir):
+def test_read_csv_in_memory(tmp_dir):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.csv"
     df.to_csv(path, index=False)
-    chain = dc.from_csv(path.as_uri(), in_memory=True)
+    chain = dc.read_csv(path.as_uri(), in_memory=True)
     df1 = chain.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df)
 
 
 @skip_if_not_sqlite
-def test_to_from_csv_in_memory(tmp_dir):
+def test_to_read_csv_in_memory(tmp_dir):
     df = pd.DataFrame(DF_DATA)
     dc_to = dc.from_pandas(df, in_memory=True)
     path = tmp_dir / "test.csv"
     dc_to.to_csv(path)
-    dc_from = dc.from_csv(path.as_uri(), in_memory=True)
+    dc_from = dc.read_csv(path.as_uri(), in_memory=True)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df)
 
 
-def test_from_csv_no_header_error(tmp_dir, test_session):
+def test_read_csv_no_header_error(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA.values()).transpose()
     path = tmp_dir / "test.csv"
     df.to_csv(path, header=False, index=False)
     with pytest.raises(DataChainParamsError):
-        dc.from_csv(path.as_uri(), header=False, session=test_session)
+        dc.read_csv(path.as_uri(), header=False, session=test_session)
 
 
-def test_from_csv_no_header_output_dict(tmp_dir, test_session):
+def test_read_csv_no_header_output_dict(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA.values()).transpose()
     path = tmp_dir / "test.csv"
     df.to_csv(path, header=False, index=False)
-    chain = dc.from_csv(
+    chain = dc.read_csv(
         path.as_uri(),
         header=False,
         output={"first_name": str, "age": int, "city": str},
@@ -1333,7 +1333,7 @@ def test_from_csv_no_header_output_dict(tmp_dir, test_session):
     assert (sort_df(df1).values != sort_df(df).values).sum() == 0
 
 
-def test_from_csv_no_header_output_feature(tmp_dir, test_session):
+def test_read_csv_no_header_output_feature(tmp_dir, test_session):
     class Output(BaseModel):
         first_name: str
         age: int
@@ -1342,18 +1342,18 @@ def test_from_csv_no_header_output_feature(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA.values()).transpose()
     path = tmp_dir / "test.csv"
     df.to_csv(path, header=False, index=False)
-    chain = dc.from_csv(
+    chain = dc.read_csv(
         path.as_uri(), header=False, output=Output, session=test_session
     )
     df1 = chain.select("first_name", "age", "city").to_pandas()
     assert (sort_df(df1).values != sort_df(df).values).sum() == 0
 
 
-def test_from_csv_no_header_output_list(tmp_dir, test_session):
+def test_read_csv_no_header_output_list(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA.values()).transpose()
     path = tmp_dir / "test.csv"
     df.to_csv(path, header=False, index=False)
-    chain = dc.from_csv(
+    chain = dc.read_csv(
         path.as_uri(),
         header=False,
         output=["first_name", "age", "city"],
@@ -1363,17 +1363,17 @@ def test_from_csv_no_header_output_list(tmp_dir, test_session):
     assert (sort_df(df1).values != sort_df(df).values).sum() == 0
 
 
-def test_from_csv_tab_delimited(tmp_dir, test_session):
+def test_read_csv_tab_delimited(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.csv"
     df.to_csv(path, sep="\t", index=False)
-    chain = dc.from_csv(path.as_uri(), delimiter="\t", session=test_session)
+    chain = dc.read_csv(path.as_uri(), delimiter="\t", session=test_session)
     df1 = chain.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df)
 
 
 @skip_if_not_sqlite
-def test_from_csv_null_collect(tmp_dir, test_session):
+def test_read_csv_null_collect(tmp_dir, test_session):
     # Clickhouse requires setting type to Nullable(Type).
     # See https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/189.
     df = pd.DataFrame(DF_DATA)
@@ -1383,7 +1383,7 @@ def test_from_csv_null_collect(tmp_dir, test_session):
     df["gender"] = gender
     path = tmp_dir / "test.csv"
     df.to_csv(path, index=False)
-    chain = dc.from_csv(path.as_uri(), object_name="csv", session=test_session)
+    chain = dc.read_csv(path.as_uri(), object_name="csv", session=test_session)
     for i, row in enumerate(chain.collect()):
         # None value in numeric column will get converted to nan.
         if not height[i]:
@@ -1393,27 +1393,27 @@ def test_from_csv_null_collect(tmp_dir, test_session):
         assert row[1].gender == gender[i]
 
 
-def test_from_csv_nrows(tmp_dir, test_session):
+def test_read_csv_nrows(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.csv"
     df.to_csv(path, index=False)
-    chain = dc.from_csv(path.as_uri(), nrows=2, session=test_session)
+    chain = dc.read_csv(path.as_uri(), nrows=2, session=test_session)
     df1 = chain.select("first_name", "age", "city").to_pandas()
     assert df_equal(df1, df[:2])
 
 
-def test_from_csv_column_types(tmp_dir, test_session):
+def test_read_csv_column_types(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.csv"
     df.to_csv(path, index=False)
-    chain = dc.from_csv(
+    chain = dc.read_csv(
         path.as_uri(), column_types={"age": "str"}, session=test_session
     )
     df1 = chain.select("first_name", "age", "city").to_pandas()
     assert df1["age"].dtype == pd.StringDtype
 
 
-def test_from_csv_parse_options(tmp_dir, test_session):
+def test_read_csv_parse_options(tmp_dir, test_session):
     def skip_comment(row):
         if row.text.startswith("# "):
             return "skip"
@@ -1431,7 +1431,7 @@ def test_from_csv_parse_options(tmp_dir, test_session):
     path = tmp_dir / "test.csv"
     path.write_text(s)
 
-    chain = dc.from_csv(
+    chain = dc.read_csv(
         path.as_uri(),
         session=test_session,
         parse_options={"invalid_row_handler": skip_comment, "delimiter": ";"},
@@ -2429,12 +2429,12 @@ def test_from_parquet_nan_inf(tmp_dir, test_session):
     assert any(r for r in res if np.isneginf(r))
 
 
-def test_from_csv_nan_inf(tmp_dir, test_session):
+def test_read_csv_nan_inf(tmp_dir, test_session):
     vals = [float("nan"), float("inf"), float("-inf")]
     df = pd.DataFrame({"vals": vals})
     path = tmp_dir / "test.csv"
     df.to_csv(path, index=False)
-    chain = dc.from_csv(path.as_uri(), session=test_session)
+    chain = dc.read_csv(path.as_uri(), session=test_session)
 
     res = list(chain.collect("vals"))
     assert len(res) == 3

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -184,7 +184,7 @@ def test_from_features_basic(test_session):
 
     ds_name = "my_ds"
     ds.save(ds_name)
-    ds = dc.from_dataset(name=ds_name)
+    ds = dc.read_dataset(name=ds_name)
 
     assert isinstance(ds._query.feature_schema, dict)
     assert isinstance(ds.signals_schema, SignalSchema)
@@ -202,7 +202,7 @@ def test_from_features_basic_in_memory():
 
     ds_name = "my_ds"
     ds.save(ds_name)
-    ds = dc.from_dataset(name=ds_name)
+    ds = dc.read_dataset(name=ds_name)
 
     assert isinstance(ds._query.feature_schema, dict)
     assert isinstance(ds.signals_schema, SignalSchema)
@@ -227,7 +227,7 @@ def test_from_records_empty_chain_with_schema(test_session):
 
     ds_name = "my_ds"
     ds.save(ds_name)
-    ds = dc.from_dataset(name=ds_name)
+    ds = dc.read_dataset(name=ds_name)
 
     assert isinstance(ds._query.feature_schema, dict)
     assert isinstance(ds.signals_schema, SignalSchema)
@@ -248,7 +248,7 @@ def test_from_records_empty_chain_without_schema(test_session):
 
     ds_name = "my_ds"
     ds.save(ds_name)
-    ds = dc.from_dataset(name=ds_name)
+    ds = dc.read_dataset(name=ds_name)
 
     assert ds.schema.keys() == {
         "source",
@@ -409,7 +409,7 @@ def test_preserve_feature_schema(test_session):
 
     ds_name = "my_ds1"
     ds.save(ds_name)
-    ds = dc.from_dataset(name=ds_name)
+    ds = dc.read_dataset(name=ds_name)
 
     assert isinstance(ds._query.feature_schema, dict)
     assert isinstance(ds.signals_schema, SignalSchema)
@@ -833,7 +833,7 @@ def test_collect_nested_feature(test_session):
         assert nested == features_nested[n]
 
 
-def test_select_from_dataset_without_sys_columns(test_session):
+def test_select_read_hf_without_sys_columns(test_session):
     from datachain import func
 
     chain = (
@@ -938,7 +938,7 @@ def test_select_restore_from_saving(test_session):
     name = "test_test_select_save"
     chain.select("my_n.fr").save(name)
 
-    restored = dc.from_dataset(name)
+    restored = dc.read_dataset(name)
     n = 0
     restored_sorted = sorted(restored.collect(), key=lambda x: x[0].count)
     features_sorted = sorted(features, key=lambda x: x.count)
@@ -984,7 +984,7 @@ def test_select_distinct(test_session):
         assert np.allclose([emb[i] for emb in actual], [emp[i] for emp in expected])
 
 
-def test_from_dataset_name_version(test_session):
+def test_read_hf_name_version(test_session):
     name = "test-version"
     dc.from_values(
         first_name=["Alice", "Bob", "Charlie"],
@@ -997,7 +997,7 @@ def test_from_dataset_name_version(test_session):
         session=test_session,
     ).save(name)
 
-    chain = dc.from_dataset(name)
+    chain = dc.read_dataset(name)
     assert chain.name == name
     assert chain.version
 
@@ -2279,7 +2279,7 @@ def test_rename_object_column_name_with_mutate(test_session):
     # check that persist after saving
     ds.save("mutated")
 
-    ds = dc.from_dataset(name="mutated", session=test_session)
+    ds = dc.read_dataset(name="mutated", session=test_session)
     assert ds.signals_schema.values.get("file") is File
     assert ds.signals_schema.values.get("ids") is int
     assert ds.signals_schema.values.get("fname") is str
@@ -2300,7 +2300,7 @@ def test_rename_object_name_with_mutate(test_session):
     # check that persist after saving
     ds.save("mutated")
 
-    ds = dc.from_dataset(name="mutated", session=test_session)
+    ds = dc.read_dataset(name="mutated", session=test_session)
     assert ds.signals_schema.values.get("my_file") is File
     assert ds.signals_schema.values.get("ids") is int
     assert "file" not in ds.signals_schema.values
@@ -2378,7 +2378,7 @@ def test_mutate_with_saving(test_session):
     ds = dc.from_values(id=[1, 2], session=test_session)
     ds = ds.mutate(new=ds.column("id") / 2).save("mutated")
 
-    ds = dc.from_dataset(name="mutated", session=test_session)
+    ds = dc.read_dataset(name="mutated", session=test_session)
     assert ds.signals_schema.values["new"] is float
     assert list(ds.collect("new")) == [0.5, 1.0]
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -179,7 +179,7 @@ def test_pandas_incorrect_column_names(test_session):
 
 
 def test_from_features_basic(test_session):
-    ds = dc.from_records(dc.DataChain.DEFAULT_FILE_RECORD, session=test_session)
+    ds = dc.read_records(dc.DataChain.DEFAULT_FILE_RECORD, session=test_session)
     ds = ds.gen(lambda prm: [File(path="")] * 5, params="path", output={"file": File})
 
     ds_name = "my_ds"
@@ -194,7 +194,7 @@ def test_from_features_basic(test_session):
 
 @skip_if_not_sqlite
 def test_from_features_basic_in_memory():
-    ds = dc.from_records(dc.DataChain.DEFAULT_FILE_RECORD, in_memory=True)
+    ds = dc.read_records(dc.DataChain.DEFAULT_FILE_RECORD, in_memory=True)
     assert ds.session.catalog.in_memory is True
     assert ds.session.catalog.metastore.db.db_file == ":memory:"
     assert ds.session.catalog.warehouse.db.db_file == ":memory:"
@@ -211,7 +211,7 @@ def test_from_features_basic_in_memory():
 
 
 def test_from_features(test_session):
-    ds = dc.from_records(dc.DataChain.DEFAULT_FILE_RECORD, session=test_session)
+    ds = dc.read_records(dc.DataChain.DEFAULT_FILE_RECORD, session=test_session)
     ds = ds.gen(
         lambda prm: list(zip([File(path="")] * len(features), features)),
         params="path",
@@ -221,9 +221,9 @@ def test_from_features(test_session):
     assert [r[1] for r in ds.order_by("t1.nnn", "t1.count").collect()] == features
 
 
-def test_from_records_empty_chain_with_schema(test_session):
+def test_read_record_empty_chain_with_schema(test_session):
     schema = {"my_file": File, "my_col": int}
-    ds = dc.from_records([], schema=schema, session=test_session)
+    ds = dc.read_records([], schema=schema, session=test_session)
 
     ds_name = "my_ds"
     ds.save(ds_name)
@@ -243,8 +243,8 @@ def test_from_records_empty_chain_with_schema(test_session):
     )
 
 
-def test_from_records_empty_chain_without_schema(test_session):
-    ds = dc.from_records([], schema=None, session=test_session)
+def test_read_record_empty_chain_without_schema(test_session):
+    ds = dc.read_records([], schema=None, session=test_session)
 
     ds_name = "my_ds"
     ds.save(ds_name)
@@ -400,7 +400,7 @@ def test_listings_reindex_subpath_local_file_system(test_session, tmp_dir):
 
 
 def test_preserve_feature_schema(test_session):
-    ds = dc.from_records(dc.DataChain.DEFAULT_FILE_RECORD, session=test_session)
+    ds = dc.read_records(dc.DataChain.DEFAULT_FILE_RECORD, session=test_session)
     ds = ds.gen(
         lambda prm: list(zip([File(path="")] * len(features), features, features)),
         params="path",
@@ -1174,7 +1174,7 @@ def test_parse_tabular_no_files(test_session):
         chain.parse_tabular()
 
     schema = {"file": File, "my_col": int}
-    chain = dc.from_records([], schema=schema, session=test_session, in_memory=True)
+    chain = dc.read_records([], schema=schema, session=test_session, in_memory=True)
 
     with pytest.raises(DatasetPrepareError):
         chain.parse_tabular()

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -81,7 +81,7 @@ def sort_files(files):
 
 
 def test_repr(test_session):
-    chain = dc.from_values(
+    chain = dc.read_values(
         sign1=features_nested, col1=["a", "b", "c"], session=test_session
     )
     assert (
@@ -275,7 +275,7 @@ def test_datasets(test_session):
     datasets = [d for d in ds.collect("dataset") if d.name == "fibonacci"]
     assert len(datasets) == 0
 
-    dc.from_values(fib=[1, 1, 2, 3, 5, 8], session=test_session).save("fibonacci")
+    dc.read_values(fib=[1, 1, 2, 3, 5, 8], session=test_session).save("fibonacci")
 
     ds = dc.datasets(session=test_session)
     datasets = [d for d in ds.collect("dataset") if d.name == "fibonacci"]
@@ -289,7 +289,7 @@ def test_datasets(test_session):
 
 
 def test_datasets_studio(studio_datasets, test_session):
-    dc.from_values(fib=[1, 1, 2, 3, 5, 8], session=test_session).save("fibonacci")
+    dc.read_values(fib=[1, 1, 2, 3, 5, 8], session=test_session).save("fibonacci")
     ds = dc.datasets(studio=True, session=test_session)
     # Local datasets are not included in the list
     datasets = [d for d in ds.collect("dataset") if d.name == "fibonacci"]
@@ -315,7 +315,7 @@ def test_datasets_in_memory():
     datasets = [d for d in ds.collect("dataset") if d.name == "fibonacci"]
     assert len(datasets) == 0
 
-    dc.from_values(fib=[1, 1, 2, 3, 5, 8]).save("fibonacci")
+    dc.read_values(fib=[1, 1, 2, 3, 5, 8]).save("fibonacci")
 
     ds = dc.datasets()
     assert ds.session.catalog.in_memory is True
@@ -421,7 +421,7 @@ def test_from_features_simple_types(test_session):
     fib = [1, 1, 2, 3, 5, 8]
     values = ["odd" if num % 2 else "even" for num in fib]
 
-    ds = dc.from_values(fib=fib, odds=values, session=test_session)
+    ds = dc.read_values(fib=fib, odds=values, session=test_session)
 
     df = sort_df(ds.to_pandas())
     assert len(df) == len(fib)
@@ -434,7 +434,7 @@ def test_from_features_simple_types_in_memory():
     fib = [1, 1, 2, 3, 5, 8]
     values = ["odd" if num % 2 else "even" for num in fib]
 
-    ds = dc.from_values(fib=fib, odds=values, in_memory=True)
+    ds = dc.read_values(fib=fib, odds=values, in_memory=True)
     assert ds.session.catalog.in_memory is True
     assert ds.session.catalog.metastore.db.db_file == ":memory:"
     assert ds.session.catalog.warehouse.db.db_file == ":memory:"
@@ -446,7 +446,7 @@ def test_from_features_simple_types_in_memory():
 
 
 def test_from_features_more_simple_types(test_session):
-    ds = dc.from_values(
+    ds = dc.read_values(
         t1=features,
         num=range(len(features)),
         bb=[True, True, False],
@@ -483,7 +483,7 @@ def test_file_list(test_session):
     sizes = [1, 2, 3, 4, 5]
     files = [File(path=name, size=size) for name, size in zip(names, sizes)]
 
-    ds = dc.from_values(file=files, session=test_session)
+    ds = dc.read_values(file=files, session=test_session)
 
     assert sort_files(files) == [
         r[0] for r in ds.order_by("file.path", "file.size").collect()
@@ -496,7 +496,7 @@ def test_gen(test_session):
         sqrt: float
         my_name: str
 
-    ds = dc.from_values(t1=features, session=test_session)
+    ds = dc.read_values(t1=features, session=test_session)
     ds = ds.gen(
         x=lambda m_fr: [
             _TestFr(
@@ -524,7 +524,7 @@ def test_map(test_session):
         sqrt: float
         my_name: str
 
-    chain = dc.from_values(t1=features, session=test_session).map(
+    chain = dc.read_values(t1=features, session=test_session).map(
         x=lambda m_fr: _TestFr(
             sqrt=math.sqrt(m_fr.count),
             my_name=m_fr.nnn + "_suf",
@@ -546,7 +546,7 @@ def test_map(test_session):
 
 
 def test_map_existing_column_after_step(test_session):
-    chain = dc.from_values(t1=features, session=test_session).map(
+    chain = dc.read_values(t1=features, session=test_session).map(
         x=lambda _: "test",
         params="t1",
         output={"x": str},
@@ -566,7 +566,7 @@ def test_agg(test_session):
         cnt: int
         my_name: str
 
-    chain = dc.from_values(t1=features, session=test_session).agg(
+    chain = dc.read_values(t1=features, session=test_session).agg(
         x=lambda frs: [
             _TestFr(
                 f=File(path=""),
@@ -606,7 +606,7 @@ def test_agg_two_params(test_session):
     ]
 
     ds = (
-        dc.from_values(t1=features, t2=features2, session=test_session)
+        dc.read_values(t1=features, t2=features2, session=test_session)
         .order_by("t1.nnn", "t2.nnn")
         .agg(
             x=lambda frs1, frs2: [
@@ -633,7 +633,7 @@ def test_agg_simple_iiterator(test_session):
 
     keys = ["a", "b", "c"]
     values = [3, 1, 2]
-    ds = dc.from_values(key=keys, val=values, session=test_session).gen(res=func)
+    ds = dc.read_values(key=keys, val=values, session=test_session).gen(res=func)
 
     df = sort_df(ds.to_pandas())
     res = df["res_1"].tolist()
@@ -641,7 +641,7 @@ def test_agg_simple_iiterator(test_session):
 
 
 def test_agg_simple_iterator_error(test_session):
-    chain = dc.from_values(key=["a", "b", "c"], session=test_session)
+    chain = dc.read_values(key=["a", "b", "c"], session=test_session)
 
     with pytest.raises(UdfSignatureError):
 
@@ -680,7 +680,7 @@ def test_agg_tuple_result_iterator(test_session):
 
     keys = ["n1", "n2", "n1"]
     values = [1, 5, 9]
-    ds = dc.from_values(key=keys, val=values, session=test_session).agg(
+    ds = dc.read_values(key=keys, val=values, session=test_session).agg(
         x=func, partition_by=C("key")
     )
 
@@ -701,7 +701,7 @@ def test_agg_tuple_result_generator(test_session):
     keys = ["n1", "n2", "n1"]
     values = [1, 5, 9]
     ds = (
-        dc.from_values(key=keys, val=values, session=test_session)
+        dc.read_values(key=keys, val=values, session=test_session)
         .agg(x=func, partition_by=C("key"))
         .order_by("x_1.name")
     )
@@ -715,7 +715,7 @@ def test_batch_map(test_session):
         sqrt: float
         my_name: str
 
-    chain = dc.from_values(t1=features, session=test_session).batch_map(
+    chain = dc.read_values(t1=features, session=test_session).batch_map(
         x=lambda m_frs: [
             _TestFr(
                 sqrt=math.sqrt(m_fr.count),
@@ -744,7 +744,7 @@ def test_batch_map_wrong_size(test_session):
         total: int
         names: str
 
-    chain = dc.from_values(t1=features, session=test_session).batch_map(
+    chain = dc.read_values(t1=features, session=test_session).batch_map(
         x=lambda m_frs: [
             _TestFr(
                 total=sum(m_fr.count for m_fr in m_frs),
@@ -771,7 +771,7 @@ def test_batch_map_two_params(test_session):
         MyFr(nnn="n1", count=2),
     ]
 
-    ds = dc.from_values(t1=features, t2=features2, session=test_session).batch_map(
+    ds = dc.read_values(t1=features, t2=features2, session=test_session).batch_map(
         x=lambda frs1, frs2: [
             _TestFr(
                 f=File(path=""),
@@ -797,13 +797,13 @@ def test_batch_map_tuple_result_iterator(test_session):
         for val in t1:
             yield math.sqrt(val)
 
-    chain = dc.from_values(t1=[1, 4, 9], session=test_session).batch_map(x=sqrt)
+    chain = dc.read_values(t1=[1, 4, 9], session=test_session).batch_map(x=sqrt)
 
     assert list(chain.order_by("x").collect("x")) == [1, 2, 3]
 
 
 def test_collect(test_session):
-    chain = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
 
     n = 0
     for sample in chain.order_by("f1.nnn", "f1.count").collect():
@@ -821,7 +821,7 @@ def test_collect(test_session):
 
 
 def test_collect_nested_feature(test_session):
-    chain = dc.from_values(sign1=features_nested, session=test_session)
+    chain = dc.read_values(sign1=features_nested, session=test_session)
 
     for n, sample in enumerate(
         chain.order_by("sign1.fr.nnn", "sign1.fr.count").collect()
@@ -837,7 +837,7 @@ def test_select_read_hf_without_sys_columns(test_session):
     from datachain import func
 
     chain = (
-        dc.from_values(
+        dc.read_values(
             name=["a", "a", "b", "b", "b", "c"],
             val=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         )
@@ -854,7 +854,7 @@ def test_select_read_hf_without_sys_columns(test_session):
 
 
 def test_select_feature(test_session):
-    chain = dc.from_values(my_n=features_nested, session=test_session)
+    chain = dc.read_values(my_n=features_nested, session=test_session)
     dc_ordered = chain.order_by("my_n.fr.nnn", "my_n.fr.count")
 
     samples = dc_ordered.select("my_n").collect()
@@ -882,7 +882,7 @@ def test_select_feature(test_session):
 
 
 def test_select_columns_intersection(test_session):
-    chain = dc.from_values(my_n=features_nested, session=test_session)
+    chain = dc.read_values(my_n=features_nested, session=test_session)
 
     samples = (
         chain.order_by("my_n.fr.nnn", "my_n.fr.count")
@@ -899,7 +899,7 @@ def test_select_columns_intersection(test_session):
 
 
 def test_select_except(test_session):
-    chain = dc.from_values(fr1=features_nested, fr2=features, session=test_session)
+    chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
     samples = (
         chain.order_by("fr1.fr.nnn", "fr1.fr.count").select_except("fr2").collect()
@@ -913,7 +913,7 @@ def test_select_except(test_session):
 
 
 def test_select_wrong_type(test_session):
-    chain = dc.from_values(fr1=features_nested, fr2=features, session=test_session)
+    chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
     with pytest.raises(SignalResolvingTypeError):
         list(chain.select(4).collect())
@@ -923,7 +923,7 @@ def test_select_wrong_type(test_session):
 
 
 def test_select_except_error(test_session):
-    chain = dc.from_values(fr1=features_nested, fr2=features, session=test_session)
+    chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
     with pytest.raises(SignalResolvingError):
         list(chain.select_except("not_exist", "file").collect())
@@ -933,7 +933,7 @@ def test_select_except_error(test_session):
 
 
 def test_select_restore_from_saving(test_session):
-    chain = dc.from_values(my_n=features_nested, session=test_session)
+    chain = dc.read_values(my_n=features_nested, session=test_session)
 
     name = "test_test_select_save"
     chain.select("my_n.fr").save(name)
@@ -962,7 +962,7 @@ def test_select_distinct(test_session):
     ]
 
     actual = (
-        dc.from_values(
+        dc.read_values(
             embedding=[
                 Embedding(id=1, filename="a.jpg", values=expected[0]),
                 Embedding(id=2, filename="b.jpg", values=expected[2]),
@@ -986,7 +986,7 @@ def test_select_distinct(test_session):
 
 def test_read_hf_name_version(test_session):
     name = "test-version"
-    dc.from_values(
+    dc.read_values(
         first_name=["Alice", "Bob", "Charlie"],
         age=[40, 30, None],
         city=[
@@ -1004,7 +1004,7 @@ def test_read_hf_name_version(test_session):
 
 def test_chain_of_maps(test_session):
     chain = (
-        dc.from_values(my_n=features_nested, session=test_session)
+        dc.read_values(my_n=features_nested, session=test_session)
         .map(full_name=lambda my_n: my_n.label + "-" + my_n.fr.nnn, output=str)
         .map(square=lambda my_n: my_n.fr.count**2, output=int)
     )
@@ -1025,7 +1025,7 @@ def test_vector(test_session):
     def get_vector(key) -> list[float]:
         return vector
 
-    ds = dc.from_values(key=[123], session=test_session).map(emd=get_vector)
+    ds = dc.read_values(key=[123], session=test_session).map(emd=get_vector)
 
     df = ds.to_pandas()
     assert np.allclose(df["emd"].tolist()[0], vector)
@@ -1037,7 +1037,7 @@ def test_vector_of_vectors(test_session):
     def get_vector(key) -> list[list[float]]:
         return vector
 
-    ds = dc.from_values(key=[123], session=test_session).map(emd_list=get_vector)
+    ds = dc.read_values(key=[123], session=test_session).map(emd_list=get_vector)
 
     df = ds.to_pandas()
     actual = df["emd_list"].tolist()[0]
@@ -1053,7 +1053,7 @@ def test_unsupported_output_type(test_session):
         return [vector]
 
     with pytest.raises(TypeError):
-        dc.from_values(key=[123], session=test_session).map(emd=get_vector)
+        dc.read_values(key=[123], session=test_session).map(emd=get_vector)
 
 
 def test_collect_single_item(test_session):
@@ -1063,7 +1063,7 @@ def test_collect_single_item(test_session):
 
     scores = [0.1, 0.2, 0.3, 0.4, 0.5]
 
-    chain = dc.from_values(file=files, score=scores, session=test_session)
+    chain = dc.read_values(file=files, score=scores, session=test_session)
     chain = chain.order_by("file.path", "file.size")
 
     assert list(chain.collect("file")) == files
@@ -1084,7 +1084,7 @@ def test_default_output_type(test_session):
     names = sorted(["f1.jpg", "f1.json", "f1.txt", "f2.jpg", "f2.json"])
     suffix = "-new"
 
-    chain = dc.from_values(name=names, session=test_session).map(
+    chain = dc.read_values(name=names, session=test_session).map(
         res1=lambda name: name + suffix
     )
 
@@ -1167,7 +1167,7 @@ def test_parse_tabular_partitions(tmp_dir, test_session):
 
 
 def test_parse_tabular_no_files(test_session):
-    chain = dc.from_values(
+    chain = dc.read_values(
         f1=features, num=range(len(features)), session=test_session, in_memory=True
     )
     with pytest.raises(DatasetPrepareError):
@@ -1442,7 +1442,7 @@ def test_read_csv_parse_options(tmp_dir, test_session):
 
 
 def test_to_csv_features(tmp_dir, test_session):
-    dc_to = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
     path = tmp_dir / "test.csv"
     dc_to.order_by("f1.nnn", "f1.count").to_csv(path)
     with open(path) as f:
@@ -1451,7 +1451,7 @@ def test_to_csv_features(tmp_dir, test_session):
 
 
 def test_to_tsv_features(tmp_dir, test_session):
-    dc_to = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
     path = tmp_dir / "test.csv"
     dc_to.order_by("f1.nnn", "f1.count").to_csv(path, delimiter="\t")
     with open(path) as f:
@@ -1460,7 +1460,7 @@ def test_to_tsv_features(tmp_dir, test_session):
 
 
 def test_to_csv_features_nested(tmp_dir, test_session):
-    dc_to = dc.from_values(sign1=features_nested, session=test_session)
+    dc_to = dc.read_values(sign1=features_nested, session=test_session)
     path = tmp_dir / "test.csv"
     dc_to.order_by("sign1.fr.nnn", "sign1.fr.count").to_csv(path)
     with open(path) as f:
@@ -1522,14 +1522,14 @@ def test_explode(tmp_dir, test_session, column_type, object_name, model_name):
 
 
 def test_explode_raises_on_wrong_column_type(test_session):
-    chain = dc.from_values(f1=features, session=test_session)
+    chain = dc.read_values(f1=features, session=test_session)
 
     with pytest.raises(TypeError):
         chain.explode("f1.count")
 
 
 def test_to_json_features(tmp_dir, test_session):
-    dc_to = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
     path = tmp_dir / "test.json"
     dc_to.order_by("f1.nnn", "f1.count").to_json(path)
     with open(path) as f:
@@ -1541,7 +1541,7 @@ def test_to_json_features(tmp_dir, test_session):
 
 
 def test_to_json_features_nested(tmp_dir, test_session):
-    dc_to = dc.from_values(sign1=features_nested, session=test_session)
+    dc_to = dc.read_values(sign1=features_nested, session=test_session)
     path = tmp_dir / "test.json"
     dc_to.order_by("sign1.fr.nnn", "sign1.fr.count").to_json(path)
     with open(path) as f:
@@ -1598,7 +1598,7 @@ def test_read_jsonl_jmespath(tmp_dir, test_session):
 
 
 def test_to_jsonl_features(tmp_dir, test_session):
-    dc_to = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
     path = tmp_dir / "test.json"
     dc_to.order_by("f1.nnn", "f1.count").to_jsonl(path)
     with open(path) as f:
@@ -1610,7 +1610,7 @@ def test_to_jsonl_features(tmp_dir, test_session):
 
 
 def test_to_jsonl_features_nested(tmp_dir, test_session):
-    dc_to = dc.from_values(sign1=features_nested, session=test_session)
+    dc_to = dc.read_values(sign1=features_nested, session=test_session)
     path = tmp_dir / "test.json"
     dc_to.order_by("sign1.fr.nnn", "sign1.fr.count").to_jsonl(path)
     with open(path) as f:
@@ -1723,7 +1723,7 @@ def test_to_read_parquet_partitioned(tmp_dir, test_session, chunk_size):
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 def test_to_read_parquet_features(tmp_dir, test_session, chunk_size):
-    dc_to = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
 
     path = tmp_dir / "test.parquet"
     dc_to.to_parquet(path, chunk_size=chunk_size)
@@ -1749,7 +1749,7 @@ def test_to_read_parquet_features(tmp_dir, test_session, chunk_size):
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 def test_to_read_parquet_nested_features(tmp_dir, test_session, chunk_size):
-    dc_to = dc.from_values(sign1=features_nested, session=test_session)
+    dc_to = dc.read_values(sign1=features_nested, session=test_session)
 
     path = tmp_dir / "test.parquet"
     dc_to.to_parquet(path, chunk_size=chunk_size)
@@ -1770,7 +1770,7 @@ def test_to_read_parquet_nested_features(tmp_dir, test_session, chunk_size):
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 def test_to_read_parquet_two_top_level_features(tmp_dir, test_session, chunk_size):
-    dc_to = dc.from_values(f1=features, nest1=features_nested, session=test_session)
+    dc_to = dc.read_values(f1=features, nest1=features_nested, session=test_session)
 
     path = tmp_dir / "test.parquet"
     dc_to.to_parquet(path, chunk_size=chunk_size)
@@ -1798,7 +1798,7 @@ def test_parallel_in_memory():
 
     with pytest.raises(RuntimeError):
         list(
-            dc.from_values(key=vals, in_memory=True)
+            dc.read_values(key=vals, in_memory=True)
             .settings(parallel=True)
             .map(res=lambda key: prefix + key)
             .collect("res")
@@ -1810,7 +1810,7 @@ def test_exec(test_session):
     all_names = set()
 
     chain = (
-        dc.from_values(name=names, session=test_session)
+        dc.read_values(name=names, session=test_session)
         .map(nop=lambda name: all_names.add(name))
         .exec()
     )
@@ -1819,7 +1819,7 @@ def test_exec(test_session):
 
 
 def test_extend_features(test_session):
-    chain = dc.from_values(f1=features, num=range(len(features)), session=test_session)
+    chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
 
     res = chain._extend_to_data_model("sum", "num")
     assert res == sum(range(len(features)))
@@ -1837,7 +1837,7 @@ def test_from_features_object_name(test_session):
     fib = [1, 1, 2, 3, 5, 8]
     values = ["odd" if num % 2 else "even" for num in fib]
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         fib=fib, odds=values, object_name="custom", session=test_session
     )
     assert "custom.fib" in chain.to_pandas(flatten=True).columns
@@ -1854,7 +1854,7 @@ def test_parse_tabular_object_name(tmp_dir, test_session):
 
 
 def test_sys_feature(test_session):
-    ds = dc.from_values(t1=features, session=test_session).order_by(
+    ds = dc.read_values(t1=features, session=test_session).order_by(
         "t1.nnn", "t1.count"
     )
     ds_sys = ds.settings(sys=True)
@@ -1886,7 +1886,7 @@ def test_sys_feature(test_session):
 
 
 def test_to_pandas_multi_level(test_session):
-    df = dc.from_values(t1=features, session=test_session).to_pandas()
+    df = dc.read_values(t1=features, session=test_session).to_pandas()
 
     assert "t1" in df.columns
     assert "nnn" in df["t1"].columns
@@ -1895,7 +1895,7 @@ def test_to_pandas_multi_level(test_session):
 
 
 def test_to_pandas_multi_level_flatten(test_session):
-    df = dc.from_values(t1=features, session=test_session).to_pandas(flatten=True)
+    df = dc.read_values(t1=features, session=test_session).to_pandas(flatten=True)
 
     assert "t1.nnn" in df.columns
     assert "t1.count" in df.columns
@@ -1905,7 +1905,7 @@ def test_to_pandas_multi_level_flatten(test_session):
 
 def test_to_pandas_empty(test_session):
     df = (
-        dc.from_values(t1=[1, 2, 3], session=test_session)
+        dc.read_values(t1=[1, 2, 3], session=test_session)
         .limit(0)
         .to_pandas(flatten=True)
     )
@@ -1915,7 +1915,7 @@ def test_to_pandas_empty(test_session):
     assert df["t1"].tolist() == []
 
     df = (
-        dc.from_values(my_n=features_nested, session=test_session)
+        dc.read_values(my_n=features_nested, session=test_session)
         .limit(0)
         .to_pandas(flatten=False)
     )
@@ -1929,7 +1929,7 @@ def test_to_pandas_empty(test_session):
     ]
 
     df = (
-        dc.from_values(my_n=features_nested, session=test_session)
+        dc.read_values(my_n=features_nested, session=test_session)
         .limit(0)
         .to_pandas(flatten=True)
     )
@@ -1941,7 +1941,7 @@ def test_to_pandas_empty(test_session):
 
 def test_mutate(test_session):
     chain = (
-        dc.from_values(t1=features, session=test_session)
+        dc.read_values(t1=features, session=test_session)
         .order_by("t1.nnn", "t1.count")
         .mutate(circle=2 * 3.14 * Column("t1.count"), place="pref_" + Column("t1.nnn"))
     )
@@ -1957,7 +1957,7 @@ def test_mutate(test_session):
 def test_order_by_with_nested_columns(test_session, with_function):
     names = ["a.txt", "c.txt", "d.txt", "a.txt", "b.txt"]
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         file=[File(path=name) for name in names], session=test_session
     )
     if with_function:
@@ -1980,7 +1980,7 @@ def test_order_by_collect(test_session):
     numbers = [6, 2, 3, 1, 5, 7, 4]
     letters = ["u", "y", "x", "z", "v", "t", "w"]
 
-    chain = dc.from_values(number=numbers, letter=letters, session=test_session)
+    chain = dc.read_values(number=numbers, letter=letters, session=test_session)
     assert list(chain.order_by("number").collect()) == [
         (1, "z"),
         (2, "y"),
@@ -2006,7 +2006,7 @@ def test_order_by_collect(test_session):
 def test_order_by_descending(test_session, with_function):
     names = ["a.txt", "c.txt", "d.txt", "a.txt", "b.txt"]
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         file=[File(path=name) for name in names], session=test_session
     )
     if with_function:
@@ -2026,17 +2026,17 @@ def test_order_by_descending(test_session, with_function):
 
 
 def test_union(test_session):
-    chain1 = dc.from_values(value=[1, 2], session=test_session)
-    chain2 = dc.from_values(value=[3, 4], session=test_session)
+    chain1 = dc.read_values(value=[1, 2], session=test_session)
+    chain2 = dc.read_values(value=[3, 4], session=test_session)
     chain3 = chain1 | chain2
     assert chain3.count() == 4
     assert list(chain3.order_by("value").collect("value")) == [1, 2, 3, 4]
 
 
 def test_union_different_columns(test_session):
-    chain1 = dc.from_values(value=[1, 2], name=["chain", "more"], session=test_session)
-    chain2 = dc.from_values(value=[3, 4], session=test_session)
-    chain3 = dc.from_values(other=["a", "different", "thing"], session=test_session)
+    chain1 = dc.read_values(value=[1, 2], name=["chain", "more"], session=test_session)
+    chain2 = dc.read_values(value=[3, 4], session=test_session)
+    chain3 = dc.read_values(other=["a", "different", "thing"], session=test_session)
     with pytest.raises(
         ValueError, match="Cannot perform union. name only present in left"
     ):
@@ -2055,8 +2055,8 @@ def test_union_different_columns(test_session):
 
 
 def test_union_different_column_order(test_session):
-    chain1 = dc.from_values(value=[1, 2], name=["chain", "more"], session=test_session)
-    chain2 = dc.from_values(
+    chain1 = dc.read_values(value=[1, 2], name=["chain", "more"], session=test_session)
+    chain2 = dc.read_values(
         name=["different", "order"], value=[9, 10], session=test_session
     )
     assert list(chain1.union(chain2).order_by("value").collect()) == [
@@ -2068,27 +2068,27 @@ def test_union_different_column_order(test_session):
 
 
 def test_subtract(test_session):
-    chain1 = dc.from_values(a=[1, 1, 2], b=["x", "y", "z"], session=test_session)
-    chain2 = dc.from_values(a=[1, 2], b=["x", "y"], session=test_session)
+    chain1 = dc.read_values(a=[1, 1, 2], b=["x", "y", "z"], session=test_session)
+    chain2 = dc.read_values(a=[1, 2], b=["x", "y"], session=test_session)
     assert set(chain1.subtract(chain2, on=["a", "b"]).collect()) == {(1, "y"), (2, "z")}
     assert set(chain1.subtract(chain2, on=["b"]).collect()) == {(2, "z")}
     assert set(chain1.subtract(chain2, on=["a"]).collect()) == set()
     assert set(chain1.subtract(chain2).collect()) == {(1, "y"), (2, "z")}
     assert chain1.subtract(chain1).count() == 0
 
-    chain3 = dc.from_values(a=[1, 3], c=["foo", "bar"], session=test_session)
+    chain3 = dc.read_values(a=[1, 3], c=["foo", "bar"], session=test_session)
     assert set(chain1.subtract(chain3, on="a").collect()) == {(2, "z")}
     assert set(chain1.subtract(chain3).collect()) == {(2, "z")}
 
-    chain4 = dc.from_values(d=[1, 2, 3], e=["x", "y", "z"], session=test_session)
-    chain5 = dc.from_values(a=[1, 2], b=["x", "y"], session=test_session)
+    chain4 = dc.read_values(d=[1, 2, 3], e=["x", "y", "z"], session=test_session)
+    chain5 = dc.read_values(a=[1, 2], b=["x", "y"], session=test_session)
 
     assert set(chain4.subtract(chain5, on="d", right_on="a").collect()) == {(3, "z")}
 
 
 def test_subtract_error(test_session):
-    chain1 = dc.from_values(a=[1, 1, 2], b=["x", "y", "z"], session=test_session)
-    chain2 = dc.from_values(a=[1, 2], b=["x", "y"], session=test_session)
+    chain1 = dc.read_values(a=[1, 1, 2], b=["x", "y", "z"], session=test_session)
+    chain2 = dc.read_values(a=[1, 2], b=["x", "y"], session=test_session)
     with pytest.raises(DataChainParamsError):
         chain1.subtract(chain2, on=[])
     with pytest.raises(TypeError):
@@ -2124,14 +2124,14 @@ def test_subtract_error(test_session):
     with pytest.raises(TypeError):
         chain1.subtract(chain2, on=42, right_on=42)
 
-    chain3 = dc.from_values(c=["foo", "bar"], session=test_session)
+    chain3 = dc.read_values(c=["foo", "bar"], session=test_session)
     with pytest.raises(DataChainParamsError):
         chain1.subtract(chain3)
 
 
 def test_column_math(test_session):
     fib = [1, 1, 2, 3, 5, 8]
-    chain = dc.from_values(num=fib, session=test_session).order_by("num")
+    chain = dc.read_values(num=fib, session=test_session).order_by("num")
 
     ch = chain.mutate(add2=chain.column("num") + 2)
     assert list(ch.collect("add2")) == [x + 2 for x in fib]
@@ -2143,15 +2143,15 @@ def test_column_math(test_session):
 @skip_if_not_sqlite
 def test_column_math_division(test_session):
     fib = [1, 1, 2, 3, 5, 8]
-    chain = dc.from_values(num=fib, session=test_session)
+    chain = dc.read_values(num=fib, session=test_session)
 
     ch = chain.mutate(div2=chain.column("num") / 2.0)
     assert list(ch.collect("div2")) == [x / 2.0 for x in fib]
 
 
-def test_from_values_array_of_floats(test_session):
+def test_read_values_array_of_floats(test_session):
     embeddings = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
-    chain = dc.from_values(emd=embeddings, session=test_session)
+    chain = dc.read_values(emd=embeddings, session=test_session)
 
     assert list(chain.order_by("emd").collect("emd")) == embeddings
 
@@ -2168,7 +2168,7 @@ def test_custom_model_with_nested_lists(test_session):
 
     DataModel.register(Nested)
 
-    ds = dc.from_values(
+    ds = dc.read_values(
         nested=[
             Nested(
                 values=[[0.5, 0.5], [0.5, 0.5]],
@@ -2190,7 +2190,7 @@ def test_custom_model_with_nested_lists(test_session):
 
 
 def test_min_limit(test_session):
-    chain = dc.from_values(a=[1, 2, 3, 4, 5], session=test_session)
+    chain = dc.read_values(a=[1, 2, 3, 4, 5], session=test_session)
     assert chain.count() == 5
     assert chain.limit(4).count() == 4
     assert chain.count() == 5
@@ -2203,7 +2203,7 @@ def test_min_limit(test_session):
 
 
 def test_show_limit(test_session):
-    chain = dc.from_values(a=[1, 2, 3, 4, 5], session=test_session)
+    chain = dc.read_values(a=[1, 2, 3, 4, 5], session=test_session)
     assert chain.count() == 5
     assert chain.limit(4).count() == 4
     chain.show(1)
@@ -2227,7 +2227,7 @@ def test_gen_limit(test_session):
     keys = ["a", "b", "c", "d"]
     values = [3, 3, 3, 3]
 
-    ds = dc.from_values(key=keys, val=values, session=test_session)
+    ds = dc.read_values(key=keys, val=values, session=test_session)
 
     assert ds.count() == 4
     assert ds.gen(res=func).count() == 12
@@ -2246,7 +2246,7 @@ def test_gen_filter(test_session):
     keys = ["a", "b", "c", "d"]
     values = [3, 3, 3, 3]
 
-    ds = dc.from_values(key=keys, val=values, session=test_session)
+    ds = dc.read_values(key=keys, val=values, session=test_session)
 
     assert ds.count() == 4
     assert ds.gen(res=func).count() == 12
@@ -2254,7 +2254,7 @@ def test_gen_filter(test_session):
 
 
 def test_rename_non_object_column_name_with_mutate(test_session):
-    ds = dc.from_values(ids=[1, 2, 3], session=test_session)
+    ds = dc.read_values(ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(my_ids=Column("ids"))
 
     assert ds.signals_schema.values == {"my_ids": int}
@@ -2270,7 +2270,7 @@ def test_rename_object_column_name_with_mutate(test_session):
     sizes = [1, 2, 3]
     files = [File(path=name, size=size) for name, size in zip(names, sizes)]
 
-    ds = dc.from_values(file=files, ids=[1, 2, 3], session=test_session)
+    ds = dc.read_values(file=files, ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(fname=Column("file.path"))
 
     assert list(ds.order_by("fname").collect("fname")) == ["a", "b", "c"]
@@ -2291,7 +2291,7 @@ def test_rename_object_name_with_mutate(test_session):
     sizes = [1, 2, 3]
     files = [File(path=name, size=size) for name, size in zip(names, sizes)]
 
-    ds = dc.from_values(file=files, ids=[1, 2, 3], session=test_session)
+    ds = dc.read_values(file=files, ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(my_file=Column("file"))
 
     assert list(ds.order_by("my_file.path").collect("my_file.path")) == ["a", "b", "c"]
@@ -2308,7 +2308,7 @@ def test_rename_object_name_with_mutate(test_session):
 
 
 def test_column(test_session):
-    ds = dc.from_values(
+    ds = dc.read_values(
         ints=[1, 2],
         floats=[0.5, 0.5],
         file=[File(path="a"), File(path="b")],
@@ -2335,36 +2335,36 @@ def test_column(test_session):
 
 
 def test_mutate_with_subtraction(test_session):
-    ds = dc.from_values(id=[1, 2], session=test_session)
+    ds = dc.read_values(id=[1, 2], session=test_session)
     assert ds.mutate(new=ds.column("id") - 1).signals_schema.values["new"] is int
 
 
 def test_mutate_with_addition(test_session):
-    ds = dc.from_values(id=[1, 2], session=test_session)
+    ds = dc.read_values(id=[1, 2], session=test_session)
     assert ds.mutate(new=ds.column("id") + 1).signals_schema.values["new"] is int
 
 
 def test_mutate_with_division(test_session):
-    ds = dc.from_values(id=[1, 2], session=test_session)
+    ds = dc.read_values(id=[1, 2], session=test_session)
     assert ds.mutate(new=ds.column("id") / 10).signals_schema.values["new"] is float
 
 
 def test_mutate_with_multiplication(test_session):
-    ds = dc.from_values(id=[1, 2], session=test_session)
+    ds = dc.read_values(id=[1, 2], session=test_session)
     assert ds.mutate(new=ds.column("id") * 10).signals_schema.values["new"] is int
 
 
 def test_mutate_with_sql_func(test_session):
     from datachain import func
 
-    ds = dc.from_values(id=[1, 2], session=test_session)
+    ds = dc.read_values(id=[1, 2], session=test_session)
     assert ds.mutate(new=func.avg("id")).signals_schema.values["new"] is float
 
 
 def test_mutate_with_complex_expression(test_session):
     from datachain import func
 
-    ds = dc.from_values(id=[1, 2], name=["Jim", "Jon"], session=test_session)
+    ds = dc.read_values(id=[1, 2], name=["Jim", "Jon"], session=test_session)
     assert (
         ds.mutate(new=func.sum("id") * (5 - func.min("id"))).signals_schema.values[
             "new"
@@ -2375,7 +2375,7 @@ def test_mutate_with_complex_expression(test_session):
 
 @skip_if_not_sqlite
 def test_mutate_with_saving(test_session):
-    ds = dc.from_values(id=[1, 2], session=test_session)
+    ds = dc.read_values(id=[1, 2], session=test_session)
     ds = ds.mutate(new=ds.column("id") / 2).save("mutated")
 
     ds = dc.read_dataset(name="mutated", session=test_session)
@@ -2385,7 +2385,7 @@ def test_mutate_with_saving(test_session):
 
 def test_mutate_with_expression_without_type(test_session):
     with pytest.raises(DataChainColumnError) as excinfo:
-        dc.from_values(id=[1, 2], session=test_session).mutate(
+        dc.read_values(id=[1, 2], session=test_session).mutate(
             new=(Column("id") - 1)
         ).save()
 
@@ -2394,9 +2394,9 @@ def test_mutate_with_expression_without_type(test_session):
     )
 
 
-def test_from_values_nan_inf(test_session):
+def test_read_values_nan_inf(test_session):
     vals = [float("nan"), float("inf"), float("-inf")]
-    chain = dc.from_values(vals=vals, session=test_session)
+    chain = dc.read_values(vals=vals, session=test_session)
     res = list(chain.collect("vals"))
     assert len(res) == 3
     assert any(r for r in res if np.isnan(r))
@@ -2464,7 +2464,7 @@ def test_group_by_int(test_session):
     from datachain import func
 
     ds = (
-        dc.from_values(
+        dc.read_values(
             col1=["a", "a", "b", "b", "b", "c"],
             col2=[1, 2, 3, 4, 5, 6],
             session=test_session,
@@ -2538,7 +2538,7 @@ def test_group_by_float(test_session):
     from datachain import func
 
     ds = (
-        dc.from_values(
+        dc.read_values(
             col1=["a", "a", "b", "b", "b", "c"],
             col2=[1.5, 2.5, 3.5, 4.5, 5.5, 6.5],
             session=test_session,
@@ -2612,7 +2612,7 @@ def test_group_by_str(test_session):
     from datachain import func
 
     ds = (
-        dc.from_values(
+        dc.read_values(
             col1=["a", "a", "b", "b", "b", "c"],
             col2=["1", "2", "3", "4", "5", "6"],
             session=test_session,
@@ -2686,7 +2686,7 @@ def test_group_by_multiple_partition_by(test_session):
     from datachain import func
 
     ds = (
-        dc.from_values(
+        dc.read_values(
             col1=["a", "a", "b", "b", "b", "c"],
             col2=[1, 2, 1, 2, 1, 2],
             col3=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -2777,7 +2777,7 @@ def test_group_by_no_partition_by(test_session):
     from datachain import func
 
     ds = (
-        dc.from_values(
+        dc.read_values(
             col1=["a", "a", "b", "b", "b", "c"],
             col2=[1, 2, 1, 2, 1, 2],
             col3=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -2832,7 +2832,7 @@ def test_group_by_schema(test_session):
         return Parent(signal=signal)
 
     chain = (
-        dc.from_values(
+        dc.read_values(
             name=["a", "a", "b", "b", "b", "c"],
             val=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         )
@@ -2878,7 +2878,7 @@ def test_group_by_schema(test_session):
 def test_group_by_error(test_session):
     from datachain import func
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         col1=["a", "a", "b", "b", "b", "c"],
         col2=[1, 2, 3, 4, 5, 6],
         session=test_session,
@@ -2909,7 +2909,7 @@ def test_group_by_error(test_session):
 def test_group_by_case(test_session):
     from datachain import func
 
-    ds = dc.from_values(
+    ds = dc.read_values(
         col1=[1.0, 0.0, 3.2, 0.1, 5.9, -1.0],
         col2=[0.0, 6.1, -0.05, 3.7, 0.1, -3.0],
         session=test_session,
@@ -2936,7 +2936,7 @@ def test_window_functions(test_session, desc):
 
     window = func.window(partition_by="col1", order_by="col2", desc=desc)
 
-    ds = dc.from_values(
+    ds = dc.read_values(
         col1=["a", "a", "b", "b", "b", "c"],
         col2=[1, 2, 3, 4, 5, 6],
         session=test_session,
@@ -3016,7 +3016,7 @@ def test_window_error(test_session):
 
     window = func.window(partition_by="col1", order_by="col2")
 
-    chain = dc.from_values(
+    chain = dc.read_values(
         col1=["a", "a", "b", "b", "b", "c"],
         col2=[1, 2, 3, 4, 5, 6],
         session=test_session,

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1554,7 +1554,7 @@ def test_to_json_features_nested(tmp_dir, test_session):
 
 # These deprecation warnings occur in the datamodel-code-generator package.
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
-def test_to_from_jsonl(tmp_dir, test_session):
+def test_to_read_jsonl(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     dc_to = dc.from_pandas(df, session=test_session)
     path = tmp_dir / "test.jsonl"
@@ -1567,7 +1567,7 @@ def test_to_from_jsonl(tmp_dir, test_session):
         for n, a, c in zip(DF_DATA["first_name"], DF_DATA["age"], DF_DATA["city"])
     ]
 
-    dc_from = dc.from_json(path.as_uri(), format="jsonl", session=test_session)
+    dc_from = dc.read_json(path.as_uri(), format="jsonl", session=test_session)
     df1 = dc_from.select("jsonl.first_name", "jsonl.age", "jsonl.city").to_pandas()
     df1 = df1["jsonl"]
     assert df_equal(df1, df)
@@ -1575,7 +1575,7 @@ def test_to_from_jsonl(tmp_dir, test_session):
 
 # These deprecation warnings occur in the datamodel-code-generator package.
 @pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20")
-def test_from_jsonl_jmespath(tmp_dir, test_session):
+def test_read_jsonl_jmespath(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     values = [
         {"first_name": n, "age": a, "city": c}
@@ -1589,7 +1589,7 @@ def test_from_jsonl_jmespath(tmp_dir, test_session):
             )
             f.write("\n")
 
-    dc_from = dc.from_json(
+    dc_from = dc.read_json(
         path.as_uri(), format="jsonl", jmespath="value", session=test_session
     )
     df1 = dc_from.select("value.first_name", "value.age", "value.city").to_pandas()

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2443,21 +2443,21 @@ def test_read_csv_nan_inf(tmp_dir, test_session):
     assert any(r for r in res if np.isneginf(r))
 
 
-def test_from_hf(test_session):
+def test_read_hf(test_session):
     ds = Dataset.from_dict(DF_DATA)
-    df = dc.from_hf(ds, session=test_session).to_pandas()
+    df = dc.read_hf(ds, session=test_session).to_pandas()
     assert df_equal(df, pd.DataFrame(DF_DATA))
 
 
-def test_from_hf_object_name(test_session):
+def test_read_hf_object_name(test_session):
     ds = Dataset.from_dict(DF_DATA)
-    df = dc.from_hf(ds, session=test_session, object_name="obj").to_pandas()
+    df = dc.read_hf(ds, session=test_session, object_name="obj").to_pandas()
     assert df_equal(df["obj"], pd.DataFrame(DF_DATA))
 
 
-def test_from_hf_invalid(test_session):
+def test_read_hf_invalid(test_session):
     with pytest.raises(FileNotFoundError):
-        dc.from_hf("invalid_dataset", session=test_session)
+        dc.read_hf("invalid_dataset", session=test_session)
 
 
 def test_group_by_int(test_session):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1621,32 +1621,32 @@ def test_to_jsonl_features_nested(tmp_dir, test_session):
     ]
 
 
-def test_from_parquet(tmp_dir, test_session):
+def test_read_parquet(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.parquet"
     df.to_parquet(path)
-    chain = dc.from_parquet(path.as_uri(), session=test_session)
+    chain = dc.read_parquet(path.as_uri(), session=test_session)
     df1 = chain.select("first_name", "age", "city").to_pandas()
 
     assert df_equal(df1, df)
 
 
 @skip_if_not_sqlite
-def test_from_parquet_in_memory(tmp_dir):
+def test_read_parquet_in_memory(tmp_dir):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.parquet"
     df.to_parquet(path)
-    chain = dc.from_parquet(path.as_uri(), in_memory=True)
+    chain = dc.read_parquet(path.as_uri(), in_memory=True)
     df1 = chain.select("first_name", "age", "city").to_pandas()
 
     assert df_equal(df1, df)
 
 
-def test_from_parquet_partitioned(tmp_dir, test_session):
+def test_read_parquet_partitioned(tmp_dir, test_session):
     df = pd.DataFrame(DF_DATA)
     path = tmp_dir / "test.parquet"
     df.to_parquet(path, partition_cols=["first_name"])
-    chain = dc.from_parquet(path.as_uri(), session=test_session)
+    chain = dc.read_parquet(path.as_uri(), session=test_session)
     df1 = chain.select("first_name", "age", "city").to_pandas()
     df1 = df1.sort_values("first_name").reset_index(drop=True)
     assert df_equal(df1, df)
@@ -1682,7 +1682,7 @@ def test_to_parquet_partitioned(tmp_dir, test_session):
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
 @pytest.mark.parametrize("kwargs", ({}, {"compression": "gzip"}))
-def test_to_from_parquet(tmp_dir, test_session, chunk_size, kwargs):
+def test_to_read_parquet(tmp_dir, test_session, chunk_size, kwargs):
     df = pd.DataFrame(DF_DATA)
     dc_to = dc.read_pandas(df, session=test_session)
 
@@ -1692,14 +1692,14 @@ def test_to_from_parquet(tmp_dir, test_session, chunk_size, kwargs):
     assert path.is_file()
     pd.testing.assert_frame_equal(sort_df(pd.read_parquet(path)), sort_df(df))
 
-    dc_from = dc.from_parquet(path.as_uri(), session=test_session)
+    dc_from = dc.read_parquet(path.as_uri(), session=test_session)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
 
     assert df_equal(df1, df)
 
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
-def test_to_from_parquet_partitioned(tmp_dir, test_session, chunk_size):
+def test_to_read_parquet_partitioned(tmp_dir, test_session, chunk_size):
     df = pd.DataFrame(DF_DATA)
     dc_to = dc.read_pandas(df, session=test_session)
 
@@ -1715,14 +1715,14 @@ def test_to_from_parquet_partitioned(tmp_dir, test_session, chunk_size):
     df1 = df1.sort_values("first_name").reset_index(drop=True)
     pd.testing.assert_frame_equal(df1, df)
 
-    dc_from = dc.from_parquet(path.as_uri(), session=test_session)
+    dc_from = dc.read_parquet(path.as_uri(), session=test_session)
     df1 = dc_from.select("first_name", "age", "city").to_pandas()
     df1 = df1.sort_values("first_name").reset_index(drop=True)
     assert df1.equals(df)
 
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
-def test_to_from_parquet_features(tmp_dir, test_session, chunk_size):
+def test_to_read_parquet_features(tmp_dir, test_session, chunk_size):
     dc_to = dc.from_values(f1=features, num=range(len(features)), session=test_session)
 
     path = tmp_dir / "test.parquet"
@@ -1730,7 +1730,7 @@ def test_to_from_parquet_features(tmp_dir, test_session, chunk_size):
 
     assert path.is_file()
 
-    dc_from = dc.from_parquet(path.as_uri(), session=test_session)
+    dc_from = dc.read_parquet(path.as_uri(), session=test_session)
 
     n = 0
     for sample in dc_from.order_by("f1.nnn", "f1.count").select("f1", "num").collect():
@@ -1748,7 +1748,7 @@ def test_to_from_parquet_features(tmp_dir, test_session, chunk_size):
 
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
-def test_to_from_parquet_nested_features(tmp_dir, test_session, chunk_size):
+def test_to_read_parquet_nested_features(tmp_dir, test_session, chunk_size):
     dc_to = dc.from_values(sign1=features_nested, session=test_session)
 
     path = tmp_dir / "test.parquet"
@@ -1756,7 +1756,7 @@ def test_to_from_parquet_nested_features(tmp_dir, test_session, chunk_size):
 
     assert path.is_file()
 
-    dc_from = dc.from_parquet(path.as_uri(), session=test_session)
+    dc_from = dc.read_parquet(path.as_uri(), session=test_session)
 
     for n, sample in enumerate(
         dc_from.order_by("sign1.fr.nnn", "sign1.fr.count").select("sign1").collect()
@@ -1769,7 +1769,7 @@ def test_to_from_parquet_nested_features(tmp_dir, test_session, chunk_size):
 
 
 @pytest.mark.parametrize("chunk_size", (1000, 2))
-def test_to_from_parquet_two_top_level_features(tmp_dir, test_session, chunk_size):
+def test_to_read_parquet_two_top_level_features(tmp_dir, test_session, chunk_size):
     dc_to = dc.from_values(f1=features, nest1=features_nested, session=test_session)
 
     path = tmp_dir / "test.parquet"
@@ -1777,7 +1777,7 @@ def test_to_from_parquet_two_top_level_features(tmp_dir, test_session, chunk_siz
 
     assert path.is_file()
 
-    dc_from = dc.from_parquet(path.as_uri(), session=test_session)
+    dc_from = dc.read_parquet(path.as_uri(), session=test_session)
 
     for n, sample in enumerate(
         dc_from.order_by("f1.nnn", "f1.count").select("f1", "nest1").collect()
@@ -2415,12 +2415,12 @@ def test_read_pandas_nan_inf(test_session):
     assert any(r for r in res if np.isneginf(r))
 
 
-def test_from_parquet_nan_inf(tmp_dir, test_session):
+def test_read_parquet_nan_inf(tmp_dir, test_session):
     vals = [float("nan"), float("inf"), float("-inf")]
     tbl = pa.table({"vals": vals})
     path = tmp_dir / "test.parquet"
     pq.write_table(tbl, path)
-    chain = dc.from_parquet(path.as_uri(), session=test_session)
+    chain = dc.read_parquet(path.as_uri(), session=test_session)
 
     res = list(chain.collect("vals"))
     assert len(res) == 3

--- a/tests/unit/lib/test_datachain_bootstrap.py
+++ b/tests/unit/lib/test_datachain_bootstrap.py
@@ -26,7 +26,7 @@ def test_udf():
             self.value = MyMapper.TEARDOWN_VALUE
 
     vals = ["a", "b", "c", "d", "e", "f"]
-    chain = dc.from_values(key=vals)
+    chain = dc.read_values(key=vals)
 
     udf = MyMapper()
     res = list(chain.map(res=udf).collect("res"))
@@ -52,7 +52,7 @@ def test_no_bootstrap_for_callable():
 
     udf = MyMapper()
 
-    chain = dc.from_values(key=["a", "b", "c"])
+    chain = dc.read_values(key=["a", "b", "c"])
     list(chain.map(res=udf).collect())
 
     assert udf._had_bootstrap is False
@@ -64,7 +64,7 @@ def test_bootstrap_in_chain():
     prime = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
 
     res = list(
-        dc.from_values(val=prime)
+        dc.read_values(val=prime)
         .setup(init_val=lambda: base)
         .map(x=lambda val, init_val: val + init_val, output=int)
         .order_by("x")
@@ -77,7 +77,7 @@ def test_bootstrap_in_chain():
 def test_vars_duplication_error():
     with pytest.raises(DatasetPrepareError):
         (
-            dc.from_values(val=[2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
+            dc.read_values(val=[2, 3, 5, 7, 11, 13, 17, 19, 23, 29])
             .setup(init_val=lambda: 11, connection=lambda: 123)
             .setup(init_val=lambda: 599)
         )

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -49,8 +49,8 @@ team = [
 
 
 def test_merge_objects(test_session):
-    ch1 = dc.from_values(emp=employees, session=test_session)
-    ch2 = dc.from_values(team=team, session=test_session)
+    ch1 = dc.read_values(emp=employees, session=test_session)
+    ch2 = dc.read_values(team=team, session=test_session)
     ch = ch1.merge(ch2, "emp.person.name", "team.player")
 
     str_default = String.default_value(test_session.catalog.warehouse.db.dialect)
@@ -84,8 +84,8 @@ def test_merge_objects(test_session):
 
 @pytest.mark.parametrize("multiple_predicates", [True, False])
 def test_merge_objects_full_join(test_session, multiple_predicates):
-    ch1 = dc.from_values(emp=employees, session=test_session)
-    ch2 = dc.from_values(team=team, session=test_session)
+    ch1 = dc.read_values(emp=employees, session=test_session)
+    ch2 = dc.read_values(team=team, session=test_session)
     if multiple_predicates:
         ch = ch1.merge(
             ch2,
@@ -135,8 +135,8 @@ def test_merge_similar_objects(test_session):
         Employee(id=154, person=User(name="David", age=29)),
     ]
 
-    ch1 = dc.from_values(emp=employees, session=test_session)
-    ch2 = dc.from_values(emp=new_employees, session=test_session)
+    ch1 = dc.read_values(emp=employees, session=test_session)
+    ch2 = dc.read_values(emp=new_employees, session=test_session)
 
     rname = "qq"
     ch = ch1.merge(ch2, "emp.person.name", rname=rname)
@@ -160,9 +160,9 @@ def test_merge_similar_objects_in_memory():
         Employee(id=154, person=User(name="David", age=29)),
     ]
 
-    ch1 = dc.from_values(emp=employees, in_memory=True)
+    ch1 = dc.read_values(emp=employees, in_memory=True)
     # This should use the same session as above (in_memory=True automatically)
-    ch2 = dc.from_values(emp=new_employees)
+    ch2 = dc.read_values(emp=new_employees)
     assert ch1.session.catalog.in_memory is True
     assert ch1.session.catalog.metastore.db.db_file == ":memory:"
     assert ch1.session.catalog.warehouse.db.db_file == ":memory:"
@@ -193,8 +193,8 @@ def test_merge_values(test_session):
     delivery_ids = [11, 44]
     delivery_time = [24.0, 16.5]
 
-    ch1 = dc.from_values(id=order_ids, descr=order_descr, session=test_session)
-    ch2 = dc.from_values(id=delivery_ids, time=delivery_time, session=test_session)
+    ch1 = dc.read_values(id=order_ids, descr=order_descr, session=test_session)
+    ch2 = dc.read_values(id=delivery_ids, time=delivery_time, session=test_session)
 
     ch = ch1.merge(ch2, "id")
 
@@ -235,10 +235,10 @@ def test_merge_multi_conditions(test_session):
     delivery_name = ["water", "unknown"]
     delivery_time = [24.0, 16.5]
 
-    ch1 = dc.from_values(
+    ch1 = dc.read_values(
         id=order_ids, name=order_name, descr=order_descr, session=test_session
     )
-    ch2 = dc.from_values(
+    ch2 = dc.read_values(
         id=delivery_ids, d_name=delivery_name, time=delivery_time, session=test_session
     )
 
@@ -256,8 +256,8 @@ def test_merge_multi_conditions(test_session):
 
 
 def test_merge_errors(test_session):
-    ch1 = dc.from_values(emp=employees, session=test_session)
-    ch2 = dc.from_values(team=team, session=test_session)
+    ch1 = dc.read_values(emp=employees, session=test_session)
+    ch2 = dc.read_values(team=team, session=test_session)
 
     with pytest.raises(DatasetMergeError):
         ch1.merge(ch2, "unknown")
@@ -287,7 +287,7 @@ def test_merge_errors(test_session):
 
 
 def test_merge_with_itself(test_session):
-    ch = dc.from_values(emp=employees, session=test_session)
+    ch = dc.read_values(emp=employees, session=test_session)
     merged = ch.merge(ch, "emp.id")
 
     count = 0
@@ -301,7 +301,7 @@ def test_merge_with_itself(test_session):
 
 
 def test_merge_with_itself_column(test_session):
-    ch = dc.from_values(emp=employees, session=test_session)
+    ch = dc.read_values(emp=employees, session=test_session)
     merged = ch.merge(ch, C("emp.id"))
 
     count = 0
@@ -319,7 +319,7 @@ def test_merge_on_expression(test_session):
         c = chain.c("team.sport")
         return func.substr(c, func.length(c) - 3)
 
-    chain = dc.from_values(team=team, session=test_session)
+    chain = dc.read_values(team=team, session=test_session)
     right_dc = chain.clone()
 
     # cross join on "ball" from sport

--- a/tests/unit/lib/test_diff.py
+++ b/tests/unit/lib/test_diff.py
@@ -125,7 +125,7 @@ def test_compare_no_status_col(test_session, str_default):
     assert list(diff.order_by("id").collect()) == expected
 
 
-def test_compare_from_datasets(test_session, str_default):
+def test_compare_read_hfs(test_session, str_default):
     ds1 = dc.from_values(
         id=[1, 2, 4],
         name=["John1", "Doe", "Andy"],
@@ -139,8 +139,8 @@ def test_compare_from_datasets(test_session, str_default):
     ).save("ds2")
 
     # this adds sys columns to ds1 and ds2
-    ds1 = dc.from_dataset("ds1")
-    ds2 = dc.from_dataset("ds2")
+    ds1 = dc.read_dataset("ds1")
+    ds2 = dc.read_dataset("ds2")
 
     diff = ds1.compare(ds2, same=True, on=["id"], status_col="diff")
 

--- a/tests/unit/lib/test_diff.py
+++ b/tests/unit/lib/test_diff.py
@@ -29,13 +29,13 @@ def int_default(test_session):
 @pytest.mark.parametrize("modified", (True, False))
 @pytest.mark.parametrize("same", (True, False))
 def test_compare(test_session, str_default, added, deleted, modified, same):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John1", "Doe", "Andy"],
         session=test_session,
     )
 
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         session=test_session,
@@ -96,13 +96,13 @@ def test_compare(test_session, str_default, added, deleted, modified, same):
 
 
 def test_compare_no_status_col(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John1", "Doe", "Andy"],
         session=test_session,
     )
 
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         session=test_session,
@@ -126,13 +126,13 @@ def test_compare_no_status_col(test_session, str_default):
 
 
 def test_compare_read_hfs(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John1", "Doe", "Andy"],
         session=test_session,
     ).save("ds1")
 
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         session=test_session,
@@ -154,7 +154,7 @@ def test_compare_read_hfs(test_session, str_default):
 
 @pytest.mark.parametrize("right_name", ("other_name", "name"))
 def test_compare_with_explicit_compare_fields(test_session, str_default, right_name):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John1", "Doe", "Andy"],
         city=["New York", "Boston", "San Francisco"],
@@ -168,7 +168,7 @@ def test_compare_with_explicit_compare_fields(test_session, str_default, right_n
         "session": test_session,
     }
 
-    ds2 = dc.from_values(**ds2_data).save("ds2")
+    ds2 = dc.read_values(**ds2_data).save("ds2")
 
     diff = ds1.compare(
         ds2,
@@ -191,13 +191,13 @@ def test_compare_with_explicit_compare_fields(test_session, str_default, right_n
 
 
 def test_compare_different_left_right_on_columns(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John1", "Doe", "Andy"],
         session=test_session,
     ).save("ds1")
 
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         other_id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         session=test_session,
@@ -224,7 +224,7 @@ def test_compare_different_left_right_on_columns(test_session, str_default):
 
 @pytest.mark.parametrize("on_self", (True, False))
 def test_compare_on_equal_datasets(test_session, on_self):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 3],
         name=["John", "Doe", "Andy"],
         session=test_session,
@@ -233,7 +233,7 @@ def test_compare_on_equal_datasets(test_session, on_self):
     if on_self:
         ds2 = ds1
     else:
-        ds2 = dc.from_values(
+        ds2 = dc.read_values(
             id=[1, 2, 3],
             name=["John", "Doe", "Andy"],
             session=test_session,
@@ -257,13 +257,13 @@ def test_compare_on_equal_datasets(test_session, on_self):
 
 
 def test_compare_multiple_columns(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John", "Doe", "Andy"],
         city=["London", "New York", "Tokyo"],
         session=test_session,
     )
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         city=["Paris", "Berlin", "Tokyo"],
@@ -289,13 +289,13 @@ def test_compare_multiple_columns(test_session, str_default):
 
 
 def test_compare_multiple_match_columns(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John", "Doe", "Andy"],
         city=["London", "New York", "Tokyo"],
         session=test_session,
     )
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "John", "Andy"],
         city=["Paris", "Berlin", "Tokyo"],
@@ -321,13 +321,13 @@ def test_compare_multiple_match_columns(test_session, str_default):
 
 
 def test_compare_additional_column_on_left(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John", "Doe", "Andy"],
         city=["London", "New York", "Tokyo"],
         session=test_session,
     ).save("ds1")
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         session=test_session,
@@ -352,12 +352,12 @@ def test_compare_additional_column_on_left(test_session, str_default):
 
 
 def test_compare_additional_column_on_right(test_session, str_default):
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         id=[1, 2, 4],
         name=["John", "Doe", "Andy"],
         session=test_session,
     )
-    ds2 = dc.from_values(
+    ds2 = dc.read_values(
         id=[1, 3, 4],
         name=["John", "Mark", "Andy"],
         city=["London", "New York", "Tokyo"],
@@ -378,8 +378,8 @@ def test_compare_additional_column_on_right(test_session, str_default):
 
 
 def test_compare_missing_on(test_session):
-    ds1 = dc.from_values(id=[1, 2, 4], session=test_session)
-    ds2 = dc.from_values(id=[1, 2, 4], session=test_session)
+    ds1 = dc.read_values(id=[1, 2, 4], session=test_session)
+    ds2 = dc.read_values(id=[1, 2, 4], session=test_session)
 
     with pytest.raises(ValueError) as exc_info:
         ds1.compare(ds2, on=None)
@@ -388,8 +388,8 @@ def test_compare_missing_on(test_session):
 
 
 def test_compare_right_on_wrong_length(test_session):
-    ds1 = dc.from_values(id=[1, 2, 4], session=test_session)
-    ds2 = dc.from_values(id=[1, 2, 4], session=test_session)
+    ds1 = dc.read_values(id=[1, 2, 4], session=test_session)
+    ds2 = dc.read_values(id=[1, 2, 4], session=test_session)
 
     with pytest.raises(ValueError) as exc_info:
         ds1.compare(ds2, on=["id"], right_on=["id", "name"])
@@ -398,8 +398,8 @@ def test_compare_right_on_wrong_length(test_session):
 
 
 def test_compare_right_compare_defined_but_not_compare(test_session):
-    ds1 = dc.from_values(id=[1, 2, 4], session=test_session)
-    ds2 = dc.from_values(id=[1, 2, 4], session=test_session)
+    ds1 = dc.read_values(id=[1, 2, 4], session=test_session)
+    ds2 = dc.read_values(id=[1, 2, 4], session=test_session)
 
     with pytest.raises(ValueError) as exc_info:
         ds1.compare(ds2, on=["id"], right_compare=["name"])
@@ -410,8 +410,8 @@ def test_compare_right_compare_defined_but_not_compare(test_session):
 
 
 def test_compare_right_compare_wrong_length(test_session):
-    ds1 = dc.from_values(id=[1, 2, 4], session=test_session)
-    ds2 = dc.from_values(id=[1, 2, 4], session=test_session)
+    ds1 = dc.read_values(id=[1, 2, 4], session=test_session)
+    ds2 = dc.read_values(id=[1, 2, 4], session=test_session)
 
     with pytest.raises(ValueError) as exc_info:
         ds1.compare(ds2, on=["id"], compare=["name"], right_compare=["name", "city"])
@@ -430,16 +430,16 @@ def test_diff(test_session, str_default, int_default, status_col, right_on):
     fs3 = File(source="s3", path="p3", version="1", etag="e1")
     fs4 = File(source="s4", path="p4", version="1", etag="e1")
 
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         file1=[fs1_updated, fs2, fs4], score=[1, 2, 4], session=test_session
     )
 
     if right_on:
-        ds2 = dc.from_values(
+        ds2 = dc.read_values(
             file2=[fs1, fs3, fs4], score=[1, 3, 4], session=test_session
         )
     else:
-        ds2 = dc.from_values(
+        ds2 = dc.read_values(
             file1=[fs1, fs3, fs4], score=[1, 3, 4], session=test_session
         )
 
@@ -487,10 +487,10 @@ def test_diff_nested(test_session, str_default, int_default, status_col):
     fs3 = Nested(file=File(source="s3", path="p3", version="1", etag="e1"))
     fs4 = Nested(file=File(source="s4", path="p4", version="1", etag="e1"))
 
-    ds1 = dc.from_values(
+    ds1 = dc.read_values(
         nested=[fs1_updated, fs2, fs4], score=[1, 2, 4], session=test_session
     )
-    ds2 = dc.from_values(nested=[fs1, fs3, fs4], score=[1, 3, 4], session=test_session)
+    ds2 = dc.read_values(nested=[fs1, fs3, fs4], score=[1, 3, 4], session=test_session)
 
     diff = ds1.diff(
         ds2,

--- a/tests/unit/lib/test_feature_utils.py
+++ b/tests/unit/lib/test_feature_utils.py
@@ -29,7 +29,7 @@ def test_e2e(test_session):
     fib = [1, 1, 2, 3, 5, 8]
     values = ["odd" if num % 2 else "even" for num in fib]
 
-    chain = dc.from_values(fib=fib, odds=values, session=test_session)
+    chain = dc.read_values(fib=fib, odds=values, session=test_session)
 
     vals = list(chain.order_by("fib").collect())
     lst1 = [item[0] for item in vals]
@@ -51,7 +51,7 @@ def test_single_value():
 def test_single_e2e(test_session):
     fib = [1, 1, 2, 3, 5, 8]
 
-    chain = dc.from_values(fib=fib, session=test_session)
+    chain = dc.read_values(fib=fib, session=test_session)
 
     vals = list(chain.order_by("fib").collect())
     flattened = [item for sublist in vals for item in sublist]
@@ -61,17 +61,17 @@ def test_single_e2e(test_session):
 
 def test_not_array_value_error():
     with pytest.raises(ValuesToTupleError):
-        dc.from_values(value=True)
+        dc.read_values(value=True)
 
 
 def test_empty_value_list_error():
     with pytest.raises(ValuesToTupleError):
-        dc.from_values(value=[])
+        dc.read_values(value=[])
 
 
 def test_features_length_missmatch():
     with pytest.raises(ValuesToTupleError):
-        dc.from_values(value1=[1, 2, 3], value2=[1, 2, 3, 4, 5])
+        dc.read_values(value1=[1, 2, 3], value2=[1, 2, 3, 4, 5])
 
 
 def test_unknown_output_type():
@@ -81,22 +81,22 @@ def test_unknown_output_type():
             def __init__(self, val):
                 self.val = val
 
-        dc.from_values(value1=[UnknownFrType(1), UnknownFrType(23)])
+        dc.read_values(value1=[UnknownFrType(1), UnknownFrType(23)])
 
 
 def test_output_type_missmatch():
     with pytest.raises(ValuesToTupleError):
-        dc.from_values(value1=[1, 2, 3], output={"res": str})
+        dc.read_values(value1=[1, 2, 3], output={"res": str})
 
 
 def test_output_length_missmatch():
     with pytest.raises(ValuesToTupleError):
-        dc.from_values(value1=[1, 2, 3], output={"out1": int, "out2": int})
+        dc.read_values(value1=[1, 2, 3], output={"out1": int, "out2": int})
 
 
 def test_output_spec_wrong_type():
     with pytest.raises(ValuesToTupleError):
-        dc.from_values(value1=[1, 2, 3], output=123)
+        dc.read_values(value1=[1, 2, 3], output=123)
 
 
 def test_resolve_column():

--- a/tests/unit/lib/test_schema.py
+++ b/tests/unit/lib/test_schema.py
@@ -12,7 +12,7 @@ def test_column_filter_by_regex(test_session):
         "dog.txtx",
     ]
 
-    chain = dc.from_values(file=[File(path=p) for p in names]).filter(
+    chain = dc.read_values(file=[File(path=p) for p in names]).filter(
         dc.C("file.path").regexp("dog\\.txt$")
     )
 

--- a/tests/unit/sql/test_selectable.py
+++ b/tests/unit/sql/test_selectable.py
@@ -22,6 +22,6 @@ def test_select_values(warehouse, query):
         select("letter", "int").select_from(values(DATA, ["letter", "float", "int"])),
     ],
 )
-def test_select_from_values(warehouse, query):
+def test_select_read_values(warehouse, query):
     result = list(warehouse.db.execute(query))
     assert result == [("a", 100), ("b", 200), ("c", 300), ("d", 400)]

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -27,7 +27,7 @@ from tests.utils import skip_if_not_sqlite
 
 @pytest.fixture()
 def chain():
-    return dc.from_values(
+    return dc.read_values(
         num=list(range(1, 6)),
         val=["x" * i for i in range(1, 6)],
     )
@@ -853,7 +853,7 @@ def test_ifelse_mutate_with_columns_as_values(chain, if_val, else_val, type_, re
 @pytest.mark.parametrize("col", ["val", dc.C("val")])
 @skip_if_not_sqlite
 def test_isnone_mutate(col):
-    chain = dc.from_values(
+    chain = dc.read_values(
         num=list(range(1, 6)),
         val=[None if i > 3 else "A" for i in range(1, 6)],
     )
@@ -868,7 +868,7 @@ def test_isnone_mutate(col):
 @pytest.mark.parametrize("col", [dc.C("val"), "val"])
 @skip_if_not_sqlite
 def test_isnone_with_ifelse_mutate(col):
-    chain = dc.from_values(
+    chain = dc.read_values(
         num=list(range(1, 6)),
         val=[None if i > 3 else "A" for i in range(1, 6)],
     )
@@ -879,7 +879,7 @@ def test_isnone_with_ifelse_mutate(col):
 
 
 def test_array_contains():
-    chain = dc.from_values(
+    chain = dc.read_values(
         arr=[list(range(1, i)) * i for i in range(2, 7)],
         val=list(range(2, 7)),
     )

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -40,7 +40,7 @@ def _tree_to_entries(tree: dict, path=""):
 def listing(test_session):
     catalog = test_session.catalog
     dataset_name, _, _, _ = get_listing("file:///whatever", test_session)
-    dc.from_values(file=list(_tree_to_entries(TREE))).save(dataset_name, listing=True)
+    dc.read_values(file=list(_tree_to_entries(TREE))).save(dataset_name, listing=True)
 
     return Listing(
         catalog.metastore.clone(),
@@ -55,14 +55,14 @@ def test_get_listing_returns_exact_math_on_update(test_session):
     # Context: https://github.com/iterative/datachain/pull/726
     # On update it should be returning the exact match (not a "bigger" one)
     dataset_name_dir1, _, _, exists = get_listing("file:///whatever/dir1", test_session)
-    dc.from_values(file=list(_tree_to_entries(TREE["dir1"]))).save(
+    dc.read_values(file=list(_tree_to_entries(TREE["dir1"]))).save(
         dataset_name_dir1, listing=True
     )
     assert dataset_name_dir1 == f"{LISTING_PREFIX}file:///whatever/dir1/"
     assert not exists
 
     dataset_name, _, _, exists = get_listing("file:///whatever", test_session)
-    dc.from_values(file=list(_tree_to_entries(TREE))).save(dataset_name, listing=True)
+    dc.read_values(file=list(_tree_to_entries(TREE))).save(dataset_name, listing=True)
     assert dataset_name == f"{LISTING_PREFIX}file:///whatever/"
     assert not exists
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -108,7 +108,7 @@ def create_tar_dataset_with_legacy_columns(
     The resulting dataset contains both the original files (as regular objects)
     and the tar members (as v-objects).
     """
-    chain = dc.from_storage(uri, session=session)
+    chain = dc.read_storage(uri, session=session)
     tar_entries = chain.filter(C("file.path").glob("*.tar")).gen(file=process_tar)
     return (
         chain.union(tar_entries)


### PR DESCRIPTION
- **Rename from_storage to read_storage**
- **Rename from_csv to read_csv**
- **Rename from_hf to read_hf**
- **Rename from_dataset to read_dataset**
- **Rename from json to read json**
- **Rename from_pandas to read_pandas**
- **Rename from_parquet to read_parquet**
- **Rename from_records to read_records**
- **Rename from_values to read_values**


I decided not to update to_x to write_x because write_storage doesn't makes sense in our context. We are writing to storage but not writing storage itself and so on. 
It is also in line with other tools like  https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_parquet.html#pandas-dataframe-to-parquet

cc. @dmpetrov 


Closes #984 
