### PR TITLE
Restrict pydantic less that 2.11 to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "multiprocess==0.70.16",
   "cloudpickle",
   "orjson>=3.10.5",
-  "pydantic>=2,<3",
+  "pydantic>=2,<2.11",
   "jmespath>=1.0",
   "datamodel-code-generator>=0.25",
   "Pillow>=10.0.0,<12",


### PR DESCRIPTION
With recent release in pydantic, the pickling is not working as
expected. This restricts the pydantic to 2.10.6 untill we fix the
breaking changes.

Relevant links:
- https://github.com/pydantic/pydantic/releases/tag/v2.11.0
- https://github.com/pydantic/pydantic/pull/11032
- https://iterativeai.slack.com/archives/C04A9RWEZBN/p1743143098907759
