### PR TITLE
Fix to not show temp datasets

### DIFF
--- a/src/datachain/lib/dataset_info.py
+++ b/src/datachain/lib/dataset_info.py
@@ -12,6 +12,7 @@ from datachain.dataset import (
 )
 from datachain.job import Job
 from datachain.lib.data_model import DataModel
+from datachain.query.session import Session
 from datachain.utils import TIME_ZERO
 
 if TYPE_CHECKING:
@@ -31,6 +32,10 @@ class DatasetInfo(DataModel):
     metrics: dict[str, Any] = Field(default={})
     error_message: str = Field(default="")
     error_stack: str = Field(default="")
+
+    @property
+    def is_temp(self) -> bool:
+        return Session.is_temp_dataset(self.name)
 
     @staticmethod
     def _validate_dict(

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -140,6 +140,8 @@ def datasets(
         )
     ]
 
+    datasets_values = [d for d in datasets_values if not d.is_temp]
+
     return read_values(
         session=session,
         settings=settings,

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -100,6 +100,10 @@ class Session:
     def get_temp_prefix(self) -> str:
         return f"{self.DATASET_PREFIX}{self.name}_"
 
+    @classmethod
+    def is_temp_dataset(cls, name) -> bool:
+        return name.startswith(cls.DATASET_PREFIX)
+
     def _cleanup_temp_datasets(self) -> None:
         prefix = self.get_temp_prefix()
         try:

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -538,7 +538,7 @@ def test_show(capsys, test_session):
         assert f"{i} {first_name[i]}" in normalized_output
 
 
-def test_show_temp_datasets(capsys, test_session):
+def test_show_without_temp_datasets(capsys, test_session):
     dc.read_values(
         key=[1, 2, 3, 4], session=test_session
     ).save()  # creates temp dataset

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -538,6 +538,17 @@ def test_show(capsys, test_session):
         assert f"{i} {first_name[i]}" in normalized_output
 
 
+def test_show_temp_datasets(capsys, test_session):
+    dc.read_values(
+        key=[1, 2, 3, 4], session=test_session
+    ).save()  # creates temp dataset
+    dc.datasets().show()
+    captured = capsys.readouterr()
+    normalized_output = re.sub(r"\s+", " ", captured.out)
+    print(normalized_output)
+    assert "Empty result" in normalized_output
+
+
 def test_class_method_deprecated(capsys, test_session):
     with pytest.warns(DeprecationWarning):
         dc.DataChain.from_values(key=["a", "b", "c"], session=test_session)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -47,6 +47,18 @@ def test_session_empty_name():
     assert name.startswith(Session.GLOBAL_SESSION_NAME + "_")
 
 
+@pytest.mark.parametrize(
+    "name,is_temp",
+    (
+        ("session_global_456b5d_0cda3b", True),
+        ("session_TestSession_456b5d_0cda3b", True),
+        ("cats", False),
+    ),
+)
+def test_is_temp_dataset(name, is_temp):
+    assert Session.is_temp_dataset(name) is is_temp
+
+
 def test_ephemeral_dataset_lifecycle(catalog):
     session_name = "asd3d4"
     with Session(session_name, catalog=catalog) as session:


### PR DESCRIPTION
Fixing `dc.datasets().show()` not to show temp datasets.