### PR TITLE
Better error hadling in `.select_except()`

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -87,6 +87,12 @@ class SignalResolvingTypeError(SignalResolvingError):
         )
 
 
+class SignalRemoveError(SignalSchemaError):
+    def __init__(self, path: Optional[list[str]], msg: str):
+        name = " '" + ".".join(path) + "'" if path else ""
+        super().__init__(f"cannot remove signal name{name}: {msg}")
+
+
 class CustomType(BaseModel):
     schema_version: int = Field(ge=1, le=2, strict=True)
     name: str
@@ -631,11 +637,10 @@ class SignalSchema:
 
             if signal not in self.values:
                 if has_signal(signal):
-                    raise SignalResolvingError(
+                    raise SignalRemoveError(
                         signal.split("."),
-                        "select_except() error - cannot remove nested signal since"
-                        " that is going to break it's parent schema which is not"
-                        " currently supported",
+                        "select_except() error - removing nested signal would"
+                        " break parent schema, which isn't supported.",
                     )
                 raise SignalResolvingError(
                     signal.split("."),

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -620,18 +620,28 @@ class SignalSchema:
         return curr_type
 
     def select_except_signals(self, *args: str) -> "SignalSchema":
-        schema = copy.deepcopy(self.values)
-        for field in args:
-            if not isinstance(field, str):
-                raise SignalResolvingTypeError("select_except()", field)
+        def has_signal(signal: str):
+            signal = signal.replace(".", DEFAULT_DELIMITER)
+            return any(signal == s for s in self.db_signals())
 
-            if field not in self.values:
+        schema = copy.deepcopy(self.values)
+        for signal in args:
+            if not isinstance(signal, str):
+                raise SignalResolvingTypeError("select_except()", signal)
+
+            if signal not in self.values:
+                if has_signal(signal):
+                    raise SignalResolvingError(
+                        signal.split("."),
+                        "select_except() error - cannot remove nested signal since"
+                        " that is going to break it's parent schema which is not"
+                        " currently supported",
+                    )
                 raise SignalResolvingError(
-                    field.split("."),
-                    "select_except() error - the feature name does not exist or "
-                    "inside of feature (not supported)",
+                    signal.split("."),
+                    "select_except() error - the signal does not exist",
                 )
-            del schema[field]
+            del schema[signal]
 
         return SignalSchema(schema)
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -22,6 +22,7 @@ from datachain.lib.file import File
 from datachain.lib.listing import LISTING_PREFIX
 from datachain.lib.listing_info import ListingInfo
 from datachain.lib.signal_schema import (
+    SignalRemoveError,
     SignalResolvingError,
     SignalResolvingTypeError,
     SignalSchema,
@@ -937,20 +938,11 @@ def test_select_wrong_type(test_session):
 def test_select_except_error(test_session):
     chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
-    with pytest.raises(SignalResolvingError) as exc_info:
+    with pytest.raises(SignalResolvingError):
         list(chain.select_except("not_exist", "file").collect())
-    assert str(exc_info.value) == (
-        "cannot resolve signal name 'not_exist': select_except() error -"
-        " the signal does not exist"
-    )
 
-    with pytest.raises(SignalResolvingError) as exc_info:
+    with pytest.raises(SignalRemoveError):
         list(chain.select_except("fr1.label", "file").collect())
-    assert str(exc_info.value) == (
-        "cannot resolve signal name 'fr1.label': select_except() error - cannot"
-        " remove nested signal since that is going to break it's parent schema"
-        " which is not currently supported"
-    )
 
 
 def test_select_restore_from_saving(test_session):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -937,11 +937,20 @@ def test_select_wrong_type(test_session):
 def test_select_except_error(test_session):
     chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
-    with pytest.raises(SignalResolvingError):
+    with pytest.raises(SignalResolvingError) as exc_info:
         list(chain.select_except("not_exist", "file").collect())
+    assert str(exc_info.value) == (
+        "cannot resolve signal name 'not_exist': select_except() error -"
+        " the signal does not exist"
+    )
 
-    with pytest.raises(SignalResolvingError):
+    with pytest.raises(SignalResolvingError) as exc_info:
         list(chain.select_except("fr1.label", "file").collect())
+    assert str(exc_info.value) == (
+        "cannot resolve signal name 'fr1.label': select_except() error - cannot"
+        " remove nested signal since that is going to break it's parent schema"
+        " which is not currently supported"
+    )
 
 
 def test_select_restore_from_saving(test_session):

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -10,6 +10,7 @@ from datachain.lib.file import File, TextFile
 from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import (
     SetupError,
+    SignalRemoveError,
     SignalResolvingError,
     SignalSchema,
     SignalSchemaError,
@@ -590,7 +591,7 @@ def test_select_except_signals():
 def test_select_except_signals_error():
     schema = SignalSchema({"age": float, "address": str, "f": MyType1})
 
-    with pytest.raises(SignalResolvingError):
+    with pytest.raises(SignalRemoveError):
         schema.select_except_signals("address", "f.aa")
 
     with pytest.raises(SignalResolvingError):


### PR DESCRIPTION
Splitting error messages when signal is not found and when trying to remove nested signal which is not supported.
Also making error message little bit better.