### PR TITLE
Added `DataChain.persist()`

### DIFF
--- a/examples/multimodal/wds_filtered.py
+++ b/examples/multimodal/wds_filtered.py
@@ -27,7 +27,7 @@ filtered = (
         / func.least("laion.json.original_width", "laion.json.original_height")
         < 3.0
     )
-    .save()
+    .persist()
 )
 
 filtered.show(3)

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -444,8 +444,11 @@ class DataChain:
         return listings(*args, **kwargs)
 
     def persist(self) -> "Self":
-        """Save to temporary dataset that will be removed after the process ends.
-        Temporary datasets are useful for optimization.
+        """Saves temporary chain that will be removed after the process ends.
+        Temporary datasets are useful for optimization, for example when we have
+        multiple chains starting with identical sub-chain. We can then persist that
+        common chain and use it to calculate other chains, to avoid re-calculation
+        every time.
         It returns the chain itself.
         """
         schema = self.signals_schema.clone_without_sys_signals().serialize()

--- a/tests/func/test_catalog.py
+++ b/tests/func/test_catalog.py
@@ -505,7 +505,7 @@ def test_dataset_stats(test_session):
         ids=ids,
         file=[dc.File(path=name, size=size) for name, size in values],
         session=test_session,
-    ).save()
+    ).persist()
     dataset_version1 = test_session.catalog.get_dataset(ds1.name).get_version(1)
     assert dataset_version1.num_objects == 3
     assert dataset_version1.size == 6
@@ -515,7 +515,7 @@ def test_dataset_stats(test_session):
         file1=[dc.File(path=name, size=size) for name, size in values],
         file2=[dc.File(path=name, size=size * 2) for name, size in values],
         session=test_session,
-    ).save()
+    ).persist()
     dataset_version2 = test_session.catalog.get_dataset(ds2.name).get_version(1)
     assert dataset_version2.num_objects == 3
     assert dataset_version2.size == 18
@@ -561,7 +561,7 @@ def test_ls_datasets_no_json(test_session):
         ids=ids,
         file=[dc.File(path=name, size=size) for name, size in values],
         session=test_session,
-    ).save()
+    ).persist()
     datasets = test_session.catalog.ls_datasets()
     assert datasets
     for d in datasets:

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -282,7 +282,7 @@ def test_map_file(cloud_test_catalog, use_cache, prefetch):
         dc.read_storage(ctc.src_uri, session=ctc.session)
         .settings(cache=use_cache, prefetch=prefetch)
         .map(signal=with_checks(new_signal))
-        .save()
+        .persist()
     )
 
     expected = {
@@ -541,7 +541,7 @@ def test_show(capsys, test_session):
 def test_show_without_temp_datasets(capsys, test_session):
     dc.read_values(
         key=[1, 2, 3, 4], session=test_session
-    ).save()  # creates temp dataset
+    ).persist()  # creates temp dataset
     dc.datasets().show()
     captured = capsys.readouterr()
     normalized_output = re.sub(r"\s+", " ", captured.out)
@@ -1230,7 +1230,7 @@ def test_udf_after_limit(cloud_test_catalog):
     chain = (
         dc.read_storage(ctc.src_uri, session=ctc.session)
         .mutate(name=pathfunc.name("file.path"))
-        .save()
+        .persist()
     )
     # We test a few different orderings here, because we've had strange
     # bugs in the past where calling add_signals() after limit() gave us
@@ -1578,7 +1578,7 @@ def test_gen_file(cloud_test_catalog, use_cache, prefetch):
         dc.read_storage(ctc.src_uri, session=ctc.session)
         .settings(cache=use_cache, prefetch=prefetch)
         .gen(signal=with_checks(new_signal), output=str)
-        .save()
+        .persist()
     )
     expected = {
         "Cats and Dogs",

--- a/tests/func/test_hidden_field.py
+++ b/tests/func/test_hidden_field.py
@@ -61,7 +61,7 @@ def test_datachain_save(test_session):
     inner = InnerClass(inner_value=1.1, hide_inner=1.2)
     outer = OuterClass(outer_value=1.3, hide_outer=1.4, inner_object=inner)
 
-    ds = dc.read_values(outer=[outer], nums=[1], session=test_session).save()
+    ds = dc.read_values(outer=[outer], nums=[1], session=test_session).persist()
 
     version = test_session.catalog.get_dataset(ds.name).get_version(1)
     feature_schema = version.feature_schema

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1032,7 +1032,7 @@ def test_chain_of_maps(test_session):
     for signal in signals:
         assert signal in chain.schema
 
-    preserved = chain.save()
+    preserved = chain.persist()
     for signal in signals:
         assert signal in preserved.schema
 
@@ -2405,7 +2405,7 @@ def test_mutate_with_expression_without_type(test_session):
     with pytest.raises(DataChainColumnError) as excinfo:
         dc.read_values(id=[1, 2], session=test_session).mutate(
             new=(Column("id") - 1)
-        ).save()
+        ).persist()
 
     assert str(excinfo.value) == (
         "Error for column new: Cannot infer type with expression id - :id_1"


### PR DESCRIPTION
Added new method to create temp datasets `.persist()`. Old way to create temp datasets was to call `.save()` without name but now name is mandatory in `.save()`.