### PR TITLE
Added `DataChain.storage_switch()` method

### DIFF
--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -3071,7 +3071,7 @@ def test_storage_switch(test_session):
     assert all(source == new_storage for source in ds.collect("file.source"))
 
 
-def test_storage_switch_only_some_files(test_session):
+def test_storage_switch_with_explicit_old_storage(test_session):
     old_storage1 = "s3://old_1"
     old_storage2 = "s3://old_2"
     new_storage = "s3://new"


### PR DESCRIPTION
Added `DataChain.storage_switch()` method to update `source` column with new storage value (e.g different s3 bucket).
Optionally `old_storage` argument can be passed so only those rows with `old_storage` values are updated which can be convenient when dataset has multiple sources and we only want to update one of those.

TODO:

- [ ] Reset `version`, `etag`, `last_modified` and `size`
- [ ] Create new method called `bucket_update()` to update `version`, `etag`, `last_modified`