### PR TITLE
Add DATACHAIN_DISTRIBUTED_PYTHONPATH env variable

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -437,9 +437,17 @@ class UDFStep(Step, ABC):
                             "distributed processing."
                         )
 
-                    from datachain.catalog.loader import get_udf_distributor_class
+                    from datachain.catalog.loader import (
+                        DISTRIBUTED_IMPORT_PATH,
+                        get_udf_distributor_class,
+                    )
 
-                    udf_distributor_class = get_udf_distributor_class()
+                    if not (udf_distributor_class := get_udf_distributor_class()):
+                        raise RuntimeError(
+                            f"{DISTRIBUTED_IMPORT_PATH} import path is required "
+                            "for distributed UDF processing."
+                        )
+
                     udf_distributor = udf_distributor_class(
                         catalog=catalog,
                         table=udf_table,

--- a/src/datachain/query/dispatch.py
+++ b/src/datachain/query/dispatch.py
@@ -13,7 +13,7 @@ from multiprocess import get_context
 
 from datachain.catalog import Catalog
 from datachain.catalog.catalog import clone_catalog_with_cache
-from datachain.catalog.loader import get_udf_distributor_class
+from datachain.catalog.loader import DISTRIBUTED_IMPORT_PATH, get_udf_distributor_class
 from datachain.lib.udf import _get_cache
 from datachain.query.batch import RowsOutput, RowsOutputBatch
 from datachain.query.dataset import (
@@ -91,7 +91,12 @@ def udf_entrypoint() -> int:
 
 
 def udf_worker_entrypoint() -> int:
-    return get_udf_distributor_class().run_worker()
+    if not (udf_distributor_class := get_udf_distributor_class()):
+        raise RuntimeError(
+            f"{DISTRIBUTED_IMPORT_PATH} import path is required "
+            "for distributed UDF processing."
+        )
+    return udf_distributor_class.run_worker()
 
 
 class UDFDispatcher:


### PR DESCRIPTION
Add `DATACHAIN_DISTRIBUTED_PYTHONPATH` env variable to be able to set `PYTHONPATH` for the `DATACHAIN_DISTRIBUTED` module.

Not useful right now, but will be used later in the follow-up distributed compute updates.