### PR TITLE
Limit pyarrow version to be <20.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "numpy>=1,<3",
   "pandas>=2.0.0",
   "packaging",
-  "pyarrow",
+  "pyarrow<20",
   "typing-extensions",
   "python-dateutil>=2",
   "attrs>=21.3.0",


### PR DESCRIPTION
With latest pyarrow [20.0.0](https://github.com/apache/arrow/releases/tag/apache-arrow-20.0.0) release we now have tests broken.

<details>
    <summary>pytest run output</summary>


    $ pytest tests/unit/lib/test_hf.py -k test_hf_array
    Test session starts (platform: darwin, Python 3.13.2, pytest 8.3.5, pytest-sugar 1.0.0)
    benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
    rootdir: /Users/vlad/work/iterative/datachain
    configfile: pyproject.toml
    plugins: servers-0.5.10, cov-6.0.0, hypothesis-6.129.4, sugar-1.0.0, benchmark-5.1.0, mock-3.14.0, xdist-3.6.1, requests-mock-1.12.1
    collected 6 items / 5 deselected / 1 selected


    ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_hf_array ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

        def test_hf_array():
            ds = Dataset.from_dict({"arr": [[[0, 1], [2, 3]]]})
            new_features = ds.features.copy()
            new_features["arr"] = Array2D(shape=(2, 2), dtype="int32")
            ds = ds.cast(new_features)
            schema = get_output_schema(ds.features)
            assert schema["arr"] == list[list[int]]

            gen = HFGenerator(ds, dict_to_data_model("", schema))
            gen.setup()
    >       row = next(iter(gen.process()))

    /Users/vlad/work/iterative/datachain/tests/unit/lib/test_hf.py:88:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    /Users/vlad/work/iterative/datachain/src/datachain/lib/hf.py:99: in process
        for row in ds:
    /Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/datasets/arrow_dataset.py:2387: in __iter__
        formatted_output = format_table(
    /Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/datasets/formatting/formatting.py:666: in format_table
        formatted_output = formatter(pa_table_to_format, query_type=query_type)
    /Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/datasets/formatting/formatting.py:411: in __call__
        return self.format_row(pa_table)
    /Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/datasets/formatting/formatting.py:459: in format_row
        row = self.python_arrow_extractor().extract_row(pa_table)
    /Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/datasets/formatting/formatting.py:145: in extract_row
        return _unnest(pa_table.to_pydict())
    pyarrow/table.pxi:2308: in pyarrow.lib._Tabular.to_pydict
        ???
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    >   ???
    E   TypeError: ArrayExtensionArray.to_pylist() got an unexpected keyword argument 'maps_as_pydicts'

    pyarrow/table.pxi:1380: TypeError
    -------------------------------------------------------------------------------- Captured stderr call ---------------------------------------------------------------------------------
    Casting the dataset: 100%|██████████| 1/1 [00:00<00:00, 181.55 examples/s]


     tests/unit/lib/test_hf.py ⨯                                                                                                                                            100% ██████████
    =============================================================================== short test summary info ===============================================================================
    FAILED tests/unit/lib/test_hf.py::test_hf_array - TypeError: ArrayExtensionArray.to_pylist() got an unexpected keyword argument 'maps_as_pydicts'

    Results (0.39s):
           1 failed
             - tests/unit/lib/test_hf.py:78 test_hf_array
           5 deselected
    ~/w/i/datachain

</details>


Also in CI [here](https://github.com/iterative/datachain/actions/runs/14694556371/job/41234418602?pr=1059), for example.

This looks a bit odd and in short amount of time I can not find a way to fix this. We definitely need a proper fix for this and to remove version limit, here is an issue for that: https://github.com/iterative/datachain/issues/1061