### PR TITLE
fix(setup): allow non callable values

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1993,7 +1993,8 @@ class DataChain:
         """Setup variables to pass to UDF functions.
 
         Use before running map/gen/agg/batch_map to save an object and pass it as an
-        argument to the UDF.
+        argument to the UDF. If callable / function value is passed it will be called
+        and the result value is cached and used.
 
         Example:
             ```py
@@ -2004,7 +2005,7 @@ class DataChain:
             (
                 dc.read_storage(DATA, type="text")
                 .settings(parallel=4, cache=True)
-                .setup(client=lambda: anthropic.Anthropic(api_key=API_KEY))
+                .setup(client=anthropic.Anthropic(api_key=API_KEY))
                 .map(
                     claude=lambda client, file: client.messages.create(
                         model=MODEL,

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -989,7 +989,7 @@ def test_row_to_objs():
     assert res == ["myname", 12.5, val, None]
 
 
-def test_row_to_objs_setup():
+def test_row_to_objs_setup_callable():
     spec = {"name": str, "age": float, "init_val": int, "fr": MyType2}
     setup_value = 84635
     setup = {"init_val": lambda: setup_value}
@@ -1009,8 +1009,11 @@ def test_row_to_objs_setup():
 
 
 def test_setup_not_callable():
-    with pytest.raises(SetupError):
-        SignalSchema({"name": str}, {"init_val": "asdfd"})
+    setup_value = "asdfd"
+    schema = SignalSchema({"name": str, "init_val": str}, {"init_val": setup_value})
+    row = ("myname",)
+    res = schema.row_to_objs(row)
+    assert res == ["myname", setup_value]
 
 
 def test_setup_error():


### PR DESCRIPTION
Fixes #1069

Allow regular values in `setup()`:

`client=anthropic.Anthropic(api_key=API_KEY)` instead of using `lambda`: `client=lambda: anthropic.Anthropic(api_key=API_KEY)`

Callable is still supported and cached.

TODO:

- [ ] Needs some testing with distributed mode (can we serialize non callable properly)
- [x] Update docs

