### PR TITLE
Set name for 'read_values' UDF

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -90,6 +90,7 @@ def build(session: nox.Session) -> None:
 @nox.session(python=python_versions)
 def examples(session: nox.Session) -> None:
     session.install(".[examples]")
+    session.run("uv", "pip", "list")
     session.run(
         "pytest",
         "--durations=0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "Pillow>=10.0.0,<12",
   "msgpack>=1.0.4,<2",
   "psutil",
-  "huggingface_hub",
+  "huggingface_hub<0.31",  # fix for "Provider 'featherless-ai' not supported" error
   "iterative-telemetry>=0.0.10",
   "platformdirs",
   "dvc-studio-client>=0.21,<1",

--- a/src/datachain/lib/dc/values.py
+++ b/src/datachain/lib/dc/values.py
@@ -42,6 +42,8 @@ def read_values(
     def _func_fr() -> Iterator[tuple_type]:  # type: ignore[valid-type]
         yield from tuples
 
+    _func_fr.__name__ = "read_values"
+
     chain = read_records(
         DataChain.DEFAULT_FILE_RECORD,
         session=session,


### PR DESCRIPTION
TODO: we also should check all other `dc.read_xxx` methods