### PR TITLE
Added `update_versions` argument to `DataChain.save()`

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -779,6 +779,7 @@ class Catalog:
         uuid: Optional[str] = None,
         description: Optional[str] = None,
         attrs: Optional[list[str]] = None,
+        update_version: Optional[str] = "patch",
     ) -> "DatasetRecord":
         """
         Creates new dataset of a specific version.
@@ -795,6 +796,11 @@ class Catalog:
         try:
             dataset = self.get_dataset(name)
             default_version = dataset.next_version_patch
+            if update_version == "major":
+                default_version = dataset.next_version_major
+            if update_version == "minor":
+                default_version = dataset.next_version_minor
+
             if (description or attrs) and (
                 dataset.description != description or dataset.attrs != attrs
             ):

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -461,6 +461,7 @@ class DataChain:
         version: Optional[str] = None,
         description: Optional[str] = None,
         attrs: Optional[list[str]] = None,
+        update_version: Optional[str] = "patch",
         **kwargs,
     ) -> "Self":
         """Save to a Dataset. It returns the chain itself.
@@ -472,9 +473,21 @@ class DataChain:
             description : description of a dataset.
             attrs : attributes of a dataset. They can be without value, e.g "NLP",
                 or with a value, e.g "location=US".
+            update_version: which part of the dataset version to automatically increase.
+                Available values: `major`, `minor` or `patch`. Default is `patch`.
         """
         if version is not None:
             semver.validate(version)
+
+        if update_version is not None and update_version not in [
+            "patch",
+            "major",
+            "minor",
+        ]:
+            raise ValueError(
+                "update_version can have one of the following values: major, minor or",
+                " patch",
+            )
 
         schema = self.signals_schema.clone_without_sys_signals().serialize()
         return self._evolve(
@@ -484,6 +497,7 @@ class DataChain:
                 description=description,
                 attrs=attrs,
                 feature_schema=schema,
+                update_version=update_version,
                 **kwargs,
             )
         )

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -5,7 +5,6 @@ from typing import (
     Union,
 )
 
-from datachain.error import DatasetNotFoundError
 from datachain.lib.file import (
     FileType,
     get_file_type,
@@ -132,11 +131,6 @@ def read_storage(
 
             def lst_fn(ds_name, lst_uri):
                 # disable prefetch for listing, as it pre-downloads all files
-                try:
-                    version = catalog.get_dataset(ds_name).next_version_major
-                except DatasetNotFoundError:
-                    version = None
-
                 (
                     read_records(
                         DataChain.DEFAULT_FILE_RECORD,
@@ -150,7 +144,7 @@ def read_storage(
                         output={f"{column}": file_type},
                     )
                     # for internal listing datasets, we always bump major version
-                    .save(ds_name, listing=True, version=version)
+                    .save(ds_name, listing=True, update_version="major")
                 )
 
             dc._query.set_listing_fn(

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1689,6 +1689,7 @@ class DatasetQuery:
         feature_schema: Optional[dict] = None,
         description: Optional[str] = None,
         attrs: Optional[list[str]] = None,
+        update_version: Optional[str] = "patch",
         **kwargs,
     ) -> "Self":
         """Save the query as a dataset."""
@@ -1723,6 +1724,7 @@ class DatasetQuery:
                 columns=columns,
                 description=description,
                 attrs=attrs,
+                update_version=update_version,
                 **kwargs,
             )
             version = version or dataset.latest_version


### PR DESCRIPTION
Adding new `update_versions` argument which says which version part to bump automatically on save.
It can have 3 values: `major`, `minor` and `patch`.

Example:
```python
chain = dc.read_values(fib=[1, 1, 2, 3, 5, 8])
chain.save("fibonacci")   # creates version 1.0.0
chain.save("fibonacci", update_version="minor")  # creates version 1.1.0
chain.save("fibonacci", update_version="major")  # creates version 2.0.0
chain.save("fibonacci", update_version="patch")  # creates version 2.0.1
chain.save("fibonacci")  # creates version 2.0.2
 ```