### PR TITLE
Fixing dataset version preview update

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -674,7 +674,7 @@ class AbstractDBMetastore(AbstractMetastore):
             dv = self._datasets_versions
             self.db.execute(
                 self._datasets_versions_update()
-                .where(dv.c.dataset_id == dataset.id and dv.c.version == version)
+                .where(dv.c.dataset_id == dataset.id, dv.c.version == version)
                 .values(values),
                 conn=conn,
             )  # type: ignore [attr-defined]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -3270,3 +3270,13 @@ def test_wrong_semver_format(test_session):
         "Invalid version. It should be in format: <major>.<minor>.<patch> where"
         " each version part is positive integer"
     )
+
+
+def test_semver_preview_ok(test_session):
+    ds_name = "numbers"
+    dc.read_values(num=[1, 2], session=test_session).save(ds_name)
+    dc.read_values(num=[3, 4], session=test_session).save(ds_name)
+
+    dataset = test_session.catalog.get_dataset(ds_name)
+    assert sorted([p["num"] for p in dataset.get_version("1.0.0").preview]) == [1, 2]
+    assert sorted([p["num"] for p in dataset.get_version("1.0.1").preview]) == [3, 4]


### PR DESCRIPTION
This fixes dataset version preview update which was broken after we introduced semver because we used wrong syntax for SQLAlchemy `where` condition which resulting only one condition in `AND` to be in the final query which at the end resulted on updating all versions preview with latest one. 
It was (accidentally) working before probably because version column was `int`