### PR TITLE
Fix session cleanup

### DIFF
--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -195,5 +195,11 @@ class Session:
             Session.GLOBAL_SESSION_CTX.__exit__(None, None, None)
 
         for obj in gc.get_objects():  # Get all tracked objects
-            if isinstance(obj, Session):  # Cleanup temp dataset for session variables.
-                obj.__exit__(None, None, None)
+            try:
+                if isinstance(obj, Session):
+                    # Cleanup temp dataset for session variables.
+                    obj.__exit__(None, None, None)
+            except ReferenceError:
+                continue  # Object has been finalized already
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"Exception while cleaning up session: {e}")  # noqa: G004


### PR DESCRIPTION
Caught an error:
```
$ python index.py
Exception ignored in atexit callback <function Session._global_cleanup at 0x1058b76a0>:
Traceback (most recent call last):
  File ".../python3.13/site-packages/datachain/query/session.py", line 198, in _global_cleanup
    if isinstance(obj, Session):  # Cleanup temp dataset for session variables.
ReferenceError: weakly-referenced object no longer exists
```

While running this simplest script:

```python
import datachain as dc

dc.read_storage("s3://bucket/", anon=True).save("dataset")
```
