### PR TITLE
Prevent `File(path="")` from becoming `File(path=".")`

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -237,7 +237,7 @@ class File(DataModel):
     @field_validator("path", mode="before")
     @classmethod
     def validate_path(cls, path):
-        return Path(path).as_posix()
+        return Path(path).as_posix() if path else ""
 
     def model_dump_custom(self):
         res = self.model_dump()


### PR DESCRIPTION
```
>>> datachain.File(path="")
File(source='', path='.', size=0, version='', etag='', is_latest=True, last_modified=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), location=None)
```

This happens because `pathlib.Path("").as_posix() == "."`