### PR TITLE
Do not fail CI in main branch if only codecov fails

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -9,6 +9,21 @@ coverage:
         threshold: 10%
         # non-blocking status checks
         informational: true
+    patch:
+      default:
+        # auto compares coverage to the previous base commit
+        target: auto
+        # adjust accordingly based on how flaky your tests are
+        # this allows a 10% drop from the previous base commit coverage
+        threshold: 10%
+        # non-blocking status checks
+        informational: true
+
+comment:
+  # sections shown in the PR comment
+  layout: "reach, diff, flags, files"
+  # updates the comment on PRs when coverage changes
+  behavior: default
 
 flags:
   datachain:

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -9,6 +9,7 @@ coverage:
         threshold: 10%
         # non-blocking status checks
         informational: true
+        only_pulls: true
     patch:
       default:
         # auto compares coverage to the previous base commit

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -10,15 +10,6 @@ coverage:
         # non-blocking status checks
         informational: true
         only_pulls: true
-    patch:
-      default:
-        # auto compares coverage to the previous base commit
-        target: auto
-        # adjust accordingly based on how flaky your tests are
-        # this allows a 10% drop from the previous base commit coverage
-        threshold: 10%
-        # non-blocking status checks
-        informational: true
 
 comment:
   # sections shown in the PR comment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: datachain
-        continue-on-error: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build package
         run: nox -s build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: datachain
+        continue-on-error: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build package
         run: nox -s build


### PR DESCRIPTION
While code coverage is very important metric and we should work on increasing this as much as possible, it is not really useful to see CI build failed status in `main` branch if only code coverage fails.

Trying to solve this issue:

<img width="904" alt="image" src="https://github.com/user-attachments/assets/7b24b621-f489-483b-acfb-a2a8cfad451d" />

<img width="647" alt="image" src="https://github.com/user-attachments/assets/16cc83ca-d5ee-4296-9837-3cb443c60067" />

Not sure if this will helps, need to test it.