### PR TITLE
Fix empty bucket index

### DIFF
--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -65,7 +65,7 @@ class AzureClient(Client):
                         if entries:
                             await result_queue.put(entries)
                             pbar.update(len(entries))
-                    if not found:
+                    if not found and prefix:
                         raise FileNotFoundError(
                             f"Unable to resolve remote path: {prefix}"
                         )

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -74,7 +74,7 @@ class GCSClient(Client):
             try:
                 await self._get_pages(prefix, page_queue)
                 found = await consumer
-                if not found:
+                if not found and prefix:
                     raise FileNotFoundError(f"Unable to resolve remote path: {prefix}")
             finally:
                 consumer.cancel()  # In case _get_pages() raised

--- a/tests/func/test_client.py
+++ b/tests/func/test_client.py
@@ -51,6 +51,12 @@ def test_scandir_error(client):
         scandir(client, "bogus")
 
 
+@pytest.mark.parametrize("tree", [{}], indirect=True)
+def test_scandir_empty_bucket(client):
+    results = scandir(client, "")
+    match_entries(results, [])
+
+
 @pytest.mark.xfail
 def test_scandir_not_dir(client):
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
Attempt to fix https://github.com/iterative/datachain/issues/1120

I didn't find a reasonable explanation for having this logic (except that some old code similar `found=True/False` logic, but in that case I think the dir name itself was returning (?))

## TODO

- [x] Add tests
- [x] Check other clouds
- [ ] Check some other methods (we have two ways to index)