### PR TITLE
Fix pickle/unpickle FileError exception

### DIFF
--- a/src/datachain/lib/image.py
+++ b/src/datachain/lib/image.py
@@ -19,7 +19,7 @@ def image_info(file: Union[File, ImageFile]) -> Image:
     try:
         img = file.as_image_file().read()
     except Exception as exc:
-        raise FileError(file, "unable to open image file") from exc
+        raise FileError("unable to open image file", file.source, file.path) from exc
 
     return Image(
         width=img.width,

--- a/src/datachain/lib/utils.py
+++ b/src/datachain/lib/utils.py
@@ -18,13 +18,11 @@ class AbstractUDF(ABC):
 
 
 class DataChainError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class DataChainParamsError(DataChainError):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class DataChainColumnError(DataChainParamsError):

--- a/src/datachain/lib/video.py
+++ b/src/datachain/lib/video.py
@@ -34,21 +34,27 @@ def video_info(file: Union[File, VideoFile]) -> Video:
         file.ensure_cached()
         file_path = file.get_local_path()
         if not file_path:
-            raise FileError(file, "unable to download video file")
+            raise FileError("unable to download video file", file.source, file.path)
 
     try:
         probe = ffmpeg.probe(file_path)
     except Exception as exc:
-        raise FileError(file, "unable to extract metadata from video file") from exc
+        raise FileError(
+            "unable to extract metadata from video file", file.source, file.path
+        ) from exc
 
     all_streams = probe.get("streams")
     video_format = probe.get("format")
     if not all_streams or not video_format:
-        raise FileError(file, "unable to extract metadata from video file")
+        raise FileError(
+            "unable to extract metadata from video file", file.source, file.path
+        )
 
     video_streams = [s for s in all_streams if s["codec_type"] == "video"]
     if len(video_streams) == 0:
-        raise FileError(file, "unable to extract metadata from video file")
+        raise FileError(
+            "unable to extract metadata from video file", file.source, file.path
+        )
 
     video_stream = video_streams[0]
 


### PR DESCRIPTION
Fix for https://github.com/iterative/datachain/issues/1125

```
  File "/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/multiprocess/queues.py", line 138, in get_nowait
    return self.get(False)
           ~~~~~~~~^^^^^^^
  File "/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/multiprocess/queues.py", line 125, in get
    return _ForkingPickler.loads(res)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/dill/_dill.py", line 303, in loads
    return load(file, ignore, **kwds)
  File "/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/dill/_dill.py", line 289, in load
    return Unpickler(file, ignore=ignore, **kwds).load()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/dill/_dill.py", line 444, in load
    obj = StockUnpickler.load(self)
TypeError: FileError.__init__() missing 1 required positional argument: 'message'
```