### PR TITLE
fix(client): avoid version ids if version aware is false

### DIFF
--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -15,7 +15,7 @@ class AzureClient(Client):
     protocol = "az"
 
     def info_to_file(self, v: dict[str, Any], path: str) -> File:
-        version_id = v.get("version_id")
+        version_id = v.get("version_id") if self._is_version_aware() else None
         return File(
             source=self.uri,
             path=path,

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -208,7 +208,7 @@ class Client(ABC):
 
     async def get_current_etag(self, file: "File") -> str:
         kwargs = {}
-        if getattr(self.fs, "version_aware", False):
+        if self._is_version_aware():
             kwargs["version_id"] = file.version
         info = await self.fs._info(
             self.get_full_path(file.path, file.version), **kwargs
@@ -326,8 +326,11 @@ class Client(ABC):
         """
         return not (key.startswith("/") or key.endswith("/") or "//" in key)
 
+    def _is_version_aware(self) -> bool:
+        return getattr(self.fs, "version_aware", False)
+
     async def ls_dir(self, path):
-        if getattr(self.fs, "version_aware", False):
+        if self._is_version_aware():
             kwargs = {"versions": True}
         return await self.fs._ls(path, detail=True, **kwargs)
 

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -115,7 +115,7 @@ class GCSClient(Client):
                     maxResults=page_size,
                     pageToken=next_page_token,
                     json_out=True,
-                    versions="true",
+                    versions="true" if self._is_version_aware() else "false",
                 )
                 assert page["kind"] == "storage#objects"
                 await page_queue.put(page.get("items", []))
@@ -134,7 +134,7 @@ class GCSClient(Client):
             source=self.uri,
             path=path,
             etag=v.get("etag", ""),
-            version=v.get("generation", ""),
+            version=v.get("generation", "") if self._is_version_aware() else "",
             is_latest=not v.get("timeDeleted"),
             last_modified=self.parse_timestamp(v["updated"]),
             size=v.get("size", ""),

--- a/src/datachain/client/s3.py
+++ b/src/datachain/client/s3.py
@@ -101,7 +101,7 @@ class ClientS3(Client):
             prefix = start_prefix
             if prefix:
                 prefix = prefix.lstrip(DELIMITER) + DELIMITER
-            versions = True
+            versions = self._is_version_aware()
             fs = self.fs
             await fs.set_session()
             s3 = await fs.get_s3(self.name)
@@ -139,7 +139,9 @@ class ClientS3(Client):
             source=self.uri,
             path=v["Key"],
             etag=v.get("ETag", "").strip('"'),
-            version=ClientS3.clean_s3_version(v.get("VersionId", "")),
+            version=(
+                ClientS3.clean_s3_version(v.get("VersionId", "")) if versions else ""
+            ),
             is_latest=v.get("IsLatest", True),
             last_modified=v.get("LastModified", ""),
             size=v["Size"],
@@ -193,7 +195,11 @@ class ClientS3(Client):
             source=self.uri,
             path=path,
             size=v["size"],
-            version=ClientS3.clean_s3_version(v.get("VersionId", "")),
+            version=(
+                ClientS3.clean_s3_version(v.get("VersionId", ""))
+                if self._is_version_aware()
+                else ""
+            ),
             etag=v.get("ETag", "").strip('"'),
             is_latest=v.get("IsLatest", True),
             last_modified=v.get("LastModified", ""),

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -25,6 +25,12 @@ def test_listing_generator(cloud_test_catalog, cloud_type):
         assert cat_file.source == ctc.src_uri
         assert cat_file.path == cat_entry.path
         assert cat_file.size == cat_entry.size
+        assert cat_file.etag is not None
+        # If version_aware is not passed it is enforced to be True internally
+        if catalog.client_config.get("version_aware", True):
+            assert cat_file.version is not None
+        else:
+            assert cat_file.version == ""
         assert cat_file.is_latest == cat_entry.is_latest
         assert cat_file.location is None
 


### PR DESCRIPTION
Fixing a few issue where even setting `version_aware=False` was not enough to force it not use Version APIs + do all the version id related checks.

We now don't fetch `version_id` field in commands like `read_storage` for the Files if `version_aware` False is passed. Column value will be None and we won't be enforcing or using `version_id` downstream (e.g. in prefetch, etc).

To make code like this:

```python
datachain.read_storage("s3://ivan-test-versioned", client_config={"version_aware": False}, update=True).show(10, include_hidden=True)
datachain.read_csv("s3://ivan-test-versioned/test.json", client_config={"version_aware": False}, update=True).show(10)
```

work w/o additional permissions:

```
s3:ListBucketVersions
s3:GetObjectVersion
```

(and the same should be for the GCS and Azure)

Note: testing this is complicated. Azure test FS doesn't support versioning. Main changes are related to the permissions and we can't check them on emulators properly AFAIU.