### PR TITLE
Change the default value to true for version aware in docs

### DIFF
--- a/docs/references/remotes.md
+++ b/docs/references/remotes.md
@@ -86,7 +86,7 @@ DataChain uses [s3fs](https://s3fs.readthedocs.io/en/latest/) to interact with A
     if no caching is desired. See fsspec's documentation for other available
     `cache_type` values. Default cache_type is `"readahead"`.
 
-- `version_aware`: `bool` (default: `False`)
+- `version_aware`: `bool` (default: `True`)
 
     Whether to support bucket versioning. If enable this will require the
     user to have the necessary IAM permissions for dealing with versioned


### PR DESCRIPTION
Reference discussion: https://iterativeai.slack.com/archives/C04A9RWEZBN/p1748811798250819
