### PR TITLE
fix(save): use only file signals for size

### DIFF
--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -94,7 +94,39 @@ def remote_dataset_version(schema, dataset_rows):
         "dataset_id": 1,
         "version": "1.0.0",
         "status": 4,
-        "feature_schema": {},
+        "feature_schema": {
+            "file": "File@v1",
+            "_custom_types": {
+                "File@v1": {
+                    "schema_version": 2,
+                    "name": "File@v1",
+                    "fields": {
+                        "source": "str",
+                        "path": "str",
+                        "size": "int",
+                        "version": "str",
+                        "etag": "str",
+                        "is_latest": "bool",
+                        "last_modified": "datetime",
+                        "location": "Union[dict, list[dict], NoneType]",
+                    },
+                    "bases": [
+                        ["File", "datachain.lib.file", "File@v1"],
+                        ["DataModel", "datachain.lib.data_model", "DataModel@v1"],
+                        ["BaseModel", "pydantic.main", None],
+                        ["object", "builtins", None],
+                    ],
+                    "hidden_fields": [
+                        "source",
+                        "version",
+                        "etag",
+                        "is_latest",
+                        "last_modified",
+                        "location",
+                    ],
+                }
+            },
+        },
         "created_at": "2024-02-23T10:42:31.842944+00:00",
         "finished_at": "2024-02-23T10:43:31.842944+00:00",
         "error_message": "",
@@ -121,7 +153,39 @@ def remote_dataset(remote_dataset_version, schema):
         "attrs": [],
         "schema": schema,
         "status": 4,
-        "feature_schema": {},
+        "feature_schema": {
+            "file": "File@v1",
+            "_custom_types": {
+                "File@v1": {
+                    "schema_version": 2,
+                    "name": "File@v1",
+                    "fields": {
+                        "source": "str",
+                        "path": "str",
+                        "size": "int",
+                        "version": "str",
+                        "etag": "str",
+                        "is_latest": "bool",
+                        "last_modified": "datetime",
+                        "location": "Union[dict, list[dict], NoneType]",
+                    },
+                    "bases": [
+                        ["File", "datachain.lib.file", "File@v1"],
+                        ["DataModel", "datachain.lib.data_model", "DataModel@v1"],
+                        ["BaseModel", "pydantic.main", None],
+                        ["object", "builtins", None],
+                    ],
+                    "hidden_fields": [
+                        "source",
+                        "version",
+                        "etag",
+                        "is_latest",
+                        "last_modified",
+                        "location",
+                    ],
+                }
+            },
+        },
         "created_at": "2024-02-23T10:42:31.842944+00:00",
         "finished_at": "2024-02-23T10:43:31.842944+00:00",
         "error_message": "",


### PR DESCRIPTION
Fixes an error when we are trying to save a dataset with `size` column that is not part of the File. It can be any random column.

## TODO

- [x] ~Add tests~ Not sure we need a separate test for this, code was so naive and broken that it doesn't make sense to have a separate test covering that bad behavior. Size itself is covered.