### PR TITLE
Fix pickling generated model in 'read_json'

### DIFF
--- a/src/datachain/lib/meta_formats.py
+++ b/src/datachain/lib/meta_formats.py
@@ -117,6 +117,7 @@ def read_meta(  # noqa: C901
             gl = globals()
             exec(model_code, gl)  # type: ignore[arg-type] # noqa: S102
             spec = gl["spec"]
+            spec.__module__ = "__main__"
 
     if not spec and not schema_from:
         raise ValueError(


### PR DESCRIPTION
Kind of hack found [here](https://github.com/cloudpipe/cloudpickle/issues/206#issuecomment-555939172), but it works.

Would love to have a better solution.

Using [pickletools](https://docs.python.org/3/library/pickletools.html) to check:

<details>
  <summary>Before</summary>

```
    0: \x80 PROTO      5
    2: \x95 FRAME      77
   11: \x8c SHORT_BINUNICODE 'datachain.lib.meta_formats'
   39: \x94 MEMOIZE    (as 0)
   40: \x8c SHORT_BINUNICODE 'Modeljsonl272c131de3ba4cec9f751b5be2b7facb'
   84: \x94 MEMOIZE    (as 1)
   85: \x93 STACK_GLOBAL
   86: \x94 MEMOIZE    (as 2)
   87: .    STOP
```
</details>

<details>
  <summary>After</summary>

```
    0: \x80 PROTO      5
    2: \x95 FRAME      4019
   11: \x8c SHORT_BINUNICODE 'cloudpickle.cloudpickle'
   36: \x94 MEMOIZE    (as 0)
   37: \x8c SHORT_BINUNICODE '_make_skeleton_class'
   59: \x94 MEMOIZE    (as 1)
   60: \x93 STACK_GLOBAL
   61: \x94 MEMOIZE    (as 2)
   62: (    MARK
   63: \x8c     SHORT_BINUNICODE 'pydantic._internal._model_construction'
  103: \x94     MEMOIZE    (as 3)
  104: \x8c     SHORT_BINUNICODE 'ModelMetaclass'
  120: \x94     MEMOIZE    (as 4)
  121: \x93     STACK_GLOBAL
  122: \x94     MEMOIZE    (as 5)
  123: \x8c     SHORT_BINUNICODE 'Modeljsonl272c131de3ba4cec9f751b5be2b7facb'
  167: \x94     MEMOIZE    (as 6)
  168: \x8c     SHORT_BINUNICODE 'datachain.lib.meta_formats'
  196: \x94     MEMOIZE    (as 7)
  197: \x8c     SHORT_BINUNICODE 'UserModel'
  208: \x94     MEMOIZE    (as 8)
  209: \x93     STACK_GLOBAL
  210: \x94     MEMOIZE    (as 9)
  211: \x85     TUPLE1
  212: \x94     MEMOIZE    (as 10)
  213: }        EMPTY_DICT
  214: \x94     MEMOIZE    (as 11)
  215: \x8c     SHORT_BINUNICODE '__module__'
  227: \x94     MEMOIZE    (as 12)
  228: \x8c     SHORT_BINUNICODE '__main__'
  238: \x94     MEMOIZE    (as 13)
  239: s        SETITEM
  240: \x8c     SHORT_BINUNICODE '2117100667bd406b983147484db7caea'
  274: \x94     MEMOIZE    (as 14)
  275: N        NONE
  276: t        TUPLE      (MARK at 62)
  277: \x94 MEMOIZE    (as 15)
  278: R    REDUCE
  279: \x94 MEMOIZE    (as 16)
  280: h    BINGET     0
  282: \x8c SHORT_BINUNICODE '_class_setstate'
  299: \x94 MEMOIZE    (as 17)
  300: \x93 STACK_GLOBAL
  301: \x94 MEMOIZE    (as 18)
  302: h    BINGET     16
  304: }    EMPTY_DICT
  305: \x94 MEMOIZE    (as 19)
  306: (    MARK
  307: \x8c     SHORT_BINUNICODE '__abstractmethods__'
  328: \x94     MEMOIZE    (as 20)
  329: (        MARK
  330: \x91         FROZENSET  (MARK at 329)
  331: \x94     MEMOIZE    (as 21)
  332: \x8c     SHORT_BINUNICODE '__annotations__'
  349: \x94     MEMOIZE    (as 22)
  350: }        EMPTY_DICT
  351: \x94     MEMOIZE    (as 23)
  352: (        MARK
  353: \x8c         SHORT_BINUNICODE 'name'
  359: \x94         MEMOIZE    (as 24)
  360: \x8c         SHORT_BINUNICODE 'str'
  365: \x94         MEMOIZE    (as 25)
  366: \x8c         SHORT_BINUNICODE 'wins'
  372: \x94         MEMOIZE    (as 26)
  373: \x8c         SHORT_BINUNICODE 'list[str]'
  384: \x94         MEMOIZE    (as 27)
  385: \x8c         SHORT_BINUNICODE 'cards'
  392: \x94         MEMOIZE    (as 28)
  393: h            BINGET     27
  395: u            SETITEMS   (MARK at 352)
  396: \x8c     SHORT_BINUNICODE '__class_vars__'
  412: \x94     MEMOIZE    (as 29)
  413: \x8f     EMPTY_SET
  414: \x94     MEMOIZE    (as 30)
  415: \x8c     SHORT_BINUNICODE '__firstlineno__'
  432: \x94     MEMOIZE    (as 31)
  433: K        BININT1    11
  435: \x8c     SHORT_BINUNICODE '__module__'
  447: \x94     MEMOIZE    (as 32)
  448: h        BINGET     13
  450: \x8c     SHORT_BINUNICODE '__private_attributes__'
  474: \x94     MEMOIZE    (as 33)
  475: }        EMPTY_DICT
  476: \x94     MEMOIZE    (as 34)
  477: \x8c     SHORT_BINUNICODE '__pydantic_computed_fields__'
  507: \x94     MEMOIZE    (as 35)
  508: }        EMPTY_DICT
  509: \x94     MEMOIZE    (as 36)
  510: \x8c     SHORT_BINUNICODE '__pydantic_core_schema__'
  536: \x94     MEMOIZE    (as 37)
  537: }        EMPTY_DICT
  538: \x94     MEMOIZE    (as 38)
  539: (        MARK
  540: \x8c         SHORT_BINUNICODE 'type'
  546: \x94         MEMOIZE    (as 39)
  547: \x8c         SHORT_BINUNICODE 'model'
  554: \x94         MEMOIZE    (as 40)
  555: \x8c         SHORT_BINUNICODE 'cls'
  560: \x94         MEMOIZE    (as 41)
  561: h            BINGET     16
  563: \x8c         SHORT_BINUNICODE 'schema'
  571: \x94         MEMOIZE    (as 42)
  572: }            EMPTY_DICT
  573: \x94         MEMOIZE    (as 43)
  574: (            MARK
  575: h                BINGET     39
  577: \x8c             SHORT_BINUNICODE 'model-fields'
  591: \x94             MEMOIZE    (as 44)
  592: \x8c             SHORT_BINUNICODE 'fields'
  600: \x94             MEMOIZE    (as 45)
  601: }                EMPTY_DICT
  602: \x94             MEMOIZE    (as 46)
  603: (                MARK
  604: h                    BINGET     24
  606: }                    EMPTY_DICT
  607: \x94                 MEMOIZE    (as 47)
  608: (                    MARK
  609: h                        BINGET     39
  611: \x8c                     SHORT_BINUNICODE 'model-field'
  624: \x94                     MEMOIZE    (as 48)
  625: h                        BINGET     42
  627: }                        EMPTY_DICT
  628: \x94                     MEMOIZE    (as 49)
  629: h                        BINGET     39
  631: h                        BINGET     25
  633: s                        SETITEM
  634: \x8c                     SHORT_BINUNICODE 'metadata'
  644: \x94                     MEMOIZE    (as 50)
  645: }                        EMPTY_DICT
  646: \x94                     MEMOIZE    (as 51)
  647: u                        SETITEMS   (MARK at 608)
  648: h                    BINGET     26
  650: }                    EMPTY_DICT
  651: \x94                 MEMOIZE    (as 52)
  652: (                    MARK
  653: h                        BINGET     39
  655: h                        BINGET     48
  657: h                        BINGET     42
  659: }                        EMPTY_DICT
  660: \x94                     MEMOIZE    (as 53)
  661: (                        MARK
  662: h                            BINGET     39
  664: \x8c                         SHORT_BINUNICODE 'list'
  670: \x94                         MEMOIZE    (as 54)
  671: \x8c                         SHORT_BINUNICODE 'items_schema'
  685: \x94                         MEMOIZE    (as 55)
  686: }                            EMPTY_DICT
  687: \x94                         MEMOIZE    (as 56)
  688: h                            BINGET     39
  690: h                            BINGET     25
  692: s                            SETITEM
  693: u                            SETITEMS   (MARK at 661)
  694: h                        BINGET     50
  696: }                        EMPTY_DICT
  697: \x94                     MEMOIZE    (as 57)
  698: u                        SETITEMS   (MARK at 652)
  699: h                    BINGET     28
  701: }                    EMPTY_DICT
  702: \x94                 MEMOIZE    (as 58)
  703: (                    MARK
  704: h                        BINGET     39
  706: h                        BINGET     48
  708: h                        BINGET     42
  710: }                        EMPTY_DICT
  711: \x94                     MEMOIZE    (as 59)
  712: (                        MARK
  713: h                            BINGET     39
  715: h                            BINGET     54
  717: h                            BINGET     55
  719: }                            EMPTY_DICT
  720: \x94                         MEMOIZE    (as 60)
  721: h                            BINGET     39
  723: h                            BINGET     25
  725: s                            SETITEM
  726: u                            SETITEMS   (MARK at 712)
  727: h                        BINGET     50
  729: }                        EMPTY_DICT
  730: \x94                     MEMOIZE    (as 61)
  731: u                        SETITEMS   (MARK at 703)
  732: u                    SETITEMS   (MARK at 603)
  733: \x8c             SHORT_BINUNICODE 'model_name'
  745: \x94             MEMOIZE    (as 62)
  746: h                BINGET     6
  748: \x8c             SHORT_BINUNICODE 'computed_fields'
  765: \x94             MEMOIZE    (as 63)
  766: ]                EMPTY_LIST
  767: \x94             MEMOIZE    (as 64)
  768: u                SETITEMS   (MARK at 574)
  769: \x8c         SHORT_BINUNICODE 'custom_init'
  782: \x94         MEMOIZE    (as 65)
  783: \x89         NEWFALSE
  784: \x8c         SHORT_BINUNICODE 'root_model'
  796: \x94         MEMOIZE    (as 66)
  797: \x89         NEWFALSE
  798: \x8c         SHORT_BINUNICODE 'config'
  806: \x94         MEMOIZE    (as 67)
  807: }            EMPTY_DICT
  808: \x94         MEMOIZE    (as 68)
  809: (            MARK
  810: \x8c             SHORT_BINUNICODE 'title'
  817: \x94             MEMOIZE    (as 69)
  818: h                BINGET     6
  820: \x8c             SHORT_BINUNICODE 'populate_by_name'
  838: \x94             MEMOIZE    (as 70)
  839: \x88             NEWTRUE
  840: u                SETITEMS   (MARK at 809)
  841: \x8c         SHORT_BINUNICODE 'ref'
  846: \x94         MEMOIZE    (as 71)
  847: \x8c         SHORT_BINUNICODE 'datachain.lib.meta_formats.Modeljsonl272c131de3ba4cec9f751b5be2b7facb:4412968624'
  929: \x94         MEMOIZE    (as 72)
  930: h            BINGET     50
  932: }            EMPTY_DICT
  933: \x94         MEMOIZE    (as 73)
  934: \x8c         SHORT_BINUNICODE 'pydantic_js_functions'
  957: \x94         MEMOIZE    (as 74)
  958: ]            EMPTY_LIST
  959: \x94         MEMOIZE    (as 75)
  960: h            BINGET     0
  962: \x8c         SHORT_BINUNICODE '_builtin_type'
  977: \x94         MEMOIZE    (as 76)
  978: \x93         STACK_GLOBAL
  979: \x94         MEMOIZE    (as 77)
  980: \x8c         SHORT_BINUNICODE 'MethodType'
  992: \x94         MEMOIZE    (as 78)
  993: \x85         TUPLE1
  994: \x94         MEMOIZE    (as 79)
  995: R            REDUCE
  996: \x94         MEMOIZE    (as 80)
  997: h            BINGET     0
  999: \x8c         SHORT_BINUNICODE '_make_function'
 1015: \x94         MEMOIZE    (as 81)
 1016: \x93         STACK_GLOBAL
 1017: \x94         MEMOIZE    (as 82)
 1018: (            MARK
 1019: h                BINGET     77
 1021: \x8c             SHORT_BINUNICODE 'CodeType'
 1031: \x94             MEMOIZE    (as 83)
 1032: \x85             TUPLE1
 1033: \x94             MEMOIZE    (as 84)
 1034: R                REDUCE
 1035: \x94             MEMOIZE    (as 85)
 1036: (                MARK
 1037: K                    BININT1    3
 1039: K                    BININT1    3
 1041: K                    BININT1    0
 1043: K                    BININT1    3
 1045: K                    BININT1    3
 1047: J                    BININT     16777219
 1052: C                    SHORT_BINBYTES b'\x95\x00U\x02"\x00U\x015\x01\x00\x00\x00\x00\x00\x00$\x00'
 1072: \x94                 MEMOIZE    (as 86)
 1073: X                    BINUNICODE "Hook into generating the model's JSON schema.\n\nArgs:\n    core_schema: A `pydantic-core` CoreSchema.\n        You can ignore this argument and call the handler with a new CoreSchema,\n        wrap this CoreSchema (`{'type': 'nullable', 'schema': current_schema}`),\n        or just call the handler with the original schema.\n    handler: Call into Pydantic's internal JSON schema generation.\n        This will raise a `pydantic.errors.PydanticInvalidForJsonSchema` if JSON schema\n        generation fails.\n        Since this gets called by `BaseModel.model_json_schema` you can override the\n        `schema_generator` argument to that function to change JSON schema generation globally\n        for a type.\n\nReturns:\n    A JSON schema, as a Python object.\n"
 1829: \x94                 MEMOIZE    (as 87)
 1830: \x85                 TUPLE1
 1831: \x94                 MEMOIZE    (as 88)
 1832: )                    EMPTY_TUPLE
 1833: h                    BINGET     41
 1835: \x8c                 SHORT_BINUNICODE 'core_schema'
 1848: \x94                 MEMOIZE    (as 89)
 1849: \x8c                 SHORT_BINUNICODE 'handler'
 1858: \x94                 MEMOIZE    (as 90)
 1859: \x87                 TUPLE3
 1860: \x94                 MEMOIZE    (as 91)
 1861: \x8c                 SHORT_BINUNICODE '/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/pydantic/main.py'
 1943: \x94                 MEMOIZE    (as 92)
 1944: \x8c                 SHORT_BINUNICODE '__get_pydantic_json_schema__'
 1974: \x94                 MEMOIZE    (as 93)
 1975: \x8c                 SHORT_BINUNICODE 'BaseModel.__get_pydantic_json_schema__'
 2015: \x94                 MEMOIZE    (as 94)
 2016: M                    BININT2    704
 2019: C                    SHORT_BINBYTES b'\x80\x00\xf10\x00\x10\x17\x90{\xd3\x0f#\xd0\x08#'
 2036: \x94                 MEMOIZE    (as 95)
 2037: C                    SHORT_BINBYTES b''
 2039: \x94                 MEMOIZE    (as 96)
 2040: )                    EMPTY_TUPLE
 2041: )                    EMPTY_TUPLE
 2042: t                    TUPLE      (MARK at 1036)
 2043: \x94             MEMOIZE    (as 97)
 2044: R                REDUCE
 2045: \x94             MEMOIZE    (as 98)
 2046: }                EMPTY_DICT
 2047: \x94             MEMOIZE    (as 99)
 2048: (                MARK
 2049: \x8c                 SHORT_BINUNICODE '__package__'
 2062: \x94                 MEMOIZE    (as 100)
 2063: \x8c                 SHORT_BINUNICODE 'pydantic'
 2073: \x94                 MEMOIZE    (as 101)
 2074: \x8c                 SHORT_BINUNICODE '__name__'
 2084: \x94                 MEMOIZE    (as 102)
 2085: \x8c                 SHORT_BINUNICODE 'pydantic.main'
 2100: \x94                 MEMOIZE    (as 103)
 2101: \x8c                 SHORT_BINUNICODE '__file__'
 2111: \x94                 MEMOIZE    (as 104)
 2112: \x8c                 SHORT_BINUNICODE '/Users/vlad/.virtualenvs/datachain/lib/python3.13/site-packages/pydantic/main.py'
 2194: \x94                 MEMOIZE    (as 105)
 2195: u                    SETITEMS   (MARK at 2048)
 2196: N                NONE
 2197: N                NONE
 2198: N                NONE
 2199: t                TUPLE      (MARK at 1018)
 2200: \x94         MEMOIZE    (as 106)
 2201: R            REDUCE
 2202: \x94         MEMOIZE    (as 107)
 2203: h            BINGET     0
 2205: \x8c         SHORT_BINUNICODE '_function_setstate'
 2225: \x94         MEMOIZE    (as 108)
 2226: \x93         STACK_GLOBAL
 2227: \x94         MEMOIZE    (as 109)
 2228: h            BINGET     107
 2230: }            EMPTY_DICT
 2231: \x94         MEMOIZE    (as 110)
 2232: }            EMPTY_DICT
 2233: \x94         MEMOIZE    (as 111)
 2234: (            MARK
 2235: h                BINGET     102
 2237: \x8c             SHORT_BINUNICODE '__get_pydantic_json_schema__'
 2267: \x94             MEMOIZE    (as 112)
 2268: \x8c             SHORT_BINUNICODE '__qualname__'
 2282: \x94             MEMOIZE    (as 113)
 2283: \x8c             SHORT_BINUNICODE 'BaseModel.__get_pydantic_json_schema__'
 2323: \x94             MEMOIZE    (as 114)
 2324: \x8c             SHORT_BINUNICODE '__annotations__'
 2341: \x94             MEMOIZE    (as 115)
 2342: }                EMPTY_DICT
 2343: \x94             MEMOIZE    (as 116)
 2344: (                MARK
 2345: h                    BINGET     89
 2347: \x8c                 SHORT_BINUNICODE 'CoreSchema'
 2359: \x94                 MEMOIZE    (as 117)
 2360: h                    BINGET     90
 2362: \x8c                 SHORT_BINUNICODE 'GetJsonSchemaHandler'
 2384: \x94                 MEMOIZE    (as 118)
 2385: \x8c                 SHORT_BINUNICODE 'return'
 2393: \x94                 MEMOIZE    (as 119)
 2394: \x8c                 SHORT_BINUNICODE 'JsonSchemaValue'
 2411: \x94                 MEMOIZE    (as 120)
 2412: u                    SETITEMS   (MARK at 2344)
 2413: \x8c             SHORT_BINUNICODE '__kwdefaults__'
 2429: \x94             MEMOIZE    (as 121)
 2430: N                NONE
 2431: \x8c             SHORT_BINUNICODE '__defaults__'
 2445: \x94             MEMOIZE    (as 122)
 2446: N                NONE
 2447: h                BINGET     12
 2449: h                BINGET     103
 2451: \x8c             SHORT_BINUNICODE '__doc__'
 2460: \x94             MEMOIZE    (as 123)
 2461: h                BINGET     87
 2463: \x8c             SHORT_BINUNICODE '__closure__'
 2476: \x94             MEMOIZE    (as 124)
 2477: N                NONE
 2478: \x8c             SHORT_BINUNICODE '_cloudpickle_submodules'
 2503: \x94             MEMOIZE    (as 125)
 2504: ]                EMPTY_LIST
 2505: \x94             MEMOIZE    (as 126)
 2506: \x8c             SHORT_BINUNICODE '__globals__'
 2519: \x94             MEMOIZE    (as 127)
 2520: }                EMPTY_DICT
 2521: \x94             MEMOIZE    (as 128)
 2522: u                SETITEMS   (MARK at 2234)
 2523: \x86         TUPLE2
 2524: \x94         MEMOIZE    (as 129)
 2525: \x86         TUPLE2
 2526: R            REDUCE
 2527: 0            POP
 2528: h            BINGET     16
 2530: \x86         TUPLE2
 2531: \x94         MEMOIZE    (as 130)
 2532: R            REDUCE
 2533: \x94         MEMOIZE    (as 131)
 2534: a            APPEND
 2535: s            SETITEM
 2536: u            SETITEMS   (MARK at 539)
 2537: \x8c     SHORT_BINUNICODE '__pydantic_decorators__'
 2562: \x94     MEMOIZE    (as 132)
 2563: \x8c     SHORT_BINUNICODE 'pydantic._internal._decorators'
 2595: \x94     MEMOIZE    (as 133)
 2596: \x8c     SHORT_BINUNICODE 'DecoratorInfos'
 2612: \x94     MEMOIZE    (as 134)
 2613: \x93     STACK_GLOBAL
 2614: \x94     MEMOIZE    (as 135)
 2615: )        EMPTY_TUPLE
 2616: \x81     NEWOBJ
 2617: \x94     MEMOIZE    (as 136)
 2618: N        NONE
 2619: }        EMPTY_DICT
 2620: \x94     MEMOIZE    (as 137)
 2621: (        MARK
 2622: \x8c         SHORT_BINUNICODE 'validators'
 2634: \x94         MEMOIZE    (as 138)
 2635: }            EMPTY_DICT
 2636: \x94         MEMOIZE    (as 139)
 2637: \x8c         SHORT_BINUNICODE 'field_validators'
 2655: \x94         MEMOIZE    (as 140)
 2656: }            EMPTY_DICT
 2657: \x94         MEMOIZE    (as 141)
 2658: \x8c         SHORT_BINUNICODE 'root_validators'
 2675: \x94         MEMOIZE    (as 142)
 2676: }            EMPTY_DICT
 2677: \x94         MEMOIZE    (as 143)
 2678: \x8c         SHORT_BINUNICODE 'field_serializers'
 2697: \x94         MEMOIZE    (as 144)
 2698: }            EMPTY_DICT
 2699: \x94         MEMOIZE    (as 145)
 2700: \x8c         SHORT_BINUNICODE 'model_serializers'
 2719: \x94         MEMOIZE    (as 146)
 2720: }            EMPTY_DICT
 2721: \x94         MEMOIZE    (as 147)
 2722: \x8c         SHORT_BINUNICODE 'model_validators'
 2740: \x94         MEMOIZE    (as 148)
 2741: }            EMPTY_DICT
 2742: \x94         MEMOIZE    (as 149)
 2743: h            BINGET     63
 2745: }            EMPTY_DICT
 2746: \x94         MEMOIZE    (as 150)
 2747: u            SETITEMS   (MARK at 2621)
 2748: \x86     TUPLE2
 2749: \x94     MEMOIZE    (as 151)
 2750: b        BUILD
 2751: \x8c     SHORT_BINUNICODE '__pydantic_fields__'
 2772: \x94     MEMOIZE    (as 152)
 2773: }        EMPTY_DICT
 2774: \x94     MEMOIZE    (as 153)
 2775: (        MARK
 2776: h            BINGET     24
 2778: \x8c         SHORT_BINUNICODE 'pydantic.fields'
 2795: \x94         MEMOIZE    (as 154)
 2796: \x8c         SHORT_BINUNICODE 'FieldInfo'
 2807: \x94         MEMOIZE    (as 155)
 2808: \x93         STACK_GLOBAL
 2809: \x94         MEMOIZE    (as 156)
 2810: )            EMPTY_TUPLE
 2811: \x81         NEWOBJ
 2812: \x94         MEMOIZE    (as 157)
 2813: N            NONE
 2814: }            EMPTY_DICT
 2815: \x94         MEMOIZE    (as 158)
 2816: (            MARK
 2817: \x8c             SHORT_BINUNICODE 'annotation'
 2829: \x94             MEMOIZE    (as 159)
 2830: \x8c             SHORT_BINUNICODE 'builtins'
 2840: \x94             MEMOIZE    (as 160)
 2841: \x8c             SHORT_BINUNICODE 'str'
 2846: \x94             MEMOIZE    (as 161)
 2847: \x93             STACK_GLOBAL
 2848: \x94             MEMOIZE    (as 162)
 2849: \x8c             SHORT_BINUNICODE 'evaluated'
 2860: \x94             MEMOIZE    (as 163)
 2861: \x88             NEWTRUE
 2862: \x8c             SHORT_BINUNICODE 'default'
 2871: \x94             MEMOIZE    (as 164)
 2872: \x8c             SHORT_BINUNICODE 'pydantic_core._pydantic_core'
 2902: \x94             MEMOIZE    (as 165)
 2903: \x8c             SHORT_BINUNICODE 'PydanticUndefined'
 2922: \x94             MEMOIZE    (as 166)
 2923: \x93             STACK_GLOBAL
 2924: \x94             MEMOIZE    (as 167)
 2925: \x8c             SHORT_BINUNICODE 'default_factory'
 2942: \x94             MEMOIZE    (as 168)
 2943: N                NONE
 2944: \x8c             SHORT_BINUNICODE 'alias'
 2951: \x94             MEMOIZE    (as 169)
 2952: N                NONE
 2953: \x8c             SHORT_BINUNICODE 'alias_priority'
 2969: \x94             MEMOIZE    (as 170)
 2970: N                NONE
 2971: \x8c             SHORT_BINUNICODE 'validation_alias'
 2989: \x94             MEMOIZE    (as 171)
 2990: N                NONE
 2991: \x8c             SHORT_BINUNICODE 'serialization_alias'
 3012: \x94             MEMOIZE    (as 172)
 3013: N                NONE
 3014: h                BINGET     69
 3016: N                NONE
 3017: \x8c             SHORT_BINUNICODE 'field_title_generator'
 3040: \x94             MEMOIZE    (as 173)
 3041: N                NONE
 3042: \x8c             SHORT_BINUNICODE 'description'
 3055: \x94             MEMOIZE    (as 174)
 3056: N                NONE
 3057: \x8c             SHORT_BINUNICODE 'examples'
 3067: \x94             MEMOIZE    (as 175)
 3068: N                NONE
 3069: \x8c             SHORT_BINUNICODE 'exclude'
 3078: \x94             MEMOIZE    (as 176)
 3079: N                NONE
 3080: \x8c             SHORT_BINUNICODE 'discriminator'
 3095: \x94             MEMOIZE    (as 177)
 3096: N                NONE
 3097: \x8c             SHORT_BINUNICODE 'deprecated'
 3109: \x94             MEMOIZE    (as 178)
 3110: N                NONE
 3111: \x8c             SHORT_BINUNICODE 'json_schema_extra'
 3130: \x94             MEMOIZE    (as 179)
 3131: N                NONE
 3132: \x8c             SHORT_BINUNICODE 'frozen'
 3140: \x94             MEMOIZE    (as 180)
 3141: N                NONE
 3142: \x8c             SHORT_BINUNICODE 'validate_default'
 3160: \x94             MEMOIZE    (as 181)
 3161: N                NONE
 3162: \x8c             SHORT_BINUNICODE 'repr'
 3168: \x94             MEMOIZE    (as 182)
 3169: \x88             NEWTRUE
 3170: \x8c             SHORT_BINUNICODE 'init'
 3176: \x94             MEMOIZE    (as 183)
 3177: N                NONE
 3178: \x8c             SHORT_BINUNICODE 'init_var'
 3188: \x94             MEMOIZE    (as 184)
 3189: N                NONE
 3190: \x8c             SHORT_BINUNICODE 'kw_only'
 3199: \x94             MEMOIZE    (as 185)
 3200: N                NONE
 3201: h                BINGET     50
 3203: ]                EMPTY_LIST
 3204: \x94             MEMOIZE    (as 186)
 3205: \x8c             SHORT_BINUNICODE '_attributes_set'
 3222: \x94             MEMOIZE    (as 187)
 3223: }                EMPTY_DICT
 3224: \x94             MEMOIZE    (as 188)
 3225: (                MARK
 3226: h                    BINGET     159
 3228: h                    BINGET     162
 3230: h                    BINGET     180
 3232: N                    NONE
 3233: u                    SETITEMS   (MARK at 3225)
 3234: u                SETITEMS   (MARK at 2816)
 3235: \x86         TUPLE2
 3236: \x94         MEMOIZE    (as 189)
 3237: b            BUILD
 3238: h            BINGET     26
 3240: h            BINGET     156
 3242: )            EMPTY_TUPLE
 3243: \x81         NEWOBJ
 3244: \x94         MEMOIZE    (as 190)
 3245: N            NONE
 3246: }            EMPTY_DICT
 3247: \x94         MEMOIZE    (as 191)
 3248: (            MARK
 3249: h                BINGET     159
 3251: h                BINGET     77
 3253: \x8c             SHORT_BINUNICODE 'GenericAlias'
 3267: \x94             MEMOIZE    (as 192)
 3268: \x85             TUPLE1
 3269: \x94             MEMOIZE    (as 193)
 3270: R                REDUCE
 3271: \x94             MEMOIZE    (as 194)
 3272: h                BINGET     160
 3274: \x8c             SHORT_BINUNICODE 'list'
 3280: \x94             MEMOIZE    (as 195)
 3281: \x93             STACK_GLOBAL
 3282: \x94             MEMOIZE    (as 196)
 3283: h                BINGET     162
 3285: \x85             TUPLE1
 3286: \x94             MEMOIZE    (as 197)
 3287: \x86             TUPLE2
 3288: \x94             MEMOIZE    (as 198)
 3289: R                REDUCE
 3290: \x94             MEMOIZE    (as 199)
 3291: h                BINGET     163
 3293: \x88             NEWTRUE
 3294: h                BINGET     164
 3296: h                BINGET     167
 3298: h                BINGET     168
 3300: N                NONE
 3301: h                BINGET     169
 3303: N                NONE
 3304: h                BINGET     170
 3306: N                NONE
 3307: h                BINGET     171
 3309: N                NONE
 3310: h                BINGET     172
 3312: N                NONE
 3313: h                BINGET     69
 3315: N                NONE
 3316: h                BINGET     173
 3318: N                NONE
 3319: h                BINGET     174
 3321: N                NONE
 3322: h                BINGET     175
 3324: N                NONE
 3325: h                BINGET     176
 3327: N                NONE
 3328: h                BINGET     177
 3330: N                NONE
 3331: h                BINGET     178
 3333: N                NONE
 3334: h                BINGET     179
 3336: N                NONE
 3337: h                BINGET     180
 3339: N                NONE
 3340: h                BINGET     181
 3342: N                NONE
 3343: h                BINGET     182
 3345: \x88             NEWTRUE
 3346: h                BINGET     183
 3348: N                NONE
 3349: h                BINGET     184
 3351: N                NONE
 3352: h                BINGET     185
 3354: N                NONE
 3355: h                BINGET     50
 3357: ]                EMPTY_LIST
 3358: \x94             MEMOIZE    (as 200)
 3359: h                BINGET     187
 3361: }                EMPTY_DICT
 3362: \x94             MEMOIZE    (as 201)
 3363: (                MARK
 3364: h                    BINGET     159
 3366: h                    BINGET     199
 3368: h                    BINGET     180
 3370: N                    NONE
 3371: u                    SETITEMS   (MARK at 3363)
 3372: u                SETITEMS   (MARK at 3248)
 3373: \x86         TUPLE2
 3374: \x94         MEMOIZE    (as 202)
 3375: b            BUILD
 3376: h            BINGET     28
 3378: h            BINGET     156
 3380: )            EMPTY_TUPLE
 3381: \x81         NEWOBJ
 3382: \x94         MEMOIZE    (as 203)
 3383: N            NONE
 3384: }            EMPTY_DICT
 3385: \x94         MEMOIZE    (as 204)
 3386: (            MARK
 3387: h                BINGET     159
 3389: h                BINGET     194
 3391: h                BINGET     196
 3393: h                BINGET     162
 3395: \x85             TUPLE1
 3396: \x94             MEMOIZE    (as 205)
 3397: \x86             TUPLE2
 3398: \x94             MEMOIZE    (as 206)
 3399: R                REDUCE
 3400: \x94             MEMOIZE    (as 207)
 3401: h                BINGET     163
 3403: \x88             NEWTRUE
 3404: h                BINGET     164
 3406: h                BINGET     167
 3408: h                BINGET     168
 3410: N                NONE
 3411: h                BINGET     169
 3413: N                NONE
 3414: h                BINGET     170
 3416: N                NONE
 3417: h                BINGET     171
 3419: N                NONE
 3420: h                BINGET     172
 3422: N                NONE
 3423: h                BINGET     69
 3425: N                NONE
 3426: h                BINGET     173
 3428: N                NONE
 3429: h                BINGET     174
 3431: N                NONE
 3432: h                BINGET     175
 3434: N                NONE
 3435: h                BINGET     176
 3437: N                NONE
 3438: h                BINGET     177
 3440: N                NONE
 3441: h                BINGET     178
 3443: N                NONE
 3444: h                BINGET     179
 3446: N                NONE
 3447: h                BINGET     180
 3449: N                NONE
 3450: h                BINGET     181
 3452: N                NONE
 3453: h                BINGET     182
 3455: \x88             NEWTRUE
 3456: h                BINGET     183
 3458: N                NONE
 3459: h                BINGET     184
 3461: N                NONE
 3462: h                BINGET     185
 3464: N                NONE
 3465: h                BINGET     50
 3467: ]                EMPTY_LIST
 3468: \x94             MEMOIZE    (as 208)
 3469: h                BINGET     187
 3471: }                EMPTY_DICT
 3472: \x94             MEMOIZE    (as 209)
 3473: (                MARK
 3474: h                    BINGET     159
 3476: h                    BINGET     207
 3478: h                    BINGET     180
 3480: N                    NONE
 3481: u                    SETITEMS   (MARK at 3473)
 3482: u                SETITEMS   (MARK at 3386)
 3483: \x86         TUPLE2
 3484: \x94         MEMOIZE    (as 210)
 3485: b            BUILD
 3486: u            SETITEMS   (MARK at 2775)
 3487: \x8c     SHORT_BINUNICODE '__pydantic_generic_metadata__'
 3518: \x94     MEMOIZE    (as 211)
 3519: }        EMPTY_DICT
 3520: \x94     MEMOIZE    (as 212)
 3521: (        MARK
 3522: \x8c         SHORT_BINUNICODE 'origin'
 3530: \x94         MEMOIZE    (as 213)
 3531: N            NONE
 3532: \x8c         SHORT_BINUNICODE 'args'
 3538: \x94         MEMOIZE    (as 214)
 3539: )            EMPTY_TUPLE
 3540: \x8c         SHORT_BINUNICODE 'parameters'
 3552: \x94         MEMOIZE    (as 215)
 3553: )            EMPTY_TUPLE
 3554: u            SETITEMS   (MARK at 3521)
 3555: \x8c     SHORT_BINUNICODE '__pydantic_serializer__'
 3580: \x94     MEMOIZE    (as 216)
 3581: \x8c     SHORT_BINUNICODE 'pydantic_core._pydantic_core'
 3611: \x94     MEMOIZE    (as 217)
 3612: \x8c     SHORT_BINUNICODE 'SchemaSerializer'
 3630: \x94     MEMOIZE    (as 218)
 3631: \x93     STACK_GLOBAL
 3632: \x94     MEMOIZE    (as 219)
 3633: h        BINGET     38
 3635: }        EMPTY_DICT
 3636: \x94     MEMOIZE    (as 220)
 3637: (        MARK
 3638: h            BINGET     69
 3640: h            BINGET     6
 3642: h            BINGET     70
 3644: \x88         NEWTRUE
 3645: u            SETITEMS   (MARK at 3637)
 3646: \x86     TUPLE2
 3647: \x94     MEMOIZE    (as 221)
 3648: R        REDUCE
 3649: \x94     MEMOIZE    (as 222)
 3650: \x8c     SHORT_BINUNICODE '__pydantic_validator__'
 3674: \x94     MEMOIZE    (as 223)
 3675: \x8c     SHORT_BINUNICODE 'pydantic_core._pydantic_core'
 3705: \x94     MEMOIZE    (as 224)
 3706: \x8c     SHORT_BINUNICODE 'SchemaValidator'
 3723: \x94     MEMOIZE    (as 225)
 3724: \x93     STACK_GLOBAL
 3725: \x94     MEMOIZE    (as 226)
 3726: h        BINGET     38
 3728: h        BINGET     220
 3730: \x86     TUPLE2
 3731: \x94     MEMOIZE    (as 227)
 3732: R        REDUCE
 3733: \x94     MEMOIZE    (as 228)
 3734: \x8c     SHORT_BINUNICODE '__signature__'
 3749: \x94     MEMOIZE    (as 229)
 3750: \x8c     SHORT_BINUNICODE 'pydantic._internal._utils'
 3777: \x94     MEMOIZE    (as 230)
 3778: \x8c     SHORT_BINUNICODE 'LazyClassAttribute'
 3798: \x94     MEMOIZE    (as 231)
 3799: \x93     STACK_GLOBAL
 3800: \x94     MEMOIZE    (as 232)
 3801: )        EMPTY_TUPLE
 3802: \x81     NEWOBJ
 3803: \x94     MEMOIZE    (as 233)
 3804: }        EMPTY_DICT
 3805: \x94     MEMOIZE    (as 234)
 3806: (        MARK
 3807: h            BINGET     24
 3809: \x8c         SHORT_BINUNICODE '__signature__'
 3824: \x94         MEMOIZE    (as 235)
 3825: \x8c         SHORT_BINUNICODE 'get_value'
 3836: \x94         MEMOIZE    (as 236)
 3837: \x8c         SHORT_BINUNICODE 'functools'
 3848: \x94         MEMOIZE    (as 237)
 3849: \x8c         SHORT_BINUNICODE 'partial'
 3858: \x94         MEMOIZE    (as 238)
 3859: \x93         STACK_GLOBAL
 3860: \x94         MEMOIZE    (as 239)
 3861: \x8c         SHORT_BINUNICODE 'pydantic._internal._signature'
 3892: \x94         MEMOIZE    (as 240)
 3893: \x8c         SHORT_BINUNICODE 'generate_pydantic_signature'
 3922: \x94         MEMOIZE    (as 241)
 3923: \x93         STACK_GLOBAL
 3924: \x94         MEMOIZE    (as 242)
 3925: \x85         TUPLE1
 3926: \x94         MEMOIZE    (as 243)
 3927: R            REDUCE
 3928: \x94         MEMOIZE    (as 244)
 3929: (            MARK
 3930: h                BINGET     242
 3932: )                EMPTY_TUPLE
 3933: }                EMPTY_DICT
 3934: \x94             MEMOIZE    (as 245)
 3935: (                MARK
 3936: h                    BINGET     183
 3938: h                    BINGET     103
 3940: \x8c                 SHORT_BINUNICODE 'BaseModel.__init__'
 3960: \x94                 MEMOIZE    (as 246)
 3961: \x93                 STACK_GLOBAL
 3962: \x94                 MEMOIZE    (as 247)
 3963: h                    BINGET     45
 3965: h                    BINGET     153
 3967: h                    BINGET     70
 3969: \x88                 NEWTRUE
 3970: \x8c                 SHORT_BINUNICODE 'extra'
 3977: \x94                 MEMOIZE    (as 248)
 3978: N                    NONE
 3979: u                    SETITEMS   (MARK at 3935)
 3980: N                NONE
 3981: t                TUPLE      (MARK at 3929)
 3982: \x94         MEMOIZE    (as 249)
 3983: b            BUILD
 3984: u            SETITEMS   (MARK at 3806)
 3985: b        BUILD
 3986: \x8c     SHORT_BINUNICODE 'model_config'
 4000: \x94     MEMOIZE    (as 250)
 4001: }        EMPTY_DICT
 4002: \x94     MEMOIZE    (as 251)
 4003: h        BINGET     70
 4005: \x88     NEWTRUE
 4006: s        SETITEM
 4007: \x8c     SHORT_BINUNICODE '_abc_impl'
 4018: \x94     MEMOIZE    (as 252)
 4019: ]        EMPTY_LIST
 4020: \x94     MEMOIZE    (as 253)
 4021: u        SETITEMS   (MARK at 306)
 4022: }    EMPTY_DICT
 4023: \x94 MEMOIZE    (as 254)
 4024: \x86 TUPLE2
 4025: \x94 MEMOIZE    (as 255)
 4026: \x86 TUPLE2
 4027: R    REDUCE
 4028: 0    POP
 4029: .    STOP
```
</details>

**TODO**

- [ ] tests (!)