### PR TITLE
Fix datachain version comparison

### DIFF
--- a/src/datachain/semver.py
+++ b/src/datachain/semver.py
@@ -1,8 +1,13 @@
+# Maximum version number for semver (major.minor.patch) is 999999.999999.999999
+# this number was chosen because value("999999.999999.999999") < 2**63 - 1
+MAX_VERSION_NUMBER = 999_999
+
+
 def parse(version: str) -> tuple[int, int, int]:
     """Parsing semver into 3 integers: major, minor, patch"""
     validate(version)
     parts = version.split(".")
-    return (int(parts[0]), int(parts[1]), int(parts[2]))
+    return int(parts[0]), int(parts[1]), int(parts[2])
 
 
 def validate(version: str) -> None:
@@ -20,14 +25,18 @@ def validate(version: str) -> None:
     for part in parts:
         try:
             val = int(part)
-            assert val >= 0
+            assert 0 <= val <= MAX_VERSION_NUMBER
         except (ValueError, AssertionError):
             raise ValueError(error_message) from None
 
 
 def create(major: int = 0, minor: int = 0, patch: int = 0) -> str:
     """Creates new semver from 3 integers: major, minor and patch"""
-    if major < 0 or minor < 0 or patch < 0:
+    if not (
+        0 <= major <= MAX_VERSION_NUMBER
+        and 0 <= minor <= MAX_VERSION_NUMBER
+        and 0 <= patch <= MAX_VERSION_NUMBER
+    ):
         raise ValueError("Major, minor and patch must be greater or equal to zero")
 
     return ".".join([str(major), str(minor), str(patch)])
@@ -35,10 +44,11 @@ def create(major: int = 0, minor: int = 0, patch: int = 0) -> str:
 
 def value(version: str) -> int:
     """
-    Calculate integer value of a version. This is useful when comparing two versions
+    Calculate integer value of a version. This is useful when comparing two versions.
     """
     major, minor, patch = parse(version)
-    return major * 100 + minor * 10 + patch
+    limit = MAX_VERSION_NUMBER + 1
+    return major * (limit**2) + minor * limit + patch
 
 
 def compare(v1: str, v2: str) -> int:

--- a/tests/unit/test_semver.py
+++ b/tests/unit/test_semver.py
@@ -3,35 +3,90 @@ import pytest
 from datachain import semver
 
 
-def test_parse():
-    assert semver.parse("0.1.2") == (0, 1, 2)
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("0.0.0", (0, 0, 0)),
+        ("0.1.2", (0, 1, 2)),
+        ("1.0.0", (1, 0, 0)),
+        ("10.20.30", (10, 20, 30)),
+        ("100.200.300", (100, 200, 300)),
+        ("999999.999999.999999", (999999, 999999, 999999)),
+    ],
+)
+def test_parse(version, expected):
+    assert semver.parse(version) == expected
 
 
-def test_parse_wrong_format():
+@pytest.mark.parametrize(
+    "version",
+    [
+        "0",
+        "1",
+        "-1",
+        "1.2",
+        "1.2.-3",
+        "1.2.3-alpha+01",
+        "dev",
+    ],
+)
+def test_parse_wrong_format(version):
     with pytest.raises(ValueError) as excinfo:
-        semver.parse("1.2")
+        semver.parse(version)
     assert str(excinfo.value) == (
         "Invalid version. It should be in format: <major>.<minor>.<patch> where"
         " each version part is positive integer"
     )
 
 
-def test_create():
-    assert semver.create() == "0.0.0"
-    assert semver.create(1, 2, 3) == "1.2.3"
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ((), "0.0.0"),
+        ((0, 0, 0), "0.0.0"),
+        ((1, 2, 3), "1.2.3"),
+        ((10, 20, 30), "10.20.30"),
+        ((100, 200, 300), "100.200.300"),
+        ((999999, 999999, 999999), "999999.999999.999999"),
+    ],
+)
+def test_create(version, expected):
+    assert semver.create(*version) == expected
 
 
-def test_create_wrong_values():
+@pytest.mark.parametrize(
+    "version",
+    [
+        (-1,),
+        (1, 1000000),
+        (-1, 2, 3),
+        (1, -2, 3),
+        (1, 2, -3),
+        (1000000, 0, 0),
+        (0, 1000000, 0),
+        (0, 0, 1000000),
+    ],
+)
+def test_create_wrong_values(version):
     with pytest.raises(ValueError) as excinfo:
-        semver.create(-1, 2, 3)
+        semver.create(*version)
     assert str(excinfo.value) == (
         "Major, minor and patch must be greater or equal to zero"
     )
 
 
-def test_value():
-    assert semver.value("0.0.0") == 0
-    assert semver.value("1.2.3") == 123
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("0.0.0", 0),
+        ("1.2.3", 1_000_002_000_003),
+        ("10.20.30", 10_000_020_000_030),
+        ("100.200.300", 100_000_200_000_300),
+        ("999999.999999.999999", 999_999_999_999_999_999),
+    ],
+)
+def test_value(version, expected):
+    assert semver.value(version) == expected
 
 
 @pytest.mark.parametrize(
@@ -41,6 +96,12 @@ def test_value():
         ("1.2.3", "1.2.3", 0),
         ("1.2.3", "1.2.4", -1),
         ("1.2.3", "1.2.2", 1),
+        ("0.0.0", "999999.999999.999999", -1),
+        ("999999.999999.999999", "0.0.1", 1),
+        ("999999.999999.999999", "999998.999999.999999", 1),
+        ("999999.999998.999999", "999999.999999.999999", -1),
+        ("999999.999999.999999", "999999.999999.999998", 1),
+        ("999999.999999.999999", "999999.999999.999999", 0),
     ],
 )
 def test_compare(v1, v2, result):
@@ -52,6 +113,9 @@ def test_compare(v1, v2, result):
     [
         ("0.0.0", True),
         ("100.100.100", True),
+        ("999999.999999.999999", True),
+        ("9999999.9999999.9999999", False),
+        ("1000000.0.1", False),
         ("-1.2.3", False),
         ("1.2.3-alpha+01", False),
         ("1.2", False),


### PR DESCRIPTION
To compare versions we calculating `int` based on semver.

Before it was `major * 100 + minor * 10 + patch` — max supported version is `9.9.9` (versions like `0.0.10` and `0.1.0` are the same for this algorythm).

In this PR it will be `major * 1_000_000_000_000 + minor * 1_0000_000 + patch` (max supported version is `999999.999999.999999`).

Also added more test cases.