### PR TITLE
fix(hf): initialize kwargs in default ls_dir

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -330,6 +330,7 @@ class Client(ABC):
         return getattr(self.fs, "version_aware", False)
 
     async def ls_dir(self, path):
+        kwargs = {}
         if self._is_version_aware():
             kwargs = {"versions": True}
         return await self.fs._ls(path, detail=True, **kwargs)


### PR DESCRIPTION
Fixes `ls_dir` default implementation. It used only in HF at the moment. HF supposed to be (and was covered by a test) - but it was disabled since it very unstable.