### PR TITLE
fix(hf): init with async set to false to always init loop

### DIFF
--- a/src/datachain/client/hf.py
+++ b/src/datachain/client/hf.py
@@ -15,6 +15,24 @@ class classproperty:  # noqa: N801
         return self.fget(owner)
 
 
+def _wrap_class(sync_fs_class):
+    """
+    Analog of `AsyncFileSystemWrapper.wrap_class` from fsspec, but sets
+    asynchronous to False by default. This is similar to other Async FS
+    we initialize. E.g. it means we don't break things in Jupyter where code
+    run in async.
+    """
+    from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+
+    class GeneratedAsyncFileSystemWrapper(AsyncFileSystemWrapper):
+        def __init__(self, *args, **kwargs):
+            sync_fs = sync_fs_class(*args, **kwargs)
+            super().__init__(sync_fs, asynchronous=False)
+
+    GeneratedAsyncFileSystemWrapper.__name__ = f"Async{sync_fs_class.__name__}Wrapper"
+    return GeneratedAsyncFileSystemWrapper
+
+
 @functools.cache
 def get_hf_filesystem_cls():
     import fsspec
@@ -29,10 +47,9 @@ def get_hf_filesystem_cls():
             f"{fsspec_version} is installed."
         )
 
-    from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
     from huggingface_hub import HfFileSystem
 
-    fs_cls = AsyncFileSystemWrapper.wrap_class(HfFileSystem)
+    fs_cls = _wrap_class(HfFileSystem)
     # AsyncFileSystemWrapper does not set class properties, so we need to set them back.
     fs_cls.protocol = HfFileSystem.protocol
     return fs_cls


### PR DESCRIPTION
W/o this we are getting `RuntimeError("Loop is not running")` from the `sync()` wrapper:

```python
if loop is None or loop.is_closed():
        raise RuntimeError("Loop is not running")
```

`loop` is None since we have this piece of in the `AsyncFileSystem` `init`:

```python
        if not asynchronous:
            self._loop = loop or get_loop()
        else:
            self._loop = None
```

and `asynchronous` flag is set in the `AsyncWrapper` this way:

```python
        if asynchronous is None:
            asynchronous = running_async()
```

So `running_async()` async defines if loop is created or not. And if it is not creted, `sync` doesn't work. In Jupyter `running_async()` returns True. So, all our code that does `sync` is breaking`. I'm not sure if there is a better fix for all of this tbh. cc @skshetry @martindurant

If this sounds reasonable, we can add `*args` to the  official wrapper code I think.
