### PR TITLE
Add option to list the compute clusters for a team

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -31,3 +31,5 @@ DataChain is a command-line tool for wrangling unstructured AI data at scale. Us
 	- Monitor job logs with [`datachain job logs`](job/logs.md)
 
 	- Cancel running jobs with [`datachain job cancel`](job/cancel.md)
+
+	- Check for the clusters available for jobs [`datachain job clusters`](job/clusters.md)

--- a/docs/commands/job/run.md
+++ b/docs/commands/job/run.md
@@ -72,8 +72,17 @@ datachain job run --repository https://github.com/iterative/datachain query.py
 datachain job run --priority 2 query.py
 ```
 
+8. Run a job in a specific cluster
+```bash
+# Get the cluster id using following command
+datachain job clusters
+# Use the id  of an active clusters from above
+datachain job run --cluster-id 1 query.py
+```
+
 ## Notes
 
 * Closing the logs command (e.g., with Ctrl+C) will only stop displaying the logs but will not cancel the job execution
 * To cancel a running job, use the `datachain job cancel` command
 * The job will continue running in Studio even after you stop viewing the logs
+* You can get the list of compute cluster using `datachain job clusters` command.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
                   - logs: commands/job/logs.md
                   - cancel: commands/job/cancel.md
                   - ls: commands/job/ls.md
+                  - clusters: commands/job/clusters.md
       - 📚 User Guide:
           - Overview: guide/index.md
           - 📡 Interacting with remote storage: guide/remotes.md

--- a/src/datachain/cli/parser/job.py
+++ b/src/datachain/cli/parser/job.py
@@ -172,3 +172,21 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
         default=None,
         help="Team to check logs for (default: from config)",
     )
+
+    studio_clusters_help = "List compute clusters in Studio"
+    studio_clusters_description = "List compute clusters in Studio."
+
+    studio_clusters_parser = jobs_subparser.add_parser(
+        "clusters",
+        parents=[parent_parser],
+        description=studio_clusters_description,
+        help=studio_clusters_help,
+        formatter_class=CustomHelpFormatter,
+    )
+
+    studio_clusters_parser.add_argument(
+        "--team",
+        action="store",
+        default=None,
+        help="Team to list clusters for (default: from config)",
+    )

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -30,6 +30,7 @@ DatasetExportSignedUrls = Optional[list[str]]
 FileUploadData = Optional[dict[str, Any]]
 JobData = Optional[dict[str, Any]]
 JobListData = dict[str, Any]
+ClusterListData = dict[str, Any]
 logger = logging.getLogger("datachain")
 
 DATASET_ROWS_CHUNK_SIZE = 8192
@@ -425,3 +426,6 @@ class StudioClient:
     ) -> Response[JobData]:
         url = f"datachain/job/{job_id}/cancel"
         return self._send_request(url, data={}, method="POST")
+
+    def get_clusters(self) -> Response[ClusterListData]:
+        return self._send_request("datachain/clusters", {}, method="GET")

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -52,6 +52,9 @@ def process_jobs_args(args: "Namespace"):
     if args.cmd == "ls":
         return list_jobs(args.status, args.team, args.limit)
 
+    if args.cmd == "clusters":
+        return list_clusters(args.team)
+
     raise DataChainError(f"Unknown command '{args.cmd}'.")
 
 
@@ -383,3 +386,29 @@ def show_job_logs(job_id: str, team_name: Optional[str]):
 
     client = StudioClient(team=team_name)
     show_logs_from_client(client, job_id)
+
+
+def list_clusters(team_name: Optional[str]):
+    client = StudioClient(team=team_name)
+    response = client.get_clusters()
+    if not response.ok:
+        raise DataChainError(response.message)
+
+    clusters = response.data.get("clusters", [])
+    if not clusters:
+        print("No clusters found")
+        return
+
+    rows = [
+        {
+            "ID": cluster.get("id"),
+            "Status": cluster.get("status"),
+            "Cloud Provider": cluster.get("cloud_provider"),
+            "Cloud Credentials": cluster.get("cloud_credentials"),
+            "Is Active": cluster.get("is_active"),
+            "Max Workers": cluster.get("max_workers"),
+        }
+        for cluster in clusters
+    ]
+
+    print(tabulate.tabulate(rows, headers="keys", tablefmt="grid"))


### PR DESCRIPTION
This adds an option to list the compute clusters for a team using
following command:

`datachain job clusters`

The sample output is:
```
+------+----------+------------------+---------------------+-------------+---------------+
|   ID | Status   | Cloud Provider   | Cloud Credentials   | Is Active   |   Max Workers |
+======+==========+==================+=====================+=============+===============+
|    1 | INACTIVE | AWS              | aws creds           | False       |             0 |
+------+----------+------------------+---------------------+-------------+---------------+
```
