### PR TITLE
Use string type for null-columns in CSV

### DIFF
--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -241,6 +241,8 @@ def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa:
         return dict
     if isinstance(col_type, pa.lib.DictionaryType):
         return arrow_type_mapper(col_type.value_type)  # type: ignore[return-value]
+    if pa.types.is_null(col_type):
+        return str  # use strings for null columns
     raise TypeError(f"{col_type!r} datatypes not supported, column: {column}")
 
 

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -154,6 +154,7 @@ def test_arrow_generator_partitioned(tmp_path, catalog, cache):
         (pa.map_(pa.string(), pa.int32()), dict),
         (pa.dictionary(pa.int64(), pa.string()), str),
         (pa.list_(pa.string()), list[str]),
+        (pa.null(), str),
     ),
 )
 def test_arrow_type_mapper(col_type, expected):
@@ -161,11 +162,11 @@ def test_arrow_type_mapper(col_type, expected):
 
 
 def test_arrow_type_mapper_struct():
-    col_type = pa.struct({"x": pa.int32(), "y": pa.string()})
+    col_type = pa.struct({"x": pa.int32(), "y": pa.string(), "z": pa.null()})
     fields = arrow_type_mapper(col_type).model_fields
-    assert list(fields.keys()) == ["x", "y"]
+    assert list(fields.keys()) == ["x", "y", "z"]
     dtypes = [field.annotation for field in fields.values()]
-    assert dtypes == [Optional[int], Optional[str]]
+    assert dtypes == [Optional[int], Optional[str], Optional[str]]
 
 
 def test_arrow_type_error():


### PR DESCRIPTION
In case we have empty column in CSV file we want to process, this error happens:

```
TypeError: DataType(null) datatypes not supported, column: column_name
```

We are using string as default type for columns, let's use it here too.

**TODO:**

- [x] tests