### PR TITLE
Deprecate collect() introduce to_iter() and to_list()

### DIFF
--- a/examples/get_started/json-csv-reader.py
+++ b/examples/get_started/json-csv-reader.py
@@ -48,7 +48,7 @@ def main():
 
     # Print JSON schema in Pydantic format from main COCO annotation
     chain = dc.read_storage(uri, anon="True").filter(dc.C("file.path").glob("*.json"))
-    file = chain.limit(1).to_list("file")[0]
+    file = chain.limit(1).to_values("file")[0]
     print(gen_datamodel_code(file, jmespath="@", model_name="Coco"))
 
     # Static JSON schema test parsing 3/7 objects

--- a/examples/get_started/json-csv-reader.py
+++ b/examples/get_started/json-csv-reader.py
@@ -48,7 +48,7 @@ def main():
 
     # Print JSON schema in Pydantic format from main COCO annotation
     chain = dc.read_storage(uri, anon="True").filter(dc.C("file.path").glob("*.json"))
-    file = next(chain.limit(1).collect("file"))
+    file = chain.limit(1).to_list("file")[0]
     print(gen_datamodel_code(file, jmespath="@", model_name="Coco"))
 
     # Static JSON schema test parsing 3/7 objects

--- a/examples/incremental_processing/delta.py
+++ b/examples/incremental_processing/delta.py
@@ -47,7 +47,7 @@ def process_files_with_delta():
     print("\nDataset versions:")
     test_dataset = dc.datasets().filter(C("name") == "test_files")
 
-    for version in test_dataset.collect("version"):
+    for version in test_dataset.to_iter("version"):
         print(f"- Version: {version}")
 
     # Show the last 3 records to demonstrate the incremental processing

--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -64,7 +64,7 @@ def ls_local(
     else:
         # Collect results in a list here to prevent interference from `tqdm` and `print`
         listing = listings().to_list("listing")
-        for ls in listing:
+        for (ls,) in listing:
             print(format_ls_entry(f"{ls.uri}@v{ls.version}"))  # type: ignore[union-attr]
 
 

--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -63,7 +63,7 @@ def ls_local(
                     print(format_ls_entry(entry))
     else:
         # Collect results in a list here to prevent interference from `tqdm` and `print`
-        listing = list(listings().collect("listing"))
+        listing = listings().to_list("listing")
         for ls in listing:
             print(format_ls_entry(f"{ls.uri}@v{ls.version}"))  # type: ignore[union-attr]
 

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -160,7 +160,7 @@ def infer_schema(chain: "DataChain", **kwargs) -> pa.Schema:
         kwargs["format"] = fix_pyarrow_format(format, parse_options)
 
     schemas = []
-    for file in chain.to_iter("file"):
+    for (file,) in chain.to_iter("file"):
         ds = dataset(file.get_path(), filesystem=file.get_fs(), **kwargs)  # type: ignore[union-attr]
         schemas.append(ds.schema)
     if not schemas:

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -160,7 +160,7 @@ def infer_schema(chain: "DataChain", **kwargs) -> pa.Schema:
         kwargs["format"] = fix_pyarrow_format(format, parse_options)
 
     schemas = []
-    for file in chain.collect("file"):
+    for file in chain.to_iter("file"):
         ds = dataset(file.get_path(), filesystem=file.get_fs(), **kwargs)  # type: ignore[union-attr]
         schemas.append(ds.schema)
     if not schemas:

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1170,19 +1170,26 @@ class DataChain:
         Example:
             Iterating over all rows:
             ```py
-            for row in dc.to_iter():
+            for row in ds.to_iter():
+                print(row)
+            ```
+
+            DataChain is iterable and can be used in a for loop directly which is
+            equivalent to `ds.to_iter()`:
+            ```py
+            for row in ds:
                 print(row)
             ```
 
             Iterating over all rows with selected columns:
             ```py
-            for name, size in dc.to_iter("file.path", "file.size"):
+            for name, size in ds.to_iter("file.path", "file.size"):
                 print(name, size)
             ```
 
             Iterating over a single column:
             ```py
-            for file in dc.to_iter("file.path"):
+            for file in ds.to_iter("file.path"):
                 print(file)
             ```
         """
@@ -2390,3 +2397,17 @@ class DataChain:
             ```
         """
         return list(self.to_iter(*cols))
+
+    def __iter__(self) -> Iterator[tuple[DataValue, ...]]:
+        """Make DataChain objects iterable.
+
+        Yields:
+            (tuple[DataValue, ...]): Yields tuples of all column values for each row.
+
+        Example:
+            ```py
+            for row in chain:
+                print(row)
+            ```
+        """
+        return self.to_iter()

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1206,34 +1206,8 @@ class DataChain:
     def collect(self, *cols: str) -> Iterator[tuple[DataValue, ...]]: ...
 
     def collect(self, *cols: str) -> Iterator[Union[DataValue, tuple[DataValue, ...]]]:  # type: ignore[overload-overlap,misc]
-        """Yields rows of values, optionally limited to the specified columns.
-
-        Args:
-            *cols: Limit to the specified columns. By default, all columns are selected.
-
-        Yields:
-            (DataType): Yields a single item if a column is selected.
-            (tuple[DataType, ...]): Yields a tuple of items if multiple columns are
-                selected.
-
-        Example:
-            Iterating over all rows:
-            ```py
-            for row in dc.collect():
-                print(row)
-            ```
-
-            Iterating over all rows with selected columns:
-            ```py
-            for name, size in dc.collect("file.path", "file.size"):
-                print(name, size)
-            ```
-
-            Iterating over a single column:
-            ```py
-            for file in dc.collect("file.path"):
-                print(file)
-            ```
+        """
+        Deprecated. Use `to_iter` method instead.
         """
         warnings.warn(
             "Method `collect` is deprecated. Use `to_iter` method instead.",
@@ -2374,3 +2348,45 @@ class DataChain:
             Use 0/3, 1/3 and 2/3, not 1/3, 2/3 and 3/3.
         """
         return self._evolve(query=self._query.chunk(index, total))
+
+    @overload
+    def to_list(self) -> list[tuple[DataValue, ...]]: ...
+
+    @overload
+    def to_list(self, col: str) -> list[DataValue]: ...
+
+    @overload
+    def to_list(self, *cols: str) -> list[tuple[DataValue, ...]]: ...
+
+    def to_list(self, *cols: str) -> list[Union[DataValue, tuple[DataValue, ...]]]:  # type: ignore[overload-overlap,misc]
+        """Returns a list of rows of values, optionally limited to the specified
+        columns.
+
+        Args:
+            *cols: Limit to the specified columns. By default, all columns are selected.
+
+        Returns:
+            list[DataType]: Returns a list of single items if a column is selected.
+            list[tuple[DataType, ...]]: Returns a list of tuples of items if multiple
+            columns are selected.
+
+        Example:
+            Getting all rows as a list:
+            ```py
+            rows = dc.to_list()
+            print(rows)
+            ```
+
+            Getting all rows with selected columns as a list:
+            ```py
+            name_size_pairs = dc.to_list("file.path", "file.size")
+            print(name_size_pairs)
+            ```
+
+            Getting a single column as a list:
+            ```py
+            files = dc.to_list("file.path")
+            print(files)
+            ```
+        """
+        return list(self.to_iter(*cols))

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -2254,7 +2254,7 @@ class DataChain:
             max_threads=num_threads or 1,
             client_config=client_config,
         )
-        file_exporter.run(self.to_iter(signal), progress_bar)
+        file_exporter.run(self.to_values(signal), progress_bar)
 
     def shuffle(self) -> "Self":
         """Shuffle the rows of the chain deterministically."""

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1197,12 +1197,6 @@ class DataChain:
 
         return self.results(row_factory=to_dict)
 
-    @overload
-    def to_iter(self) -> Iterator[tuple[DataValue, ...]]: ...
-
-    @overload
-    def to_iter(self, *cols: str) -> Iterator[tuple[DataValue, ...]]: ...
-
     def to_iter(self, *cols: str) -> Iterator[tuple[DataValue, ...]]:
         """Yields rows of values, optionally limited to the specified columns.
 
@@ -2395,12 +2389,6 @@ class DataChain:
         """
         return self._evolve(query=self._query.chunk(index, total))
 
-    @overload
-    def to_list(self) -> list[tuple[DataValue, ...]]: ...
-
-    @overload
-    def to_list(self, *cols: str) -> list[tuple[DataValue, ...]]: ...
-
     def to_list(self, *cols: str) -> list[tuple[DataValue, ...]]:
         """Returns a list of rows of values, optionally limited to the specified
         columns.
@@ -2431,6 +2419,30 @@ class DataChain:
             ```
         """
         return list(self.to_iter(*cols))
+
+    def to_values(self, col: str) -> list[DataValue]:
+        """Returns a flat list of values from a single column.
+
+        Args:
+            col: The name of the column to extract values from.
+
+        Returns:
+            list[DataValue]: Returns a flat list of values from the specified column.
+
+        Example:
+            Getting all values from a single column:
+            ```py
+            file_paths = dc.to_values("file.path")
+            print(file_paths)  # Returns list of strings
+            ```
+
+            Getting all file sizes:
+            ```py
+            sizes = dc.to_values("file.size")
+            print(sizes)  # Returns list of integers
+            ```
+        """
+        return [row[0] for row in self.to_list(col)]
 
     def __iter__(self) -> Iterator[tuple[DataValue, ...]]:
         """Make DataChain objects iterable.

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1267,10 +1267,10 @@ class DataChain:
             stacklevel=2,
         )
 
-        res = self.to_list(*cols)
         if len(cols) == 1:
-            return [item[0] for item in res]
-        return res
+            yield from [item[0] for item in self.to_iter(*cols)]
+        else:
+            yield from self.to_iter(*cols)
 
     def to_pytorch(
         self,

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -200,7 +200,7 @@ def datasets(
         import datachain as dc
 
         chain = dc.datasets(column="dataset")
-        for ds in chain.collect("dataset"):
+        for ds in chain.to_iter("dataset"):
             print(f"{ds.name}@v{ds.version}")
         ```
     """

--- a/src/datachain/lib/meta_formats.py
+++ b/src/datachain/lib/meta_formats.py
@@ -106,7 +106,7 @@ def read_meta(  # noqa: C901
     from datachain import read_storage
 
     if schema_from:
-        file = next(read_storage(schema_from, type="text").limit(1).collect("file"))
+        file = read_storage(schema_from, type="text").limit(1).to_list("file")[0]
         model_code = gen_datamodel_code(
             file, format=format, jmespath=jmespath, model_name=model_name
         )

--- a/src/datachain/lib/meta_formats.py
+++ b/src/datachain/lib/meta_formats.py
@@ -106,7 +106,7 @@ def read_meta(  # noqa: C901
     from datachain import read_storage
 
     if schema_from:
-        file = read_storage(schema_from, type="text").limit(1).to_list("file")[0]
+        file = read_storage(schema_from, type="text").limit(1).to_values("file")[0]
         model_code = gen_datamodel_code(
             file, format=format, jmespath=jmespath, model_name=model_name
         )

--- a/src/datachain/lib/pytorch.py
+++ b/src/datachain/lib/pytorch.py
@@ -130,7 +130,7 @@ class PytorchDataset(IterableDataset):
         if self.num_samples > 0:
             ds = ds.sample(self.num_samples)
         ds = ds.chunk(total_rank, total_workers)
-        yield from ds.collect()
+        yield from ds.to_iter()
 
     def _iter_with_prefetch(self) -> Generator[tuple[Any], None, None]:
         from datachain.lib.udf import _prefetch_inputs

--- a/tests/examples/test_wds_e2e.py
+++ b/tests/examples/test_wds_e2e.py
@@ -74,7 +74,7 @@ def test_wds(test_session, webdataset_tars):
     )
 
     num_rows = 0
-    for laion_wds in res.collect("laion"):
+    for laion_wds in res.to_iter("laion"):
         num_rows += 1
         assert isinstance(laion_wds, WDSLaion)
         idx, data = next(
@@ -106,7 +106,7 @@ def test_wds_merge_with_parquet_meta(
     res = wds.merge(meta, on="laion.json.uid", right_on="uid")
 
     num_rows = 0
-    for r in res.collect("laion"):
+    for r in res.to_iter("laion"):
         num_rows += 1
         assert isinstance(r, WDSLaion)
         assert isinstance(r.file, File)
@@ -117,7 +117,7 @@ def test_wds_merge_with_parquet_meta(
 
     assert num_rows == len(WDS_TAR_SHARDS)
 
-    meta_res = list(res.collect(*WDS_META.keys()))
+    meta_res = res.to_list(*WDS_META.keys())
 
     for field_name_idx, rows_values in enumerate(WDS_META.values()):
         assert sorted(rows_values.values()) == sorted(
@@ -125,7 +125,7 @@ def test_wds_merge_with_parquet_meta(
         )
 
     # validate correct merge
-    for laion_uid, uid in res.collect("laion.json.uid", "uid"):
+    for laion_uid, uid in res.to_iter("laion.json.uid", "uid"):
         assert laion_uid == uid
-    for caption, text in res.collect("laion.json.caption", "text"):
+    for caption, text in res.to_iter("laion.json.caption", "text"):
         assert caption == text

--- a/tests/examples/test_wds_e2e.py
+++ b/tests/examples/test_wds_e2e.py
@@ -74,7 +74,7 @@ def test_wds(test_session, webdataset_tars):
     )
 
     num_rows = 0
-    for laion_wds in res.to_iter("laion"):
+    for laion_wds in res.to_values("laion"):
         num_rows += 1
         assert isinstance(laion_wds, WDSLaion)
         idx, data = next(
@@ -106,7 +106,7 @@ def test_wds_merge_with_parquet_meta(
     res = wds.merge(meta, on="laion.json.uid", right_on="uid")
 
     num_rows = 0
-    for r in res.to_iter("laion"):
+    for r in res.to_values("laion"):
         num_rows += 1
         assert isinstance(r, WDSLaion)
         assert isinstance(r.file, File)

--- a/tests/func/functions/test_aggregate.py
+++ b/tests/func/functions/test_aggregate.py
@@ -7,7 +7,7 @@ def test_aggregate_avg(test_session):
         i: int
         f: float
 
-    ds = list(
+    ds = (
         dc.read_values(
             id=(1, 2, 3),
             data=(
@@ -18,15 +18,13 @@ def test_aggregate_avg(test_session):
             ii=(20, 40, 60),
             ff=(2.0, 4.0, 6.0),
             session=test_session,
-        )
-        .group_by(
+        ).group_by(
             t1=func.avg("data.i"),
             t2=func.avg(dc.C("data.f")),
             t3=func.avg(dc.C("ii")),
             t4=func.avg("ff"),
         )
-        .collect("t1", "t2", "t3", "t4")
-    )
+    ).to_list("t1", "t2", "t3", "t4")
 
     assert ds == [(20.0, 2.0, 40.0, 4.0)]
 
@@ -58,7 +56,7 @@ def test_aggregate_count(test_session):
             t5=func.count(dc.C("ff")),
             t6=func.count("ss"),
         )
-        .collect("t1", "t2", "t3", "t4", "t5", "t6")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6")
     )
 
     assert ds == [(3, 3, 3, 3, 3, 3)]
@@ -87,7 +85,7 @@ def test_aggregate_sum(test_session):
             t3=func.sum(dc.C("ii")),
             t4=func.sum("ff"),
         )
-        .collect("t1", "t2", "t3", "t4")
+        .to_list("t1", "t2", "t3", "t4")
     )
 
     assert ds == [(60, 6.0, 120, 12.0)]
@@ -125,7 +123,7 @@ def test_aggregate_min_max(test_session):
             t10=func.max(dc.C("ii")),
             t11=func.max("ff"),
         )
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10", "t11")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10", "t11")
     )
 
     assert ds == [(10, 1.0, "a", 30, 3.0, "c", 20, 2.0, "x", 60, 6.0)]
@@ -160,7 +158,7 @@ def test_aggregate_any_value(test_session):
             partition_by="id",
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6")
     )
 
     # any_value can return any value from the group,

--- a/tests/func/functions/test_array.py
+++ b/tests/func/functions/test_array.py
@@ -44,7 +44,7 @@ def test_array_slice(test_session):
         f: list[float]
         s: list[str]
 
-    ds = list(
+    ds = (
         dc.read_values(
             id=(1, 2, 3),
             arr=(
@@ -86,22 +86,21 @@ def test_array_slice(test_session):
             t14=func.array.slice([], 0),
         )
         .order_by("id")
-        .collect(
-            "t1",
-            "t2",
-            "t3",
-            "t4",
-            "t5",
-            "t6",
-            "t7",
-            "t8",
-            "t9",
-            "t10",
-            "t11",
-            "t12",
-            "t13",
-            "t14",
-        )
+    ).to_list(
+        "t1",
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7",
+        "t8",
+        "t9",
+        "t10",
+        "t11",
+        "t12",
+        "t13",
+        "t14",
     )
 
     assert tuple(ds) == (
@@ -186,7 +185,7 @@ def test_array_join(test_session):
             t8=func.array.join([]),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
     )
 
     assert tuple(ds) == (
@@ -238,7 +237,7 @@ def test_array_get_element(test_session):
             t12=func.array.get_element([], 0),
         )
         .order_by("id")
-        .collect(
+        .to_list(
             "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10", "t11", "t12"
         )
     )
@@ -338,7 +337,7 @@ def test_array_length(test_session):
             t8=func.array.length([]),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
     )
 
     assert tuple(ds) == (
@@ -398,7 +397,7 @@ def test_array_contains(test_session):
             t15=func.array.contains([], 1),
         )
         .order_by("id")
-        .collect(
+        .to_list(
             "t1",
             "t2",
             "t3",

--- a/tests/func/functions/test_conditional.py
+++ b/tests/func/functions/test_conditional.py
@@ -10,7 +10,7 @@ def test_conditional_and_or(test_session):
         i: int
         f: float
 
-    ds = list(
+    ds = (
         dc.read_values(
             id=(1, 2, 3),
             data=(
@@ -27,8 +27,7 @@ def test_conditional_and_or(test_session):
             t4=func.or_(dc.C("data.i") > 15, dc.C("data.f") > 2.5),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4")
-    )
+    ).to_list("t1", "t2", "t3", "t4")
 
     assert ds == [(0, 0, 0, 0), (1, 0, 1, 1), (1, 1, 1, 1)]
 
@@ -62,7 +61,7 @@ def test_conditional_case(test_session):
             ),
         )
         .order_by("id")
-        .collect("t1", "t2")
+        .to_list("t1", "t2")
     )
 
     assert ds == [
@@ -94,7 +93,7 @@ def test_conditional_ifelse(test_session):
             t3=func.ifelse(dc.C("data.s") == "b", "middle", "other"),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3")
+        .to_list("t1", "t2", "t3")
     )
 
     assert ds == [
@@ -127,7 +126,7 @@ def test_conditional_isnone(test_session):
             t3=func.isnone("data.s"),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3")
+        .to_list("t1", "t2", "t3")
     )
 
     assert ds == [
@@ -168,7 +167,7 @@ def test_conditional_greatest_least(test_session):
             t10=func.least("data.f", dc.C("ff"), 1.5, 3.5),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10")
     )
 
     assert ds == [

--- a/tests/func/functions/test_numeric.py
+++ b/tests/func/functions/test_numeric.py
@@ -7,7 +7,7 @@ def test_numeric_bit_operations(test_session):
         i: int
         j: int
 
-    ds = list(
+    ds = (
         dc.read_values(
             id=(1, 2, 3),
             data=(
@@ -28,8 +28,7 @@ def test_numeric_bit_operations(test_session):
             t6=func.bit_xor(dc.C("ii"), 0x0F),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6")
-    )
+    ).to_list("t1", "t2", "t3", "t4", "t5", "t6")
 
     assert ds == [
         (0, 15, 15, 4, 31, 27),
@@ -66,7 +65,7 @@ def test_numeric_bit_hamming_distance(test_session):
             t8=func.bit_hamming_distance(37, dc.C("data.j")),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
     )
 
     assert ds == [
@@ -99,7 +98,7 @@ def test_numeric_int_hash_64(test_session):
             t5=func.int_hash_64(42),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5")
+        .to_list("t1", "t2", "t3", "t4", "t5")
     )
 
     assert [tuple(col & (2**64 - 1) for col in row) for row in ds] == [

--- a/tests/func/functions/test_path.py
+++ b/tests/func/functions/test_path.py
@@ -29,16 +29,14 @@ def path_ds(test_session) -> dc.DataChain:
 
 
 def test_path_file_ext(path_ds):
-    ds = list(
+    ds = (
         path_ds.mutate(
             t1=func.file_ext("data.path"),
             t2=func.file_ext(dc.C("file")),
             t3=func.file_ext(dc.func.literal("path/to/file.txt")),
             t4=func.file_ext(dc.func.literal("path/to/file")),
-        )
-        .order_by("id")
-        .collect("t1", "t2", "t3", "t4")
-    )
+        ).order_by("id")
+    ).to_list("t1", "t2", "t3", "t4")
 
     assert ds == [
         ("txt", "txt", "txt", ""),
@@ -57,7 +55,7 @@ def test_path_file_stem(path_ds):
             t4=func.file_stem(dc.func.literal("path/to/file")),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4")
+        .to_list("t1", "t2", "t3", "t4")
     )
 
     assert ds == [
@@ -77,7 +75,7 @@ def test_path_name(path_ds):
             t4=func.name(dc.func.literal("path/to/file")),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4")
+        .to_list("t1", "t2", "t3", "t4")
     )
 
     assert ds == [
@@ -97,7 +95,7 @@ def test_path_parent(path_ds):
             t4=func.parent(dc.func.literal("path/to/file")),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4")
+        .to_list("t1", "t2", "t3", "t4")
     )
 
     assert ds == [

--- a/tests/func/functions/test_random.py
+++ b/tests/func/functions/test_random.py
@@ -10,7 +10,7 @@ def test_random_rand(test_session):
         )
         .mutate(t1=func.rand())
         .order_by("id")
-    ).to_list("t1")
+    ).to_values("t1")
 
     assert len(ds) == 3
     assert all(isinstance(x, int) for x in ds)

--- a/tests/func/functions/test_random.py
+++ b/tests/func/functions/test_random.py
@@ -3,17 +3,14 @@ from datachain import func
 
 
 def test_random_rand(test_session):
-    ds = list(
+    ds = (
         dc.read_values(
             id=(1, 2, 3),
             session=test_session,
         )
-        .mutate(
-            t1=func.rand(),
-        )
+        .mutate(t1=func.rand())
         .order_by("id")
-        .collect("t1")
-    )
+    ).to_list("t1")
 
     assert len(ds) == 3
     assert all(isinstance(x, int) for x in ds)

--- a/tests/func/functions/test_string.py
+++ b/tests/func/functions/test_string.py
@@ -6,7 +6,7 @@ def test_string_length(test_session):
     class Data(dc.DataModel):
         s1: str
 
-    ds = list(
+    ds = (
         dc.read_values(
             id=(1, 2, 3),
             data=(
@@ -27,8 +27,7 @@ def test_string_length(test_session):
             t7=func.string.length(dc.func.literal("")),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7")
-    )
+    ).to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7")
 
     assert ds == [
         (5, 5, 13, 13, 5, 13, 0),
@@ -63,7 +62,7 @@ def test_string_split(test_session):
             t8=func.string.split("data.s1", "/", limit=1),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8")
     )
 
     assert ds == [
@@ -125,7 +124,7 @@ def test_string_replace(test_session):
             t7=func.string.replace(dc.func.literal(""), "foo", "baz"),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7")
     )
 
     assert ds == [
@@ -162,7 +161,7 @@ def test_string_regexp_replace(test_session):
             t7=func.string.regexp_replace(dc.func.literal(""), r"foo", "bar"),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7")
     )
 
     assert ds == [
@@ -203,7 +202,7 @@ def test_string_byte_hamming_distance(test_session):
             ),
         )
         .order_by("id")
-        .collect("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9")
+        .to_list("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9")
     )
 
     assert ds == [

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1582,14 +1582,14 @@ def test_similarity_search(cloud_test_catalog):
         text = file.read().decode("utf-8")
         return text_embedding(text)
 
-    target_embedding = next(
+    target_embedding = (
         dc.read_storage(src_uri, session=session)
         .filter(dc.C("file.path").glob("*description"))
         .order_by("file.path")
         .limit(1)
         .map(embedding=calc_emb, output={"embedding": list[float]})
-        .to_iter("embedding")
-    )
+    ).to_list("embedding")[0]
+
     chain = (
         dc.read_storage(src_uri, session=session)
         .map(embedding=calc_emb, output={"embedding": list[float]})

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -738,7 +738,7 @@ def test_read_storage_check_rows(tmp_dir, test_session):
     is_sqlite = isinstance(test_session.catalog.warehouse, SQLiteWarehouse)
     tz = timezone.utc if is_sqlite else pytz.UTC
 
-    for (file,) in chain.to_iter():
+    for file in chain.to_iter("file"):
         assert isinstance(file, File)
         stat = stats[file.name]
         mtime = stat.st_mtime if is_sqlite else float(math.floor(stat.st_mtime))
@@ -830,7 +830,7 @@ def test_udf_parallel(cloud_test_catalog_tmpfile):
 
     # Check that the UDF ran successfully
     count = 0
-    for r in chain.to_iter():
+    for r in chain:
         count += 1
         assert len(r[0]) == r[1]
     assert count == 7
@@ -896,7 +896,7 @@ def test_udf_distributed(
 
     # Check that the UDF ran successfully
     count = 0
-    for r in chain.to_iter():
+    for r in chain:
         count += 1
         assert len(r[0]) == r[1]
     assert count == 225
@@ -1077,7 +1077,7 @@ def test_udf_reuse_on_error(cloud_test_catalog_tmpfile):
 
     # Retry Query
     count = 0
-    for r in chain.to_iter():
+    for r in chain:
         # Check that the UDF ran successfully
         count += 1
         assert len(r[0]) == r[1]

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -53,7 +53,7 @@ def _get_listing_datasets(session):
             f"{ds.name}@v{ds.version}"
             for ds in dc.datasets(
                 column="dataset", session=session, include_listing=True
-            ).collect("dataset")
+            ).to_iter("dataset")
             if is_listing_dataset(ds.name)
         ]
     )
@@ -96,7 +96,7 @@ def test_read_storage_glob(cloud_test_catalog):
 def test_read_storage_as_image(cloud_test_catalog):
     ctc = cloud_test_catalog
     chain = dc.read_storage(ctc.src_uri, session=ctc.session, type="image")
-    for im in chain.collect("file"):
+    for im in chain.to_iter("file"):
         assert isinstance(im, ImageFile)
 
 
@@ -309,8 +309,8 @@ def test_map_file(cloud_test_catalog, use_cache, prefetch, monkeypatch):
         "dog3 -> bark",
         "dog4 -> ruff",
     }
-    assert set(chain.collect("signal")) == expected
-    for file in chain.collect("file"):
+    assert set(chain.to_iter("signal")) == expected
+    for file in chain.to_iter("file"):
         assert bool(file.get_local_path()) is use_cache
     assert not os.listdir(ctc.catalog.cache.tmp_dir)
 
@@ -320,7 +320,7 @@ def test_read_file(cloud_test_catalog, use_cache):
     ctc = cloud_test_catalog
 
     chain = dc.read_storage(ctc.src_uri, session=ctc.session)
-    for file in chain.settings(cache=use_cache).collect("file"):
+    for file in chain.settings(cache=use_cache).to_iter("file"):
         assert file.get_local_path() is None
         file.read()
         assert bool(file.get_local_path()) is use_cache
@@ -368,7 +368,7 @@ def test_to_storage(
         "dog4": "ruff",
     }
 
-    for file in df.collect("file"):
+    for file in df.to_iter("file"):
         if placement == "filename":
             file_path = file.name
         else:
@@ -464,7 +464,7 @@ def test_read_storage_multiple_uris_cache(cloud_test_catalog):
         ).exec()
         assert chain.count() == 11
 
-        files = chain.collect("file")
+        files = chain.to_iter("file")
         assert {f.name for f in files} == {
             "cat1",
             "cat2",
@@ -738,7 +738,7 @@ def test_read_storage_check_rows(tmp_dir, test_session):
     is_sqlite = isinstance(test_session.catalog.warehouse, SQLiteWarehouse)
     tz = timezone.utc if is_sqlite else pytz.UTC
 
-    for (file,) in chain.collect():
+    for (file,) in chain.to_iter():
         assert isinstance(file, File)
         stat = stats[file.name]
         mtime = stat.st_mtime if is_sqlite else float(math.floor(stat.st_mtime))
@@ -758,7 +758,7 @@ def test_mutate_existing_column(test_session):
     ds = dc.read_values(ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(ids=Column("ids") + 1)
 
-    assert list(ds.order_by("ids").collect()) == [(2,), (3,), (4,)]
+    assert ds.order_by("ids").to_list() == [(2,), (3,), (4,)]
 
 
 @pytest.mark.parametrize("processes", [False, 2, True])
@@ -772,7 +772,7 @@ def test_parallel(processes, test_session_tmpfile):
         .settings(parallel=processes)
         .map(res=lambda key: prefix + key)
         .order_by("res")
-        .collect("res")
+        .to_iter("res")
     )
 
     assert res == [prefix + v for v in vals]
@@ -795,9 +795,9 @@ def test_udf(cloud_test_catalog):
         .filter(dc.C("file.path").glob("cats*") | (dc.C("file.size") < 4))
         .map(name_len, params=["file.path"], output={"name_len": int})
     )
-    result1 = list(chain.select("file.path", "name_len").collect())
+    result1 = chain.select("file.path", "name_len").to_list()
     # ensure that we're able to run with same query multiple times
-    result2 = list(chain.select("file.path", "name_len").collect())
+    result2 = chain.select("file.path", "name_len").to_list()
     count = chain.count()
     assert len(result1) == 3
     assert len(result2) == 3
@@ -830,7 +830,7 @@ def test_udf_parallel(cloud_test_catalog_tmpfile):
 
     # Check that the UDF ran successfully
     count = 0
-    for r in chain.collect():
+    for r in chain.to_iter():
         count += 1
         assert len(r[0]) == r[1]
     assert count == 7
@@ -861,7 +861,7 @@ def test_udf_parallel_boostrap(test_session_tmpfile):
 
     chain = dc.read_values(key=vals, session=test_session_tmpfile)
 
-    res = list(chain.settings(parallel=4).map(res=MyMapper()).collect("res"))
+    res = chain.settings(parallel=4).map(res=MyMapper()).to_list("res")
 
     assert res == [MyMapper.BOOTSTRAP_VALUE] * len(vals)
 
@@ -896,7 +896,7 @@ def test_udf_distributed(
 
     # Check that the UDF ran successfully
     count = 0
-    for r in chain.collect():
+    for r in chain.to_iter():
         count += 1
         assert len(r[0]) == r[1]
     assert count == 225
@@ -930,7 +930,7 @@ def test_class_udf(cloud_test_catalog):
         .order_by("file.size")
     )
 
-    assert list(chain.collect()) == [
+    assert chain.to_list() == [
         (3, 11),
         (4, 13),
         (4, 13),
@@ -970,7 +970,7 @@ def test_class_udf_parallel(cloud_test_catalog_tmpfile):
         .order_by("file.size")
     )
 
-    assert list(chain.collect()) == [
+    assert chain.to_list() == [
         (3, 11),
         (4, 13),
         (4, 13),
@@ -1077,7 +1077,7 @@ def test_udf_reuse_on_error(cloud_test_catalog_tmpfile):
 
     # Retry Query
     count = 0
-    for r in chain.collect():
+    for r in chain.to_iter():
         # Check that the UDF ran successfully
         count += 1
         assert len(r[0]) == r[1]
@@ -1196,7 +1196,7 @@ def test_udf_after_limit(cloud_test_catalog):
 
     def get_result(chain):
         res = chain.limit(100).map(name_int=name_int).order_by("name")
-        return list(res.collect("name", "name_int"))
+        return res.to_list("name", "name_int")
 
     expected = [(f"{i:06d}", i) for i in range(100)]
     chain = (
@@ -1231,8 +1231,8 @@ def test_row_number_with_order_by_name_len_desc_and_name_asc(cloud_test_catalog)
         name_len, params=["file.path"], output={"name_len": int}
     ).order_by("name_len", descending=True).order_by("file.path").save(ds_name)
 
-    assert list(
-        dc.read_dataset(name=ds_name, session=session).collect("sys.id", "file.path")
+    assert dc.read_dataset(name=ds_name, session=session).to_list(
+        "sys.id", "file.path"
     ) == [
         (1, "description"),
         (2, "cats/cat1"),
@@ -1264,8 +1264,8 @@ def test_row_number_with_order_by_before_map(cloud_test_catalog):
 
     # we should preserve order in final result based on order by which was added
     # before add_signals
-    assert list(
-        dc.read_dataset(name=ds_name, session=session).collect("sys.id", "file.path")
+    assert dc.read_dataset(name=ds_name, session=session).to_list(
+        "sys.id", "file.path"
     ) == [
         (1, "cats/cat1"),
         (2, "cats/cat2"),
@@ -1388,7 +1388,7 @@ def test_gen_parallel(cloud_test_catalog_tmpfile):
         .gen(gen=func, params=["file"], output={"val": str})
         .order_by("val")
     )
-    assert list(chain.collect("val")) == [
+    assert chain.to_list("val") == [
         "cats/cat1_0",
         "cats/cat1_1",
         "cats/cat1_2",
@@ -1467,7 +1467,7 @@ def test_gen_with_new_columns_numpy(cloud_test_catalog, dogs_dataset):
     ).save("dogs_with_rows_and_signals")
 
     chain = dc.read_dataset(name="dogs_with_rows_and_signals", session=session)
-    for r in chain.collect(
+    for r in chain.to_iter(
         "int_col_32",
         "int_col_64",
         "float_col_32",
@@ -1570,7 +1570,7 @@ def test_gen_file(cloud_test_catalog, use_cache, prefetch, monkeypatch):
         "ruff",
         "woof",
     }
-    assert set(chain.collect("signal")) == expected
+    assert set(chain.to_iter("signal")) == expected
     assert not os.listdir(ctc.catalog.cache.tmp_dir)
 
 
@@ -1588,7 +1588,7 @@ def test_similarity_search(cloud_test_catalog):
         .order_by("file.path")
         .limit(1)
         .map(embedding=calc_emb, output={"embedding": list[float]})
-        .collect("embedding")
+        .to_iter("embedding")
     )
     chain = (
         dc.read_storage(src_uri, session=session)
@@ -1613,7 +1613,7 @@ def test_similarity_search(cloud_test_catalog):
     ]
 
     for (p1, c1, e1), (p2, c2, e2) in zip(
-        chain.collect("file.path", "cos_dist", "eucl_dist"), expected
+        chain.to_iter("file.path", "cos_dist", "eucl_dist"), expected
     ):
         assert p1.endswith(p2)
         assert math.isclose(c1, c2, abs_tol=1e-5)
@@ -1632,7 +1632,7 @@ def test_process_and_open_tar(cloud_test_catalog, cloud_type):
     assert chain.count() == 7
 
     assert {
-        (content, file.path) for file, content in chain.collect("file", "content")
+        (content, file.path) for file, content in chain.to_iter("file", "content")
     } == {
         ("meow", "animals.tar/cats/cat1"),
         ("mrow", "animals.tar/cats/cat2"),

--- a/tests/func/test_delta.py
+++ b/tests/func/test_delta.py
@@ -62,10 +62,8 @@ def test_delta_update_from_dataset(test_session, tmp_dir, tmp_path):
     create_delta_dataset(ds_name)
     assert _get_dependencies(catalog, ds_name, "1.0.1") == [(starting_ds_name, "1.0.1")]
 
-    assert list(
-        dc.read_dataset(ds_name, version="1.0.0")
-        .order_by("file.path")
-        .collect("file.path")
+    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_list(
+        "file.path"
     ) == [
         "img1.jpg",
         "img2.jpg",
@@ -74,7 +72,7 @@ def test_delta_update_from_dataset(test_session, tmp_dir, tmp_path):
     assert list(
         dc.read_dataset(ds_name, version="1.0.1")
         .order_by("file.path")
-        .collect("file.path")
+        .to_list("file.path")
     ) == [
         "img1.jpg",
         "img2.jpg",
@@ -136,7 +134,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
     # into consideration on delta update
     etags = {
         r[0]: r[1].etag
-        for r in dc.read_dataset(ds_name, version="1.0.0").collect("index", "file")
+        for r in dc.read_dataset(ds_name, version="1.0.0").to_iter("index", "file")
     }
 
     # remove last couple of images to simulate modification since we will re-create it
@@ -157,7 +155,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
     assert list(
         dc.read_dataset(ds_name, version="1.0.0")
         .order_by("file.path")
-        .collect("file.path")
+        .to_list("file.path")
     ) == [
         "images/img4.jpg",
         "images/img6.jpg",
@@ -167,7 +165,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
     assert list(
         dc.read_dataset(ds_name, version="1.0.1")
         .order_by("file.path")
-        .collect("file.path")
+        .to_list("file.path")
     ) == [
         "images/img10.jpg",
         "images/img12.jpg",
@@ -186,7 +184,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
             dc.read_dataset(ds_name, version="1.0.1")
             .filter(C("index") == 6)
             .order_by("file.path", "file.etag")
-            .collect("file.etag")
+            .to_list("file.etag")
         )
         > etags[6]
     )
@@ -284,7 +282,7 @@ def test_delta_update_no_diff(test_session, tmp_dir, tmp_path):
     assert list(
         dc.read_dataset(ds_name, version="1.0.0")
         .order_by("file.path")
-        .collect("file.path")
+        .to_list("file.path")
     ) == [
         "images/img6.jpg",
         "images/img7.jpg",

--- a/tests/func/test_delta.py
+++ b/tests/func/test_delta.py
@@ -69,10 +69,8 @@ def test_delta_update_from_dataset(test_session, tmp_dir, tmp_path):
         "img2.jpg",
     ]
 
-    assert list(
-        dc.read_dataset(ds_name, version="1.0.1")
-        .order_by("file.path")
-        .to_list("file.path")
+    assert (dc.read_dataset(ds_name, version="1.0.1").order_by("file.path")).to_list(
+        "file.path"
     ) == [
         "img1.jpg",
         "img2.jpg",
@@ -152,20 +150,16 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
     # second version of delta dataset
     create_delta_dataset()
 
-    assert list(
-        dc.read_dataset(ds_name, version="1.0.0")
-        .order_by("file.path")
-        .to_list("file.path")
+    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_list(
+        "file.path"
     ) == [
         "images/img4.jpg",
         "images/img6.jpg",
         "images/img8.jpg",
     ]
 
-    assert list(
-        dc.read_dataset(ds_name, version="1.0.1")
-        .order_by("file.path")
-        .to_list("file.path")
+    assert (dc.read_dataset(ds_name, version="1.0.1").order_by("file.path")).to_list(
+        "file.path"
     ) == [
         "images/img10.jpg",
         "images/img12.jpg",
@@ -180,14 +174,10 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
     # check that we have newest versions for modified rows since etags are mtime
     # and modified rows etags should be bigger than the old ones
     assert (
-        next(
-            dc.read_dataset(ds_name, version="1.0.1")
-            .filter(C("index") == 6)
-            .order_by("file.path", "file.etag")
-            .to_list("file.etag")
-        )
-        > etags[6]
-    )
+        dc.read_dataset(ds_name, version="1.0.1")
+        .filter(C("index") == 6)
+        .order_by("file.path", "file.etag")
+    ).to_list("file.etag")[0] > etags[6]
 
 
 def test_delta_update_check_num_calls(test_session, tmp_dir, tmp_path, capsys):
@@ -279,10 +269,8 @@ def test_delta_update_no_diff(test_session, tmp_dir, tmp_path):
     create_delta_dataset()
     create_delta_dataset()
 
-    assert list(
-        dc.read_dataset(ds_name, version="1.0.0")
-        .order_by("file.path")
-        .to_list("file.path")
+    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_list(
+        "file.path"
     ) == [
         "images/img6.jpg",
         "images/img7.jpg",

--- a/tests/func/test_delta.py
+++ b/tests/func/test_delta.py
@@ -62,14 +62,14 @@ def test_delta_update_from_dataset(test_session, tmp_dir, tmp_path):
     create_delta_dataset(ds_name)
     assert _get_dependencies(catalog, ds_name, "1.0.1") == [(starting_ds_name, "1.0.1")]
 
-    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_list(
+    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_values(
         "file.path"
     ) == [
         "img1.jpg",
         "img2.jpg",
     ]
 
-    assert (dc.read_dataset(ds_name, version="1.0.1").order_by("file.path")).to_list(
+    assert (dc.read_dataset(ds_name, version="1.0.1").order_by("file.path")).to_values(
         "file.path"
     ) == [
         "img1.jpg",
@@ -150,7 +150,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
     # second version of delta dataset
     create_delta_dataset()
 
-    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_list(
+    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_values(
         "file.path"
     ) == [
         "images/img4.jpg",
@@ -158,7 +158,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
         "images/img8.jpg",
     ]
 
-    assert (dc.read_dataset(ds_name, version="1.0.1").order_by("file.path")).to_list(
+    assert (dc.read_dataset(ds_name, version="1.0.1").order_by("file.path")).to_values(
         "file.path"
     ) == [
         "images/img10.jpg",
@@ -269,7 +269,7 @@ def test_delta_update_no_diff(test_session, tmp_dir, tmp_path):
     create_delta_dataset()
     create_delta_dataset()
 
-    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_list(
+    assert (dc.read_dataset(ds_name, version="1.0.0").order_by("file.path")).to_values(
         "file.path"
     ) == [
         "images/img6.jpg",

--- a/tests/func/test_delta.py
+++ b/tests/func/test_delta.py
@@ -177,7 +177,7 @@ def test_delta_update_from_storage(test_session, tmp_dir, tmp_path):
         dc.read_dataset(ds_name, version="1.0.1")
         .filter(C("index") == 6)
         .order_by("file.path", "file.etag")
-    ).to_list("file.etag")[0] > etags[6]
+    ).to_values("file.etag")[0] > etags[6]
 
 
 def test_delta_update_check_num_calls(test_session, tmp_dir, tmp_path, capsys):

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -21,7 +21,7 @@ def test_resolve_file(cloud_test_catalog, caching_enabled):
     is_sqlite = isinstance(cloud_test_catalog.catalog.warehouse, SQLiteWarehouse)
 
     chain = dc.read_storage(ctc.src_uri, session=ctc.session)
-    for orig_file in chain.to_iter("file"):
+    for orig_file in chain.to_values("file"):
         file = File(
             source=orig_file.source,
             path=orig_file.path,

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -20,7 +20,7 @@ def test_resolve_file(cloud_test_catalog):
     is_sqlite = isinstance(cloud_test_catalog.catalog.warehouse, SQLiteWarehouse)
 
     chain = dc.read_storage(ctc.src_uri, session=ctc.session)
-    for orig_file in chain.collect("file"):
+    for orig_file in chain.to_iter("file"):
         file = File(
             source=orig_file.source,
             path=orig_file.path,

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -19,7 +19,7 @@ def test_listing_generator(cloud_test_catalog, cloud_type):
     entries = sorted(
         [e for e in ENTRIES if e.path.startswith("cats/")], key=lambda e: e.path
     )
-    files = chain.order_by("file.path").to_list("file")
+    files = chain.order_by("file.path").to_values("file")
 
     for cat_file, cat_entry in zip(files, entries):
         assert cat_file.source == ctc.src_uri

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -19,7 +19,7 @@ def test_listing_generator(cloud_test_catalog, cloud_type):
     entries = sorted(
         [e for e in ENTRIES if e.path.startswith("cats/")], key=lambda e: e.path
     )
-    files = chain.order_by("file.path").collect("file")
+    files = chain.order_by("file.path").to_list("file")
 
     for cat_file, cat_entry in zip(files, entries):
         assert cat_file.source == ctc.src_uri

--- a/tests/func/test_retry.py
+++ b/tests/func/test_retry.py
@@ -120,7 +120,7 @@ def test_retry_with_missing_records(test_session):
     assert retry_chain.count() == 3
 
     # Verify all records are present
-    ids = set(retry_chain.to_iter("id"))
+    ids = set(retry_chain.to_values("id"))
     assert ids == {1, 2, 3}
 
     final_first_attempts_count = retry_chain.filter(C("result.attempt") == 1).count()

--- a/tests/func/test_toolkit.py
+++ b/tests/func/test_toolkit.py
@@ -19,7 +19,7 @@ def test_train_test_split_not_random(not_random_ds, seed, weights, expected):
     assert len(res) == len(expected)
 
     for i, dc in enumerate(res):
-        assert list(dc.collect("sys.id")) == expected[i]
+        assert dc.to_list("sys.id") == expected[i]
 
 
 @pytest.mark.parametrize(
@@ -41,7 +41,7 @@ def test_train_test_split_random(pseudo_random_ds, seed, weights, expected):
     assert len(res) == len(expected)
 
     for i, dc in enumerate(res):
-        assert list(dc.collect("sys.id")) == expected[i]
+        assert dc.to_list("sys.id") == expected[i]
 
 
 def test_train_test_split_errors(not_random_ds):

--- a/tests/func/test_toolkit.py
+++ b/tests/func/test_toolkit.py
@@ -19,7 +19,7 @@ def test_train_test_split_not_random(not_random_ds, seed, weights, expected):
     assert len(res) == len(expected)
 
     for i, dc in enumerate(res):
-        assert dc.to_list("sys.id") == expected[i]
+        assert dc.to_values("sys.id") == expected[i]
 
 
 @pytest.mark.parametrize(
@@ -41,7 +41,7 @@ def test_train_test_split_random(pseudo_random_ds, seed, weights, expected):
     assert len(res) == len(expected)
 
     for i, dc in enumerate(res):
-        assert dc.to_list("sys.id") == expected[i]
+        assert dc.to_values("sys.id") == expected[i]
 
 
 def test_train_test_split_errors(not_random_ds):

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -67,7 +67,7 @@ def test_import_time(catalog, test_session):
         chain = _import_time_chain(test_session)
         (import_time_ms,) = chain.filter(
             dc.C("import") == "datachain",
-        ).to_list("cumulative_ms")
+        ).to_values("cumulative_ms")
         import_timings.append((chain, import_time_ms))
         # pass `--log-cli-level=info` to see these logs live
         logger.info("attempt %d, import time: %dms", attempt + 1, import_time_ms)

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -67,7 +67,7 @@ def test_import_time(catalog, test_session):
         chain = _import_time_chain(test_session)
         (import_time_ms,) = chain.filter(
             dc.C("import") == "datachain",
-        ).collect("cumulative_ms")
+        ).to_list("cumulative_ms")
         import_timings.append((chain, import_time_ms))
         # pass `--log-cli-level=info` to see these logs live
         logger.info("attempt %d, import time: %dms", attempt + 1, import_time_ms)
@@ -76,7 +76,7 @@ def test_import_time(catalog, test_session):
     # If there is a regression, uncomment the following to find the culprit:
     # dc.show(limit=40)
     for module in lazy_modules:
-        assert not list(chain.filter(dc.C("import").startswith(module)).collect()), (
+        assert not chain.filter(dc.C("import").startswith(module)).to_list(), (
             f"found {module} at import time"
         )
     assert min_import_time < MAX_IMPORT_TIME_MS, (

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2268,7 +2268,9 @@ def test_read_values_array_of_floats(test_session):
     embeddings = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
     chain = dc.read_values(emd=embeddings, session=test_session)
 
-    assert chain.to_list("emd") == embeddings
+    expected_embeddings = {tuple(emb) for emb in embeddings}
+    actual_embeddings = {tuple(emb) for emb in chain.to_list("emd")}
+    assert actual_embeddings == expected_embeddings
 
 
 def test_custom_model_with_nested_lists(test_session):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -912,7 +912,7 @@ def test_collect(test_session):
     chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
 
     n = 0
-    for sample in chain.order_by("f1.nnn", "f1.count").to_iter():
+    for sample in chain.order_by("f1.nnn", "f1.count"):
         assert len(sample) == 2
         fr, num = sample
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -908,7 +908,7 @@ def test_batch_map_tuple_result_iterator(test_session):
     assert chain.order_by("x").to_list("x") == [1, 2, 3]
 
 
-def test_collect(test_session):
+def test_iterable_chain(test_session):
     chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
 
     n = 0
@@ -926,7 +926,7 @@ def test_collect(test_session):
     assert n == len(features)
 
 
-def test_collect_nested_feature(test_session):
+def test_to_list_nested_feature(test_session):
     chain = dc.read_values(sign1=features_nested, session=test_session)
 
     for n, sample in enumerate(
@@ -937,6 +937,14 @@ def test_collect_nested_feature(test_session):
 
         assert isinstance(nested, MyNested)
         assert nested == features_nested[n]
+
+
+def test_collect_deprecated(test_session):
+    chain = dc.read_values(fib=[1, 1, 2, 3, 5], session=test_session)
+
+    with pytest.warns(DeprecationWarning, match="Method `collect` is deprecated"):
+        vals = list(chain.collect("fib"))
+        assert set(vals) == {1, 2, 3, 5}
 
 
 def test_select_read_hf_without_sys_columns(test_session):
@@ -1162,7 +1170,7 @@ def test_unsupported_output_type(test_session):
         dc.read_values(key=[123], session=test_session).map(emd=get_vector)
 
 
-def test_collect_single_item(test_session):
+def test_to_list_single_item(test_session):
     names = ["f1.jpg", "f1.json", "f1.txt", "f2.jpg", "f2.json"]
     sizes = [1, 2, 3, 4, 5]
     files = sort_files([File(path=name, size=size) for name, size in zip(names, sizes)])
@@ -2083,7 +2091,7 @@ def test_order_by_with_nested_columns(test_session, with_function):
     ]
 
 
-def test_order_by_collect(test_session):
+def test_order_by_to_list(test_session):
     numbers = [6, 2, 3, 1, 5, 7, 4]
     letters = ["u", "y", "x", "z", "v", "t", "w"]
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2191,7 +2191,7 @@ def test_subtract(test_session):
     chain2 = dc.read_values(a=[1, 2], b=["x", "y"], session=test_session)
     assert set(chain1.subtract(chain2, on=["a", "b"]).to_list()) == {(1, "y"), (2, "z")}
     assert set(chain1.subtract(chain2, on=["b"]).to_list()) == {(2, "z")}
-    assert set(chain1.subtract(chain2, on=["a"]).to_list()) == set()
+    assert not set(chain1.subtract(chain2, on=["a"]).to_list())
     assert set(chain1.subtract(chain2).to_list()) == {(1, "y"), (2, "z")}
     assert chain1.subtract(chain1).count() == 0
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -639,7 +639,7 @@ def test_map(test_session):
         output={"x": _TestFr},
     )
 
-    x_list = list(chain.order_by("x.my_name", "x.sqrt").to_list("x"))
+    x_list = chain.order_by("x.my_name", "x.sqrt").to_list("x")
     test_frs = [
         _TestFr(sqrt=math.sqrt(fr.count), my_name=fr.nnn + "_suf") for fr in features
     ]
@@ -685,7 +685,7 @@ def test_agg(test_session):
         output={"x": _TestFr},
     )
 
-    assert list(chain.order_by("x.my_name").to_list("x")) == [
+    assert chain.order_by("x.my_name").to_list("x") == [
         _TestFr(
             f=File(path=""),
             cnt=sum(fr.count for fr in features if fr.nnn == "n1"),
@@ -728,8 +728,8 @@ def test_agg_two_params(test_session):
         )
     )
 
-    assert list(ds.order_by("x.my_name").to_list("x.my_name")) == ["n1-n1", "n2"]
-    assert list(ds.order_by("x.cnt").to_list("x.cnt")) == [7, 20]
+    assert ds.order_by("x.my_name").to_list("x.my_name") == ["n1-n1", "n2"]
+    assert ds.order_by("x.cnt").to_list("x.cnt") == [7, 20]
 
 
 def test_agg_simple_iterator(test_session):
@@ -790,8 +790,8 @@ def test_agg_tuple_result_iterator(test_session):
         x=func, partition_by=C("key")
     )
 
-    assert list(ds.order_by("x_1.name").to_list("x_1.name")) == ["n1-n1", "n2"]
-    assert list(ds.order_by("x_1.size").to_list("x_1.size")) == [5, 10]
+    assert ds.order_by("x_1.name").to_list("x_1.name") == ["n1-n1", "n2"]
+    assert ds.order_by("x_1.size").to_list("x_1.size") == [5, 10]
 
 
 def test_agg_tuple_result_generator(test_session):
@@ -812,8 +812,8 @@ def test_agg_tuple_result_generator(test_session):
         .order_by("x_1.name")
     )
 
-    assert list(ds.order_by("x_1.name").to_list("x_1.name")) == ["n1-n1", "n2"]
-    assert list(ds.order_by("x_1.size").to_list("x_1.size")) == [5, 10]
+    assert ds.order_by("x_1.name").to_list("x_1.name") == ["n1-n1", "n2"]
+    assert ds.order_by("x_1.size").to_list("x_1.size") == [5, 10]
 
 
 def test_batch_map(test_session):
@@ -833,7 +833,7 @@ def test_batch_map(test_session):
         output={"x": _TestFr},
     )
 
-    x_list = list(chain.order_by("x.my_name", "x.sqrt").to_list("x"))
+    x_list = chain.order_by("x.my_name", "x.sqrt").to_list("x")
     test_frs = [
         _TestFr(sqrt=math.sqrt(fr.count), my_name=fr.nnn + "_suf") for fr in features
     ]
@@ -862,7 +862,7 @@ def test_batch_map_wrong_size(test_session):
     )
 
     with pytest.raises(AssertionError):
-        list(chain.to_list())
+        chain.to_list()
 
 
 def test_batch_map_two_params(test_session):
@@ -890,12 +890,12 @@ def test_batch_map_two_params(test_session):
         output={"x": _TestFr},
     )
 
-    assert list(ds.order_by("x.my_name").to_list("x.my_name")) == [
+    assert ds.order_by("x.my_name").to_list("x.my_name") == [
         "n1-n1",
         "n1-n2",
         "n2-n1",
     ]
-    assert list(ds.order_by("x.cnt").to_list("x.cnt")) == [7, 7, 13]
+    assert ds.order_by("x.cnt").to_list("x.cnt") == [7, 7, 13]
 
 
 def test_batch_map_tuple_result_iterator(test_session):
@@ -905,14 +905,14 @@ def test_batch_map_tuple_result_iterator(test_session):
 
     chain = dc.read_values(t1=[1, 4, 9], session=test_session).batch_map(x=sqrt)
 
-    assert list(chain.order_by("x").to_list("x")) == [1, 2, 3]
+    assert chain.order_by("x").to_list("x") == [1, 2, 3]
 
 
 def test_collect(test_session):
     chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
 
     n = 0
-    for sample in chain.order_by("f1.nnn", "f1.count").to_list():
+    for sample in chain.order_by("f1.nnn", "f1.count").to_iter():
         assert len(sample) == 2
         fr, num = sample
 
@@ -1022,20 +1022,20 @@ def test_select_wrong_type(test_session):
     chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
     with pytest.raises(SignalResolvingTypeError):
-        list(chain.select(4).to_list())
+        chain.select(4).to_list()
 
     with pytest.raises(SignalResolvingTypeError):
-        list(chain.select_except(features[0]).to_list())
+        chain.select_except(features[0]).to_list()
 
 
 def test_select_except_error(test_session):
     chain = dc.read_values(fr1=features_nested, fr2=features, session=test_session)
 
     with pytest.raises(SignalResolvingError):
-        list(chain.select_except("not_exist", "file").to_list())
+        chain.select_except("not_exist", "file").to_list()
 
     with pytest.raises(SignalRemoveError):
-        list(chain.select_except("fr1.label", "file").to_list())
+        chain.select_except("fr1.label", "file").to_list()
 
 
 def test_select_restore_from_saving(test_session):
@@ -1194,7 +1194,7 @@ def test_default_output_type(test_session):
         res1=lambda name: name + suffix
     )
 
-    assert list(chain.order_by("name").to_list("res1")) == [t + suffix for t in names]
+    assert chain.order_by("name").to_list("res1") == [t + suffix for t in names]
 
 
 def test_parse_tabular(tmp_dir, test_session):
@@ -1624,7 +1624,7 @@ def test_explode(tmp_dir, test_session, column_type, column, model_name):
         ("Ivan", 41, "San Francisco"),
     }
 
-    assert next(chain.limit(1).to_list(column)).__class__.__name__ == model_name
+    assert chain.limit(1).to_list(column)[0].__class__.__name__ == model_name
 
 
 def test_explode_raises_on_wrong_column_type(test_session):
@@ -1903,12 +1903,11 @@ def test_parallel_in_memory():
     vals = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
 
     with pytest.raises(RuntimeError):
-        list(
+        (
             dc.read_values(key=vals, in_memory=True)
             .settings(parallel=True)
             .map(res=lambda key: prefix + key)
-            .to_list("res")
-        )
+        ).to_list("res")
 
 
 def test_exec(test_session, monkeypatch):
@@ -2089,7 +2088,7 @@ def test_order_by_collect(test_session):
     letters = ["u", "y", "x", "z", "v", "t", "w"]
 
     chain = dc.read_values(number=numbers, letter=letters, session=test_session)
-    assert list(chain.order_by("number").to_list()) == [
+    assert chain.order_by("number").to_list() == [
         (1, "z"),
         (2, "y"),
         (3, "x"),
@@ -2099,7 +2098,7 @@ def test_order_by_collect(test_session):
         (7, "t"),
     ]
 
-    assert list(chain.order_by("letter").to_list()) == [
+    assert chain.order_by("letter").to_list() == [
         (7, "t"),
         (6, "u"),
         (5, "v"),
@@ -2138,7 +2137,7 @@ def test_union(test_session):
     chain2 = dc.read_values(value=[3, 4], session=test_session)
     chain3 = chain1 | chain2
     assert chain3.count() == 4
-    assert list(chain3.order_by("value").to_list("value")) == [1, 2, 3, 4]
+    assert chain3.order_by("value").to_list("value") == [1, 2, 3, 4]
 
 
 def test_union_different_columns(test_session):
@@ -2167,7 +2166,7 @@ def test_union_different_column_order(test_session):
     chain2 = dc.read_values(
         name=["different", "order"], value=[9, 10], session=test_session
     )
-    assert list(chain1.union(chain2).order_by("value").to_list()) == [
+    assert chain1.union(chain2).order_by("value").to_list() == [
         (1, "chain"),
         (2, "more"),
         (9, "different"),
@@ -2366,11 +2365,11 @@ def test_rename_non_object_column_name_with_mutate(test_session):
     ds = ds.mutate(my_ids=Column("ids"))
 
     assert ds.signals_schema.values == {"my_ids": int}
-    assert list(ds.order_by("my_ids").to_list("my_ids")) == [1, 2, 3]
+    assert ds.order_by("my_ids").to_list("my_ids") == [1, 2, 3]
 
     assert ds.signals_schema.values.get("my_ids") is int
     assert "ids" not in ds.signals_schema.values
-    assert list(ds.order_by("my_ids").to_list("my_ids")) == [1, 2, 3]
+    assert ds.order_by("my_ids").to_list("my_ids") == [1, 2, 3]
 
 
 def test_rename_object_column_name_with_mutate(test_session):
@@ -2381,7 +2380,7 @@ def test_rename_object_column_name_with_mutate(test_session):
     ds = dc.read_values(file=files, ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(fname=Column("file.path"))
 
-    assert list(ds.order_by("fname").to_list("fname")) == ["a", "b", "c"]
+    assert ds.order_by("fname").to_list("fname") == ["a", "b", "c"]
     assert ds.signals_schema.values == {"file": File, "ids": int, "fname": str}
 
     # check that persist after saving
@@ -2391,7 +2390,7 @@ def test_rename_object_column_name_with_mutate(test_session):
     assert ds.signals_schema.values.get("file") is File
     assert ds.signals_schema.values.get("ids") is int
     assert ds.signals_schema.values.get("fname") is str
-    assert list(ds.order_by("fname").to_list("fname")) == ["a", "b", "c"]
+    assert ds.order_by("fname").to_list("fname") == ["a", "b", "c"]
 
 
 def test_rename_column_with_mutate(test_session):
@@ -2402,7 +2401,7 @@ def test_rename_column_with_mutate(test_session):
     ds = dc.read_values(file=files, ids=[1, 2, 3], session=test_session)
     ds = ds.mutate(my_file=Column("file"))
 
-    assert list(ds.order_by("my_file.path").to_list("my_file.path")) == ["a", "b", "c"]
+    assert ds.order_by("my_file.path").to_list("my_file.path") == ["a", "b", "c"]
     assert ds.signals_schema.values == {"my_file": File, "ids": int}
 
     # check that persist after saving
@@ -2412,7 +2411,7 @@ def test_rename_column_with_mutate(test_session):
     assert ds.signals_schema.values.get("my_file") is File
     assert ds.signals_schema.values.get("ids") is int
     assert "file" not in ds.signals_schema.values
-    assert list(ds.order_by("my_file.path").to_list("my_file.path")) == ["a", "b", "c"]
+    assert ds.order_by("my_file.path").to_list("my_file.path") == ["a", "b", "c"]
 
 
 def test_column(test_session):
@@ -2488,7 +2487,7 @@ def test_mutate_with_saving(test_session):
 
     ds = dc.read_dataset(name="mutated", session=test_session)
     assert ds.signals_schema.values["new"] is float
-    assert list(ds.to_list("new")) == [0.5, 1.0]
+    assert ds.to_list("new") == [0.5, 1.0]
 
 
 def test_mutate_with_expression_without_type(test_session):
@@ -2505,7 +2504,7 @@ def test_mutate_with_expression_without_type(test_session):
 def test_read_values_nan_inf(test_session):
     vals = [float("nan"), float("inf"), float("-inf")]
     chain = dc.read_values(vals=vals, session=test_session)
-    res = list(chain.to_list("vals"))
+    res = chain.to_list("vals")
     assert len(res) == 3
     assert any(r for r in res if np.isnan(r))
     assert any(r for r in res if np.isposinf(r))
@@ -2516,7 +2515,7 @@ def test_read_pandas_nan_inf(test_session):
     vals = [float("nan"), float("inf"), float("-inf")]
     df = pd.DataFrame({"vals": vals})
     chain = dc.read_pandas(df, session=test_session)
-    res = list(chain.to_list("vals"))
+    res = chain.to_list("vals")
     assert len(res) == 3
     assert any(r for r in res if np.isnan(r))
     assert any(r for r in res if np.isposinf(r))
@@ -2544,7 +2543,7 @@ def test_read_csv_nan_inf(tmp_dir, test_session):
     df.to_csv(path, index=False)
     chain = dc.read_csv(path.as_uri(), session=test_session)
 
-    res = list(chain.to_list("vals"))
+    res = chain.to_list("vals")
     assert len(res) == 3
     assert any(r for r in res if np.isnan(r))
     assert any(r for r in res if np.isposinf(r))
@@ -3305,10 +3304,10 @@ def test_from_dataset_version_int_backward_compatible(test_session):
     dc.read_values(nums=[5], session=test_session).save(ds_name, version="2.1.2")
     dc.read_values(nums=[6], session=test_session).save(ds_name, version="3.0.0")
 
-    assert list(dc.read_dataset(ds_name, version=1).to_list("nums")) == [2]
-    assert list(dc.read_dataset(ds_name, version=2).to_list("nums")) == [5]
-    assert list(dc.read_dataset(ds_name, version=3).to_list("nums")) == [6]
-    assert list(dc.read_dataset(ds_name, version="1.0.0").to_list("nums")) == [1]
+    assert dc.read_dataset(ds_name, version=1).to_list("nums") == [2]
+    assert dc.read_dataset(ds_name, version=2).to_list("nums") == [5]
+    assert dc.read_dataset(ds_name, version=3).to_list("nums") == [6]
+    assert dc.read_dataset(ds_name, version="1.0.0").to_list("nums") == [1]
     with pytest.raises(DatasetVersionNotFoundError):
         dc.read_dataset(ds_name, version=5)
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2241,7 +2241,7 @@ def test_column_math(test_session):
     chain = dc.read_values(num=fib, session=test_session).order_by("num")
 
     ch = chain.mutate(add2=chain.column("num") + 2)
-    assert chain.to_list("add2") == [x + 2 for x in fib]
+    assert ch.to_list("add2") == [x + 2 for x in fib]
 
     ch2 = ch.mutate(x=1 - ch.column("add2"))
     assert ch2.to_list("x") == [1 - (x + 2.0) for x in fib]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1184,11 +1184,11 @@ def test_to_list_single_item(test_session):
     chain = dc.read_values(file=files, score=scores, session=test_session)
     chain = chain.order_by("file.path", "file.size")
 
-    assert chain.to_list("file") == files
-    assert chain.to_list("file.path") == names
-    assert chain.to_list("file.size") == sizes
-    assert chain.to_list("file.source") == [""] * len(names)
-    assert np.allclose(chain.to_list("score"), scores)
+    assert [item[0] for item in chain.to_list("file")] == files
+    assert [item[0] for item in chain.to_list("file.path")] == names
+    assert [item[0] for item in chain.to_list("file.size")] == sizes
+    assert [item[0] for item in chain.to_list("file.source")] == [""] * len(names)
+    assert np.allclose([item[0] for item in chain.to_list("score")], scores)
 
     for actual, expected in zip(
         chain.to_list("file.size", "score"), [[x, y] for x, y in zip(sizes, scores)]

--- a/tests/unit/lib/test_datachain_bootstrap.py
+++ b/tests/unit/lib/test_datachain_bootstrap.py
@@ -31,7 +31,7 @@ def test_udf(monkeypatch):
     chain = dc.read_values(key=vals)
 
     udf = MyMapper()
-    res = chain.map(res=udf).to_list("res")
+    res = chain.map(res=udf).to_values("res")
 
     assert res == [MyMapper.BOOTSTRAP_VALUE] * len(vals)
     assert udf.value == MyMapper.TEARDOWN_VALUE
@@ -70,7 +70,7 @@ def test_bootstrap_in_chain():
         .setup(init_val=lambda: base)
         .map(x=lambda val, init_val: val + init_val, output=int)
         .order_by("x")
-        .to_list("x")
+        .to_values("x")
     )
 
     assert res == [base + val for val in prime]

--- a/tests/unit/lib/test_datachain_bootstrap.py
+++ b/tests/unit/lib/test_datachain_bootstrap.py
@@ -31,7 +31,7 @@ def test_udf(monkeypatch):
     chain = dc.read_values(key=vals)
 
     udf = MyMapper()
-    res = list(chain.map(res=udf).collect("res"))
+    res = chain.map(res=udf).to_list("res")
 
     assert res == [MyMapper.BOOTSTRAP_VALUE] * len(vals)
     assert udf.value == MyMapper.TEARDOWN_VALUE
@@ -55,7 +55,7 @@ def test_no_bootstrap_for_callable():
     udf = MyMapper()
 
     chain = dc.read_values(key=["a", "b", "c"])
-    list(chain.map(res=udf).collect())
+    list(chain.map(res=udf).to_list())
 
     assert udf._had_bootstrap is False
     assert udf._had_teardown is False
@@ -70,7 +70,7 @@ def test_bootstrap_in_chain():
         .setup(init_val=lambda: base)
         .map(x=lambda val, init_val: val + init_val, output=int)
         .order_by("x")
-        .collect("x")
+        .to_list("x")
     )
 
     assert res == [base + val for val in prime]

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -57,7 +57,7 @@ def test_merge_objects(test_session):
 
     i = 0
     j = 0
-    for items in ch.order_by("emp.person.name", "team.player").to_iter():
+    for items in ch.order_by("emp.person.name", "team.player"):
         assert len(items) == 2
 
         empl, player = items
@@ -100,7 +100,7 @@ def test_merge_objects_full_join(test_session, multiple_predicates):
     int_default = Int.default_value(test_session.catalog.warehouse.db.dialect)
 
     i = 0
-    for items in ch.order_by("emp.person.name", "team.player").to_iter():
+    for items in ch.order_by("emp.person.name", "team.player"):
         assert len(items) == 2
 
         empl, player = items
@@ -291,7 +291,7 @@ def test_merge_with_itself(test_session):
     merged = ch.merge(ch, "emp.id")
 
     count = 0
-    for left, right in merged.order_by("emp.id").to_iter():
+    for left, right in merged.order_by("emp.id"):
         assert isinstance(left, Employee)
         assert isinstance(right, Employee)
         assert left == right == employees[count]
@@ -305,7 +305,7 @@ def test_merge_with_itself_column(test_session):
     merged = ch.merge(ch, C("emp.id"))
 
     count = 0
-    for left, right in merged.order_by("emp.id").to_iter():
+    for left, right in merged.order_by("emp.id"):
         assert isinstance(left, Employee)
         assert isinstance(right, Employee)
         assert left == right == employees[count]
@@ -331,7 +331,7 @@ def test_merge_on_expression(test_session):
 
     merged.show()
     count = 0
-    for left, right_dc in merged.order_by("team.player", "right_team.player").to_iter():
+    for left, right_dc in merged.order_by("team.player", "right_team.player"):
         assert isinstance(left, TeamMember)
         assert isinstance(right_dc, TeamMember)
         left_member, right_member = cross_team[count]

--- a/tests/unit/lib/test_datachain_merge.py
+++ b/tests/unit/lib/test_datachain_merge.py
@@ -57,7 +57,7 @@ def test_merge_objects(test_session):
 
     i = 0
     j = 0
-    for items in ch.order_by("emp.person.name", "team.player").collect():
+    for items in ch.order_by("emp.person.name", "team.player").to_iter():
         assert len(items) == 2
 
         empl, player = items
@@ -100,7 +100,7 @@ def test_merge_objects_full_join(test_session, multiple_predicates):
     int_default = Int.default_value(test_session.catalog.warehouse.db.dialect)
 
     i = 0
-    for items in ch.order_by("emp.person.name", "team.player").collect():
+    for items in ch.order_by("emp.person.name", "team.player").to_iter():
         assert len(items) == 2
 
         empl, player = items
@@ -143,12 +143,12 @@ def test_merge_similar_objects(test_session):
 
     assert list(ch.signals_schema.values.keys()) == ["sys", "emp", rname + "emp"]
 
-    empl = list(ch.collect())
+    empl = list(ch.to_list())
     assert len(empl) == 4
     assert len(empl[0]) == 2
 
     ch_inner = ch1.merge(ch2, "emp.person.name", rname=rname, inner=True)
-    assert len(list(ch_inner.collect())) == 2
+    assert len(list(ch_inner.to_list())) == 2
 
 
 @skip_if_not_sqlite
@@ -178,12 +178,12 @@ def test_merge_similar_objects_in_memory():
 
     assert list(ch.signals_schema.values.keys()) == ["sys", "emp", rname + "emp"]
 
-    empl = list(ch.collect())
+    empl = list(ch.to_list())
     assert len(empl) == 4
     assert len(empl[0]) == 2
 
     ch_inner = ch1.merge(ch2, "emp.person.name", rname=rname, inner=True)
-    assert len(list(ch_inner.collect())) == 2
+    assert len(list(ch_inner.to_list())) == 2
 
 
 def test_merge_values(test_session):
@@ -208,7 +208,7 @@ def test_merge_values(test_session):
 
     i = 0
     j = 0
-    sorted_items_list = sorted(ch.collect(), key=lambda x: x[0])
+    sorted_items_list = sorted(ch.to_list(), key=lambda x: x[0])
     for items in sorted_items_list:
         assert len(items) == 4
         id, name, _right_id, time = items
@@ -244,7 +244,7 @@ def test_merge_multi_conditions(test_session):
 
     ch = ch1.merge(ch2, ("id", "name"), ("id", C("d_name")))
 
-    res = list(ch.collect())
+    res = list(ch.to_list())
 
     assert len(res) == max(len(employees), len(team))
     success_ids = set()
@@ -291,7 +291,7 @@ def test_merge_with_itself(test_session):
     merged = ch.merge(ch, "emp.id")
 
     count = 0
-    for left, right in merged.order_by("emp.id").collect():
+    for left, right in merged.order_by("emp.id").to_iter():
         assert isinstance(left, Employee)
         assert isinstance(right, Employee)
         assert left == right == employees[count]
@@ -305,7 +305,7 @@ def test_merge_with_itself_column(test_session):
     merged = ch.merge(ch, C("emp.id"))
 
     count = 0
-    for left, right in merged.order_by("emp.id").collect():
+    for left, right in merged.order_by("emp.id").to_iter():
         assert isinstance(left, Employee)
         assert isinstance(right, Employee)
         assert left == right == employees[count]
@@ -331,7 +331,7 @@ def test_merge_on_expression(test_session):
 
     merged.show()
     count = 0
-    for left, right_dc in merged.order_by("team.player", "right_team.player").collect():
+    for left, right_dc in merged.order_by("team.player", "right_team.player").to_iter():
         assert isinstance(left, TeamMember)
         assert isinstance(right_dc, TeamMember)
         left_member, right_member = cross_team[count]

--- a/tests/unit/lib/test_diff.py
+++ b/tests/unit/lib/test_diff.py
@@ -92,7 +92,7 @@ def test_compare(test_session, str_default, added, deleted, modified, same):
         assert "diff" not in chains[CompareStatus.SAME].signals_schema.db_signals()
         expected.append((CompareStatus.SAME, 4, "Andy"))
 
-    assert list(diff.order_by("id").collect("diff", "id", "name")) == expected
+    assert diff.order_by("id").to_list("diff", "id", "name") == expected
 
 
 def test_compare_no_status_col(test_session, str_default):
@@ -122,7 +122,7 @@ def test_compare_no_status_col(test_session, str_default):
         (4, "Andy"),
     ]
 
-    assert list(diff.order_by("id").collect()) == expected
+    assert diff.order_by("id").to_list() == expected
 
 
 def test_compare_read_hfs(test_session, str_default):
@@ -144,7 +144,7 @@ def test_compare_read_hfs(test_session, str_default):
 
     diff = ds1.compare(ds2, same=True, on=["id"], status_col="diff")
 
-    assert list(diff.order_by("id").collect("diff", "id", "name")) == [
+    assert diff.order_by("id").to_list("diff", "id", "name") == [
         (CompareStatus.MODIFIED, 1, "John1"),
         (CompareStatus.ADDED, 2, "Doe"),
         (CompareStatus.DELETED, 3, str_default),
@@ -187,7 +187,7 @@ def test_compare_with_explicit_compare_fields(test_session, str_default, right_n
     ]
 
     collect_fields = ["diff", "id", "name", "city"]
-    assert list(diff.order_by("id").collect(*collect_fields)) == expected
+    assert diff.order_by("id").to_list(*collect_fields) == expected
 
 
 def test_compare_different_left_right_on_columns(test_session, str_default):
@@ -219,7 +219,7 @@ def test_compare_different_left_right_on_columns(test_session, str_default):
     ]
 
     collect_fields = ["diff", "id", "name"]
-    assert list(diff.order_by("id").collect(*collect_fields)) == expected
+    assert diff.order_by("id").to_list(*collect_fields) == expected
 
 
 @pytest.mark.parametrize("on_self", (True, False))
@@ -253,7 +253,7 @@ def test_compare_on_equal_datasets(test_session, on_self):
     ]
 
     collect_fields = ["diff", "id", "name"]
-    assert list(diff.order_by("id").collect(*collect_fields)) == expected
+    assert diff.order_by("id").to_list(*collect_fields) == expected
 
 
 def test_compare_multiple_columns(test_session, str_default):
@@ -473,7 +473,7 @@ def test_diff(test_session, str_default, int_default, status_col, right_on):
         expected = [row[1:] for row in expected]
         collect_fields = collect_fields[1:]
 
-    assert list(diff.order_by("file1.source").collect(*collect_fields)) == expected
+    assert diff.order_by("file1.source").to_list(*collect_fields) == expected
 
 
 @pytest.mark.parametrize("status_col", ("diff", None))
@@ -528,6 +528,4 @@ def test_diff_nested(test_session, str_default, int_default, status_col):
         expected = [row[1:] for row in expected]
         collect_fields = collect_fields[1:]
 
-    assert (
-        list(diff.order_by("nested.file.source").collect(*collect_fields)) == expected
-    )
+    assert diff.order_by("nested.file.source").to_list(*collect_fields) == expected

--- a/tests/unit/lib/test_feature_utils.py
+++ b/tests/unit/lib/test_feature_utils.py
@@ -31,7 +31,7 @@ def test_e2e(test_session):
 
     chain = dc.read_values(fib=fib, odds=values, session=test_session)
 
-    vals = list(chain.order_by("fib").collect())
+    vals = chain.order_by("fib").to_list()
     lst1 = [item[0] for item in vals]
     lst2 = [item[1] for item in vals]
 
@@ -53,7 +53,7 @@ def test_single_e2e(test_session):
 
     chain = dc.read_values(fib=fib, session=test_session)
 
-    vals = list(chain.order_by("fib").collect())
+    vals = list(chain.order_by("fib").to_list())
     flattened = [item for sublist in vals for item in sublist]
 
     assert flattened == fib

--- a/tests/unit/lib/test_schema.py
+++ b/tests/unit/lib/test_schema.py
@@ -16,7 +16,4 @@ def test_column_filter_by_regex(test_session):
         dc.C("file.path").regexp("dog\\.txt$")
     )
 
-    assert set(chain.collect("file.path")) == {
-        "dog.txt",
-        "1dog.txt",
-    }
+    assert set(chain.to_iter("file.path")) == {"dog.txt", "1dog.txt"}

--- a/tests/unit/lib/test_schema.py
+++ b/tests/unit/lib/test_schema.py
@@ -16,4 +16,4 @@ def test_column_filter_by_regex(test_session):
         dc.C("file.path").regexp("dog\\.txt$")
     )
 
-    assert set(chain.to_iter("file.path")) == {"dog.txt", "1dog.txt"}
+    assert set(chain.to_values("file.path")) == {"dog.txt", "1dog.txt"}

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -88,14 +88,14 @@ def test_add():
 
 
 def test_add_mutate(chain):
-    res = chain.mutate(test=strlen("val") + 1).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") + 1).order_by("num").to_values("test")
     assert res == [2, 3, 4, 5, 6]
 
-    res = chain.mutate(test=1 + strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=1 + strlen("val")).order_by("num").to_values("test")
     assert res == [2, 3, 4, 5, 6]
 
     res = (
-        chain.mutate(test=strlen("val") + strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") + strlen("val")).order_by("num").to_values("test")
     )
     assert res == [2, 4, 6, 8, 10]
 
@@ -120,14 +120,14 @@ def test_sub():
 
 
 def test_sub_mutate(chain):
-    res = chain.mutate(test=strlen("val") - 1).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") - 1).order_by("num").to_values("test")
     assert res == [0, 1, 2, 3, 4]
 
-    res = chain.mutate(test=5 - strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=5 - strlen("val")).order_by("num").to_values("test")
     assert res == [4, 3, 2, 1, 0]
 
     res = (
-        chain.mutate(test=strlen("val") - strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") - strlen("val")).order_by("num").to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -152,14 +152,14 @@ def test_mul():
 
 
 def test_mul_mutate(chain):
-    res = chain.mutate(test=strlen("val") * 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") * 2).order_by("num").to_values("test")
     assert res == [2, 4, 6, 8, 10]
 
-    res = chain.mutate(test=3 * strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=3 * strlen("val")).order_by("num").to_values("test")
     assert res == [3, 6, 9, 12, 15]
 
     res = (
-        chain.mutate(test=strlen("val") * strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") * strlen("val")).order_by("num").to_values("test")
     )
     assert res == [1, 4, 9, 16, 25]
 
@@ -184,14 +184,14 @@ def test_truediv():
 
 
 def test_truediv_mutate(chain):
-    res = chain.mutate(test=strlen("val") / 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") / 2).order_by("num").to_values("test")
     assert res == [0.5, 1.0, 1.5, 2.0, 2.5]
 
-    res = chain.mutate(test=10 / strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=10 / strlen("val")).order_by("num").to_values("test")
     assert res == [10.0, 5.0, 10 / 3, 2.5, 2.0]
 
     res = (
-        chain.mutate(test=strlen("val") / strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") / strlen("val")).order_by("num").to_values("test")
     )
     assert res == [1.0, 1.0, 1.0, 1.0, 1.0]
 
@@ -216,16 +216,16 @@ def test_floordiv():
 
 
 def test_floordiv_mutate(chain):
-    res = chain.mutate(test=strlen("val") // 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") // 2).order_by("num").to_values("test")
     assert res == [0, 1, 1, 2, 2]
 
-    res = chain.mutate(test=10 // strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=10 // strlen("val")).order_by("num").to_values("test")
     assert res == [10, 5, 3, 2, 2]
 
     res = (
         chain.mutate(test=strlen("val") // strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [1, 1, 1, 1, 1]
 
@@ -250,14 +250,14 @@ def test_mod():
 
 
 def test_mod_mutate(chain):
-    res = chain.mutate(test=strlen("val") % 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") % 2).order_by("num").to_values("test")
     assert res == [1, 0, 1, 0, 1]
 
-    res = chain.mutate(test=10 % strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=10 % strlen("val")).order_by("num").to_values("test")
     assert res == [0, 0, 1, 2, 0]
 
     res = (
-        chain.mutate(test=strlen("val") % strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") % strlen("val")).order_by("num").to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -282,14 +282,14 @@ def test_and():
 
 
 def test_and_mutate(chain):
-    res = chain.mutate(test=strlen("val") & 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") & 2).order_by("num").to_values("test")
     assert res == [0, 2, 2, 0, 0]
 
-    res = chain.mutate(test=2 & strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=2 & strlen("val")).order_by("num").to_values("test")
     assert res == [0, 2, 2, 0, 0]
 
     res = (
-        chain.mutate(test=strlen("val") & strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") & strlen("val")).order_by("num").to_values("test")
     )
     assert res == [1, 2, 3, 4, 5]
 
@@ -314,14 +314,14 @@ def test_or():
 
 
 def test_or_mutate(chain):
-    res = chain.mutate(test=strlen("val") | 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") | 2).order_by("num").to_values("test")
     assert res == [3, 2, 3, 6, 7]
 
-    res = chain.mutate(test=2 | strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=2 | strlen("val")).order_by("num").to_values("test")
     assert res == [3, 2, 3, 6, 7]
 
     res = (
-        chain.mutate(test=strlen("val") | strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") | strlen("val")).order_by("num").to_values("test")
     )
     assert res == [1, 2, 3, 4, 5]
 
@@ -331,7 +331,7 @@ def test_or_func_mutate(chain):
     res = chain.mutate(
         test=ifelse(or_(dc.C("num") < 3, dc.C("num") > 4), "Match", "Not Match")
     )
-    assert list(res.order_by("num").to_list("test")) == [
+    assert list(res.order_by("num").to_values("test")) == [
         "Match",
         "Match",
         "Not Match",
@@ -345,7 +345,7 @@ def test_and_func_mutate(chain):
     res = chain.mutate(
         test=ifelse(and_(dc.C("num") > 1, dc.C("num") < 4), "Match", "Not Match")
     )
-    assert list(res.order_by("num").to_list("test")) == [
+    assert list(res.order_by("num").to_values("test")) == [
         "Not Match",
         "Match",
         "Match",
@@ -374,14 +374,14 @@ def test_xor():
 
 
 def test_xor_mutate(chain):
-    res = chain.mutate(test=strlen("val") ^ 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") ^ 2).order_by("num").to_values("test")
     assert res == [3, 0, 1, 6, 7]
 
-    res = chain.mutate(test=2 ^ strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=2 ^ strlen("val")).order_by("num").to_values("test")
     assert res == [3, 0, 1, 6, 7]
 
     res = (
-        chain.mutate(test=strlen("val") ^ strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") ^ strlen("val")).order_by("num").to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -406,16 +406,16 @@ def test_rshift():
 
 
 def test_rshift_mutate(chain):
-    res = chain.mutate(test=strlen("val") >> 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") >> 2).order_by("num").to_values("test")
     assert res == [0, 0, 0, 1, 1]
 
-    res = chain.mutate(test=2 >> strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=2 >> strlen("val")).order_by("num").to_values("test")
     assert res == [1, 0, 0, 0, 0]
 
     res = (
         chain.mutate(test=strlen("val") >> strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -440,16 +440,16 @@ def test_lshift():
 
 
 def test_lshift_mutate(chain):
-    res = chain.mutate(test=strlen("val") << 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") << 2).order_by("num").to_values("test")
     assert res == [4, 8, 12, 16, 20]
 
-    res = chain.mutate(test=2 << strlen("val")).order_by("num").to_list("test")
+    res = chain.mutate(test=2 << strlen("val")).order_by("num").to_values("test")
     assert res == [4, 8, 16, 32, 64]
 
     res = (
         chain.mutate(test=strlen("val") << strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [2, 8, 24, 64, 160]
 
@@ -474,21 +474,21 @@ def test_lt():
 
 
 def test_lt_mutate(chain):
-    res = chain.mutate(test=strlen("val") < 3).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") < 3).order_by("num").to_values("test")
     assert res == [1, 1, 0, 0, 0]
 
-    res = chain.mutate(test=strlen("val") > 3).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") > 3).order_by("num").to_values("test")
     assert res == [0, 0, 0, 1, 1]
 
     res = (
-        chain.mutate(test=strlen("val") < strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") < strlen("val")).order_by("num").to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
 
 @pytest.mark.parametrize("value", [1, 0.5, "a", True])
 def test_mutate_with_literal(chain, value):
-    res = chain.mutate(test=value).to_list("test")
+    res = chain.mutate(test=value).to_values("test")
     assert res == [value] * 5
 
 
@@ -512,16 +512,16 @@ def test_le():
 
 
 def test_le_mutate(chain):
-    res = chain.mutate(test=strlen("val") <= 3).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") <= 3).order_by("num").to_values("test")
     assert res == [1, 1, 1, 0, 0]
 
-    res = chain.mutate(test=strlen("val") >= 3).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") >= 3).order_by("num").to_values("test")
     assert res == [0, 0, 1, 1, 1]
 
     res = (
         chain.mutate(test=strlen("val") <= strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [1, 1, 1, 1, 1]
 
@@ -546,16 +546,16 @@ def test_eq():
 
 
 def test_eq_mutate(chain):
-    res = chain.mutate(test=strlen("val") == 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") == 2).order_by("num").to_values("test")
     assert res == [0, 1, 0, 0, 0]
 
-    res = chain.mutate(test=strlen("val") == 4).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") == 4).order_by("num").to_values("test")
     assert res == [0, 0, 0, 1, 0]
 
     res = (
         chain.mutate(test=strlen("val") == strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [1, 1, 1, 1, 1]
 
@@ -580,16 +580,16 @@ def test_ne():
 
 
 def test_ne_mutate(chain):
-    res = chain.mutate(test=strlen("val") != 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") != 2).order_by("num").to_values("test")
     assert res == [1, 0, 1, 1, 1]
 
-    res = chain.mutate(test=strlen("val") != 4).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") != 4).order_by("num").to_values("test")
     assert res == [1, 1, 1, 0, 1]
 
     res = (
         chain.mutate(test=strlen("val") != strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -614,14 +614,14 @@ def test_gt():
 
 
 def test_gt_mutate(chain):
-    res = chain.mutate(test=strlen("val") > 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") > 2).order_by("num").to_values("test")
     assert res == [0, 0, 1, 1, 1]
 
-    res = chain.mutate(test=strlen("val") < 4).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") < 4).order_by("num").to_values("test")
     assert res == [1, 1, 1, 0, 0]
 
     res = (
-        chain.mutate(test=strlen("val") > strlen("val")).order_by("num").to_list("test")
+        chain.mutate(test=strlen("val") > strlen("val")).order_by("num").to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -646,16 +646,16 @@ def test_ge():
 
 
 def test_ge_mutate(chain):
-    res = chain.mutate(test=strlen("val") >= 2).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") >= 2).order_by("num").to_values("test")
     assert res == [0, 1, 1, 1, 1]
 
-    res = chain.mutate(test=strlen("val") <= 4).order_by("num").to_list("test")
+    res = chain.mutate(test=strlen("val") <= 4).order_by("num").to_values("test")
     assert res == [1, 1, 1, 1, 0]
 
     res = (
         chain.mutate(test=strlen("val") >= strlen("val"))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [1, 1, 1, 1, 1]
 
@@ -674,7 +674,7 @@ def test_sqlite_int_hash_64(value, inthash):
 
 
 def test_int_hash_64_mutate(chain):
-    res = chain.mutate(test=int_hash_64(strlen("val"))).order_by("num").to_list("test")
+    res = chain.mutate(test=int_hash_64(strlen("val"))).order_by("num").to_values("test")
     assert [x & (2**64 - 1) for x in res] == [
         10577349846663553072,
         18198135717204167749,
@@ -704,7 +704,7 @@ def test_bit_hamming_distance_mutate(chain):
     res = (
         chain.mutate(test=bit_hamming_distance(strlen("val"), 5))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [1, 3, 2, 1, 0]
 
@@ -728,7 +728,7 @@ def test_byte_hamming_distance_mutate(chain):
     res = (
         chain.mutate(test=byte_hamming_distance("val", literal("xxx")))
         .order_by("num")
-        .to_list("test")
+        .to_values("test")
     )
     assert res == [2, 1, 0, 1, 2]
 
@@ -744,7 +744,7 @@ def test_byte_hamming_distance_mutate(chain):
 )
 def test_case_mutate(chain, val, else_, type_):
     res = chain.mutate(test=case((dc.C("num") < 2, val), else_=else_))
-    assert list(res.order_by("test").to_list("test")) == sorted(
+    assert list(res.order_by("test").to_values("test")) == sorted(
         [val, else_, else_, else_, else_]
     )
     assert res.schema["test"] == type_
@@ -752,12 +752,12 @@ def test_case_mutate(chain, val, else_, type_):
 
 def test_case_mutate_column_as_value(chain):
     res = chain.mutate(test=case((dc.C("num") < 3, dc.C("val")), else_="cc"))
-    assert list(res.order_by("num").to_list("test")) == ["x", "xx", "cc", "cc", "cc"]
+    assert list(res.order_by("num").to_values("test")) == ["x", "xx", "cc", "cc", "cc"]
 
 
 def test_case_mutate_column_as_value_in_else(chain):
     res = chain.mutate(test=case((dc.C("num") < 3, dc.C("val")), else_=dc.C("val")))
-    assert list(res.order_by("num").to_list("test")) == [
+    assert list(res.order_by("num").to_values("test")) == [
         "x",
         "xx",
         "xxx",
@@ -780,7 +780,7 @@ def test_nested_case_on_condition_mutate(chain, val, else_, type_):
     res = chain.mutate(
         test=case((case((dc.C("num") < 2, True), else_=False), val), else_=else_)
     )
-    assert list(res.order_by("test").to_list("test")) == sorted(
+    assert list(res.order_by("test").to_values("test")) == sorted(
         [val, else_, else_, else_, else_]
     )
     assert res.schema["test"] == type_
@@ -799,7 +799,7 @@ def test_nested_case_on_value_mutate(chain, v1, v2, v3, type_):
     res = chain.mutate(
         test=case((dc.C("num") < 4, case((dc.C("num") < 2, v1), else_=v2)), else_=v3)
     )
-    assert list(res.order_by("num").to_list("test")) == sorted([v1, v2, v2, v3, v3])
+    assert list(res.order_by("num").to_values("test")) == sorted([v1, v2, v2, v3, v3])
     assert res.schema["test"] == type_
 
 
@@ -816,7 +816,7 @@ def test_nested_case_on_else_mutate(chain, v1, v2, v3, type_):
     res = chain.mutate(
         test=case((dc.C("num") < 3, v1), else_=case((dc.C("num") < 4, v2), else_=v3))
     )
-    assert list(res.order_by("num").to_list("test")) == sorted([v1, v1, v2, v3, v3])
+    assert list(res.order_by("num").to_values("test")) == sorted([v1, v1, v2, v3, v3])
     assert res.schema["test"] == type_
 
 
@@ -831,7 +831,7 @@ def test_nested_case_on_else_mutate(chain, v1, v2, v3, type_):
 )
 def test_ifelse_mutate(chain, if_val, else_val, type_):
     res = chain.mutate(test=ifelse(dc.C("num") < 2, if_val, else_val))
-    assert list(res.order_by("test").to_list("test")) == sorted(
+    assert list(res.order_by("test").to_values("test")) == sorted(
         [if_val, else_val, else_val, else_val, else_val]
     )
     assert res.schema["test"] == type_
@@ -846,7 +846,7 @@ def test_ifelse_mutate(chain, if_val, else_val, type_):
 )
 def test_ifelse_mutate_with_columns_as_values(chain, if_val, else_val, type_, result):
     res = chain.mutate(test=ifelse(dc.C("num") < 3, if_val, else_val))
-    assert list(res.order_by("test").to_list("test")) == result
+    assert list(res.order_by("test").to_values("test")) == result
     assert res.schema["test"] == type_
 
 
@@ -859,7 +859,7 @@ def test_isnone_mutate(col):
     )
 
     res = chain.mutate(test=isnone(col))
-    assert list(res.order_by("test").to_list("test")) == sorted(
+    assert list(res.order_by("test").to_values("test")) == sorted(
         [False, False, False, True, True]
     )
     assert res.schema["test"] is bool
@@ -874,7 +874,7 @@ def test_isnone_with_ifelse_mutate(col):
     )
 
     res = chain.mutate(test=ifelse(isnone(col), "NONE", "NOT_NONE"))
-    assert list(res.order_by("num").to_list("test")) == ["NOT_NONE"] * 3 + ["NONE"] * 2
+    assert list(res.order_by("num").to_values("test")) == ["NOT_NONE"] * 3 + ["NONE"] * 2
     assert res.schema["test"] is str
 
 
@@ -885,7 +885,7 @@ def test_array_contains():
     )
 
     assert list(
-        chain.mutate(res=contains("arr", 3)).order_by("val").to_list("res")
+        chain.mutate(res=contains("arr", 3)).order_by("val").to_values("res")
     ) == [
         0,
         0,
@@ -894,11 +894,11 @@ def test_array_contains():
         1,
     ]
     assert list(
-        chain.mutate(res=contains(dc.C("arr"), 3)).order_by("val").to_list("res")
+        chain.mutate(res=contains(dc.C("arr"), 3)).order_by("val").to_values("res")
     ) == [0, 0, 1, 1, 1]
     assert list(
-        chain.mutate(res=contains(dc.C("arr"), 10)).order_by("val").to_list("res")
+        chain.mutate(res=contains(dc.C("arr"), 10)).order_by("val").to_values("res")
     ) == [0, 0, 0, 0, 0]
     assert list(
-        chain.mutate(res=contains(dc.C("arr"), None)).order_by("val").to_list("res")
+        chain.mutate(res=contains(dc.C("arr"), None)).order_by("val").to_values("res")
     ) == [0, 0, 0, 0, 0]

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -95,7 +95,9 @@ def test_add_mutate(chain):
     assert res == [2, 3, 4, 5, 6]
 
     res = (
-        chain.mutate(test=strlen("val") + strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") + strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [2, 4, 6, 8, 10]
 
@@ -127,7 +129,9 @@ def test_sub_mutate(chain):
     assert res == [4, 3, 2, 1, 0]
 
     res = (
-        chain.mutate(test=strlen("val") - strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") - strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -159,7 +163,9 @@ def test_mul_mutate(chain):
     assert res == [3, 6, 9, 12, 15]
 
     res = (
-        chain.mutate(test=strlen("val") * strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") * strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [1, 4, 9, 16, 25]
 
@@ -191,7 +197,9 @@ def test_truediv_mutate(chain):
     assert res == [10.0, 5.0, 10 / 3, 2.5, 2.0]
 
     res = (
-        chain.mutate(test=strlen("val") / strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") / strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [1.0, 1.0, 1.0, 1.0, 1.0]
 
@@ -257,7 +265,9 @@ def test_mod_mutate(chain):
     assert res == [0, 0, 1, 2, 0]
 
     res = (
-        chain.mutate(test=strlen("val") % strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") % strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -289,7 +299,9 @@ def test_and_mutate(chain):
     assert res == [0, 2, 2, 0, 0]
 
     res = (
-        chain.mutate(test=strlen("val") & strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") & strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [1, 2, 3, 4, 5]
 
@@ -321,7 +333,9 @@ def test_or_mutate(chain):
     assert res == [3, 2, 3, 6, 7]
 
     res = (
-        chain.mutate(test=strlen("val") | strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") | strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [1, 2, 3, 4, 5]
 
@@ -381,7 +395,9 @@ def test_xor_mutate(chain):
     assert res == [3, 0, 1, 6, 7]
 
     res = (
-        chain.mutate(test=strlen("val") ^ strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") ^ strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -481,7 +497,9 @@ def test_lt_mutate(chain):
     assert res == [0, 0, 0, 1, 1]
 
     res = (
-        chain.mutate(test=strlen("val") < strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") < strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -621,7 +639,9 @@ def test_gt_mutate(chain):
     assert res == [1, 1, 1, 0, 0]
 
     res = (
-        chain.mutate(test=strlen("val") > strlen("val")).order_by("num").to_values("test")
+        chain.mutate(test=strlen("val") > strlen("val"))
+        .order_by("num")
+        .to_values("test")
     )
     assert res == [0, 0, 0, 0, 0]
 
@@ -674,7 +694,9 @@ def test_sqlite_int_hash_64(value, inthash):
 
 
 def test_int_hash_64_mutate(chain):
-    res = chain.mutate(test=int_hash_64(strlen("val"))).order_by("num").to_values("test")
+    res = (
+        chain.mutate(test=int_hash_64(strlen("val"))).order_by("num").to_values("test")
+    )
     assert [x & (2**64 - 1) for x in res] == [
         10577349846663553072,
         18198135717204167749,
@@ -874,7 +896,9 @@ def test_isnone_with_ifelse_mutate(col):
     )
 
     res = chain.mutate(test=ifelse(isnone(col), "NONE", "NOT_NONE"))
-    assert list(res.order_by("num").to_values("test")) == ["NOT_NONE"] * 3 + ["NONE"] * 2
+    assert (
+        list(res.order_by("num").to_values("test")) == ["NOT_NONE"] * 3 + ["NONE"] * 2
+    )
     assert res.schema["test"] is str
 
 

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -88,16 +88,16 @@ def test_add():
 
 
 def test_add_mutate(chain):
-    res = chain.mutate(test=strlen("val") + 1).order_by("num").collect("test")
-    assert list(res) == [2, 3, 4, 5, 6]
+    res = chain.mutate(test=strlen("val") + 1).order_by("num").to_list("test")
+    assert res == [2, 3, 4, 5, 6]
 
-    res = chain.mutate(test=1 + strlen("val")).order_by("num").collect("test")
-    assert list(res) == [2, 3, 4, 5, 6]
+    res = chain.mutate(test=1 + strlen("val")).order_by("num").to_list("test")
+    assert res == [2, 3, 4, 5, 6]
 
     res = (
-        chain.mutate(test=strlen("val") + strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") + strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [2, 4, 6, 8, 10]
+    assert res == [2, 4, 6, 8, 10]
 
 
 def test_sub():
@@ -120,16 +120,16 @@ def test_sub():
 
 
 def test_sub_mutate(chain):
-    res = chain.mutate(test=strlen("val") - 1).order_by("num").collect("test")
-    assert list(res) == [0, 1, 2, 3, 4]
+    res = chain.mutate(test=strlen("val") - 1).order_by("num").to_list("test")
+    assert res == [0, 1, 2, 3, 4]
 
-    res = chain.mutate(test=5 - strlen("val")).order_by("num").collect("test")
-    assert list(res) == [4, 3, 2, 1, 0]
+    res = chain.mutate(test=5 - strlen("val")).order_by("num").to_list("test")
+    assert res == [4, 3, 2, 1, 0]
 
     res = (
-        chain.mutate(test=strlen("val") - strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") - strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 def test_mul():
@@ -152,16 +152,16 @@ def test_mul():
 
 
 def test_mul_mutate(chain):
-    res = chain.mutate(test=strlen("val") * 2).order_by("num").collect("test")
-    assert list(res) == [2, 4, 6, 8, 10]
+    res = chain.mutate(test=strlen("val") * 2).order_by("num").to_list("test")
+    assert res == [2, 4, 6, 8, 10]
 
-    res = chain.mutate(test=3 * strlen("val")).order_by("num").collect("test")
-    assert list(res) == [3, 6, 9, 12, 15]
+    res = chain.mutate(test=3 * strlen("val")).order_by("num").to_list("test")
+    assert res == [3, 6, 9, 12, 15]
 
     res = (
-        chain.mutate(test=strlen("val") * strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") * strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [1, 4, 9, 16, 25]
+    assert res == [1, 4, 9, 16, 25]
 
 
 def test_truediv():
@@ -184,16 +184,16 @@ def test_truediv():
 
 
 def test_truediv_mutate(chain):
-    res = chain.mutate(test=strlen("val") / 2).order_by("num").collect("test")
-    assert list(res) == [0.5, 1.0, 1.5, 2.0, 2.5]
+    res = chain.mutate(test=strlen("val") / 2).order_by("num").to_list("test")
+    assert res == [0.5, 1.0, 1.5, 2.0, 2.5]
 
-    res = chain.mutate(test=10 / strlen("val")).order_by("num").collect("test")
-    assert list(res) == [10.0, 5.0, 10 / 3, 2.5, 2.0]
+    res = chain.mutate(test=10 / strlen("val")).order_by("num").to_list("test")
+    assert res == [10.0, 5.0, 10 / 3, 2.5, 2.0]
 
     res = (
-        chain.mutate(test=strlen("val") / strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") / strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [1.0, 1.0, 1.0, 1.0, 1.0]
+    assert res == [1.0, 1.0, 1.0, 1.0, 1.0]
 
 
 def test_floordiv():
@@ -216,18 +216,18 @@ def test_floordiv():
 
 
 def test_floordiv_mutate(chain):
-    res = chain.mutate(test=strlen("val") // 2).order_by("num").collect("test")
-    assert list(res) == [0, 1, 1, 2, 2]
+    res = chain.mutate(test=strlen("val") // 2).order_by("num").to_list("test")
+    assert res == [0, 1, 1, 2, 2]
 
-    res = chain.mutate(test=10 // strlen("val")).order_by("num").collect("test")
-    assert list(res) == [10, 5, 3, 2, 2]
+    res = chain.mutate(test=10 // strlen("val")).order_by("num").to_list("test")
+    assert res == [10, 5, 3, 2, 2]
 
     res = (
         chain.mutate(test=strlen("val") // strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [1, 1, 1, 1, 1]
+    assert res == [1, 1, 1, 1, 1]
 
 
 def test_mod():
@@ -250,16 +250,16 @@ def test_mod():
 
 
 def test_mod_mutate(chain):
-    res = chain.mutate(test=strlen("val") % 2).order_by("num").collect("test")
-    assert list(res) == [1, 0, 1, 0, 1]
+    res = chain.mutate(test=strlen("val") % 2).order_by("num").to_list("test")
+    assert res == [1, 0, 1, 0, 1]
 
-    res = chain.mutate(test=10 % strlen("val")).order_by("num").collect("test")
-    assert list(res) == [0, 0, 1, 2, 0]
+    res = chain.mutate(test=10 % strlen("val")).order_by("num").to_list("test")
+    assert res == [0, 0, 1, 2, 0]
 
     res = (
-        chain.mutate(test=strlen("val") % strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") % strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 def test_and():
@@ -282,16 +282,16 @@ def test_and():
 
 
 def test_and_mutate(chain):
-    res = chain.mutate(test=strlen("val") & 2).order_by("num").collect("test")
-    assert list(res) == [0, 2, 2, 0, 0]
+    res = chain.mutate(test=strlen("val") & 2).order_by("num").to_list("test")
+    assert res == [0, 2, 2, 0, 0]
 
-    res = chain.mutate(test=2 & strlen("val")).order_by("num").collect("test")
-    assert list(res) == [0, 2, 2, 0, 0]
+    res = chain.mutate(test=2 & strlen("val")).order_by("num").to_list("test")
+    assert res == [0, 2, 2, 0, 0]
 
     res = (
-        chain.mutate(test=strlen("val") & strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") & strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [1, 2, 3, 4, 5]
+    assert res == [1, 2, 3, 4, 5]
 
 
 def test_or():
@@ -314,16 +314,16 @@ def test_or():
 
 
 def test_or_mutate(chain):
-    res = chain.mutate(test=strlen("val") | 2).order_by("num").collect("test")
-    assert list(res) == [3, 2, 3, 6, 7]
+    res = chain.mutate(test=strlen("val") | 2).order_by("num").to_list("test")
+    assert res == [3, 2, 3, 6, 7]
 
-    res = chain.mutate(test=2 | strlen("val")).order_by("num").collect("test")
-    assert list(res) == [3, 2, 3, 6, 7]
+    res = chain.mutate(test=2 | strlen("val")).order_by("num").to_list("test")
+    assert res == [3, 2, 3, 6, 7]
 
     res = (
-        chain.mutate(test=strlen("val") | strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") | strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [1, 2, 3, 4, 5]
+    assert res == [1, 2, 3, 4, 5]
 
 
 @skip_if_not_sqlite
@@ -331,7 +331,7 @@ def test_or_func_mutate(chain):
     res = chain.mutate(
         test=ifelse(or_(dc.C("num") < 3, dc.C("num") > 4), "Match", "Not Match")
     )
-    assert list(res.order_by("num").collect("test")) == [
+    assert list(res.order_by("num").to_list("test")) == [
         "Match",
         "Match",
         "Not Match",
@@ -345,7 +345,7 @@ def test_and_func_mutate(chain):
     res = chain.mutate(
         test=ifelse(and_(dc.C("num") > 1, dc.C("num") < 4), "Match", "Not Match")
     )
-    assert list(res.order_by("num").collect("test")) == [
+    assert list(res.order_by("num").to_list("test")) == [
         "Not Match",
         "Match",
         "Match",
@@ -374,16 +374,16 @@ def test_xor():
 
 
 def test_xor_mutate(chain):
-    res = chain.mutate(test=strlen("val") ^ 2).order_by("num").collect("test")
-    assert list(res) == [3, 0, 1, 6, 7]
+    res = chain.mutate(test=strlen("val") ^ 2).order_by("num").to_list("test")
+    assert res == [3, 0, 1, 6, 7]
 
-    res = chain.mutate(test=2 ^ strlen("val")).order_by("num").collect("test")
-    assert list(res) == [3, 0, 1, 6, 7]
+    res = chain.mutate(test=2 ^ strlen("val")).order_by("num").to_list("test")
+    assert res == [3, 0, 1, 6, 7]
 
     res = (
-        chain.mutate(test=strlen("val") ^ strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") ^ strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 def test_rshift():
@@ -406,18 +406,18 @@ def test_rshift():
 
 
 def test_rshift_mutate(chain):
-    res = chain.mutate(test=strlen("val") >> 2).order_by("num").collect("test")
-    assert list(res) == [0, 0, 0, 1, 1]
+    res = chain.mutate(test=strlen("val") >> 2).order_by("num").to_list("test")
+    assert res == [0, 0, 0, 1, 1]
 
-    res = chain.mutate(test=2 >> strlen("val")).order_by("num").collect("test")
-    assert list(res) == [1, 0, 0, 0, 0]
+    res = chain.mutate(test=2 >> strlen("val")).order_by("num").to_list("test")
+    assert res == [1, 0, 0, 0, 0]
 
     res = (
         chain.mutate(test=strlen("val") >> strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 def test_lshift():
@@ -440,18 +440,18 @@ def test_lshift():
 
 
 def test_lshift_mutate(chain):
-    res = chain.mutate(test=strlen("val") << 2).order_by("num").collect("test")
-    assert list(res) == [4, 8, 12, 16, 20]
+    res = chain.mutate(test=strlen("val") << 2).order_by("num").to_list("test")
+    assert res == [4, 8, 12, 16, 20]
 
-    res = chain.mutate(test=2 << strlen("val")).order_by("num").collect("test")
-    assert list(res) == [4, 8, 16, 32, 64]
+    res = chain.mutate(test=2 << strlen("val")).order_by("num").to_list("test")
+    assert res == [4, 8, 16, 32, 64]
 
     res = (
         chain.mutate(test=strlen("val") << strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [2, 8, 24, 64, 160]
+    assert res == [2, 8, 24, 64, 160]
 
 
 def test_lt():
@@ -474,22 +474,22 @@ def test_lt():
 
 
 def test_lt_mutate(chain):
-    res = chain.mutate(test=strlen("val") < 3).order_by("num").collect("test")
-    assert list(res) == [1, 1, 0, 0, 0]
+    res = chain.mutate(test=strlen("val") < 3).order_by("num").to_list("test")
+    assert res == [1, 1, 0, 0, 0]
 
-    res = chain.mutate(test=strlen("val") > 3).order_by("num").collect("test")
-    assert list(res) == [0, 0, 0, 1, 1]
+    res = chain.mutate(test=strlen("val") > 3).order_by("num").to_list("test")
+    assert res == [0, 0, 0, 1, 1]
 
     res = (
-        chain.mutate(test=strlen("val") < strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") < strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 @pytest.mark.parametrize("value", [1, 0.5, "a", True])
 def test_mutate_with_literal(chain, value):
-    res = chain.mutate(test=value).collect("test")
-    assert list(res) == [value] * 5
+    res = chain.mutate(test=value).to_list("test")
+    assert res == [value] * 5
 
 
 def test_le():
@@ -512,18 +512,18 @@ def test_le():
 
 
 def test_le_mutate(chain):
-    res = chain.mutate(test=strlen("val") <= 3).order_by("num").collect("test")
-    assert list(res) == [1, 1, 1, 0, 0]
+    res = chain.mutate(test=strlen("val") <= 3).order_by("num").to_list("test")
+    assert res == [1, 1, 1, 0, 0]
 
-    res = chain.mutate(test=strlen("val") >= 3).order_by("num").collect("test")
-    assert list(res) == [0, 0, 1, 1, 1]
+    res = chain.mutate(test=strlen("val") >= 3).order_by("num").to_list("test")
+    assert res == [0, 0, 1, 1, 1]
 
     res = (
         chain.mutate(test=strlen("val") <= strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [1, 1, 1, 1, 1]
+    assert res == [1, 1, 1, 1, 1]
 
 
 def test_eq():
@@ -546,18 +546,18 @@ def test_eq():
 
 
 def test_eq_mutate(chain):
-    res = chain.mutate(test=strlen("val") == 2).order_by("num").collect("test")
-    assert list(res) == [0, 1, 0, 0, 0]
+    res = chain.mutate(test=strlen("val") == 2).order_by("num").to_list("test")
+    assert res == [0, 1, 0, 0, 0]
 
-    res = chain.mutate(test=strlen("val") == 4).order_by("num").collect("test")
-    assert list(res) == [0, 0, 0, 1, 0]
+    res = chain.mutate(test=strlen("val") == 4).order_by("num").to_list("test")
+    assert res == [0, 0, 0, 1, 0]
 
     res = (
         chain.mutate(test=strlen("val") == strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [1, 1, 1, 1, 1]
+    assert res == [1, 1, 1, 1, 1]
 
 
 def test_ne():
@@ -580,18 +580,18 @@ def test_ne():
 
 
 def test_ne_mutate(chain):
-    res = chain.mutate(test=strlen("val") != 2).order_by("num").collect("test")
-    assert list(res) == [1, 0, 1, 1, 1]
+    res = chain.mutate(test=strlen("val") != 2).order_by("num").to_list("test")
+    assert res == [1, 0, 1, 1, 1]
 
-    res = chain.mutate(test=strlen("val") != 4).order_by("num").collect("test")
-    assert list(res) == [1, 1, 1, 0, 1]
+    res = chain.mutate(test=strlen("val") != 4).order_by("num").to_list("test")
+    assert res == [1, 1, 1, 0, 1]
 
     res = (
         chain.mutate(test=strlen("val") != strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 def test_gt():
@@ -614,16 +614,16 @@ def test_gt():
 
 
 def test_gt_mutate(chain):
-    res = chain.mutate(test=strlen("val") > 2).order_by("num").collect("test")
-    assert list(res) == [0, 0, 1, 1, 1]
+    res = chain.mutate(test=strlen("val") > 2).order_by("num").to_list("test")
+    assert res == [0, 0, 1, 1, 1]
 
-    res = chain.mutate(test=strlen("val") < 4).order_by("num").collect("test")
-    assert list(res) == [1, 1, 1, 0, 0]
+    res = chain.mutate(test=strlen("val") < 4).order_by("num").to_list("test")
+    assert res == [1, 1, 1, 0, 0]
 
     res = (
-        chain.mutate(test=strlen("val") > strlen("val")).order_by("num").collect("test")
+        chain.mutate(test=strlen("val") > strlen("val")).order_by("num").to_list("test")
     )
-    assert list(res) == [0, 0, 0, 0, 0]
+    assert res == [0, 0, 0, 0, 0]
 
 
 def test_ge():
@@ -646,18 +646,18 @@ def test_ge():
 
 
 def test_ge_mutate(chain):
-    res = chain.mutate(test=strlen("val") >= 2).order_by("num").collect("test")
-    assert list(res) == [0, 1, 1, 1, 1]
+    res = chain.mutate(test=strlen("val") >= 2).order_by("num").to_list("test")
+    assert res == [0, 1, 1, 1, 1]
 
-    res = chain.mutate(test=strlen("val") <= 4).order_by("num").collect("test")
-    assert list(res) == [1, 1, 1, 1, 0]
+    res = chain.mutate(test=strlen("val") <= 4).order_by("num").to_list("test")
+    assert res == [1, 1, 1, 1, 0]
 
     res = (
         chain.mutate(test=strlen("val") >= strlen("val"))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [1, 1, 1, 1, 1]
+    assert res == [1, 1, 1, 1, 1]
 
 
 @pytest.mark.parametrize(
@@ -674,7 +674,7 @@ def test_sqlite_int_hash_64(value, inthash):
 
 
 def test_int_hash_64_mutate(chain):
-    res = chain.mutate(test=int_hash_64(strlen("val"))).order_by("num").collect("test")
+    res = chain.mutate(test=int_hash_64(strlen("val"))).order_by("num").to_list("test")
     assert [x & (2**64 - 1) for x in res] == [
         10577349846663553072,
         18198135717204167749,
@@ -704,9 +704,9 @@ def test_bit_hamming_distance_mutate(chain):
     res = (
         chain.mutate(test=bit_hamming_distance(strlen("val"), 5))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [1, 3, 2, 1, 0]
+    assert res == [1, 3, 2, 1, 0]
 
 
 @pytest.mark.parametrize(
@@ -728,9 +728,9 @@ def test_byte_hamming_distance_mutate(chain):
     res = (
         chain.mutate(test=byte_hamming_distance("val", literal("xxx")))
         .order_by("num")
-        .collect("test")
+        .to_list("test")
     )
-    assert list(res) == [2, 1, 0, 1, 2]
+    assert res == [2, 1, 0, 1, 2]
 
 
 @pytest.mark.parametrize(
@@ -744,7 +744,7 @@ def test_byte_hamming_distance_mutate(chain):
 )
 def test_case_mutate(chain, val, else_, type_):
     res = chain.mutate(test=case((dc.C("num") < 2, val), else_=else_))
-    assert list(res.order_by("test").collect("test")) == sorted(
+    assert list(res.order_by("test").to_list("test")) == sorted(
         [val, else_, else_, else_, else_]
     )
     assert res.schema["test"] == type_
@@ -752,12 +752,12 @@ def test_case_mutate(chain, val, else_, type_):
 
 def test_case_mutate_column_as_value(chain):
     res = chain.mutate(test=case((dc.C("num") < 3, dc.C("val")), else_="cc"))
-    assert list(res.order_by("num").collect("test")) == ["x", "xx", "cc", "cc", "cc"]
+    assert list(res.order_by("num").to_list("test")) == ["x", "xx", "cc", "cc", "cc"]
 
 
 def test_case_mutate_column_as_value_in_else(chain):
     res = chain.mutate(test=case((dc.C("num") < 3, dc.C("val")), else_=dc.C("val")))
-    assert list(res.order_by("num").collect("test")) == [
+    assert list(res.order_by("num").to_list("test")) == [
         "x",
         "xx",
         "xxx",
@@ -780,7 +780,7 @@ def test_nested_case_on_condition_mutate(chain, val, else_, type_):
     res = chain.mutate(
         test=case((case((dc.C("num") < 2, True), else_=False), val), else_=else_)
     )
-    assert list(res.order_by("test").collect("test")) == sorted(
+    assert list(res.order_by("test").to_list("test")) == sorted(
         [val, else_, else_, else_, else_]
     )
     assert res.schema["test"] == type_
@@ -799,7 +799,7 @@ def test_nested_case_on_value_mutate(chain, v1, v2, v3, type_):
     res = chain.mutate(
         test=case((dc.C("num") < 4, case((dc.C("num") < 2, v1), else_=v2)), else_=v3)
     )
-    assert list(res.order_by("num").collect("test")) == sorted([v1, v2, v2, v3, v3])
+    assert list(res.order_by("num").to_list("test")) == sorted([v1, v2, v2, v3, v3])
     assert res.schema["test"] == type_
 
 
@@ -816,7 +816,7 @@ def test_nested_case_on_else_mutate(chain, v1, v2, v3, type_):
     res = chain.mutate(
         test=case((dc.C("num") < 3, v1), else_=case((dc.C("num") < 4, v2), else_=v3))
     )
-    assert list(res.order_by("num").collect("test")) == sorted([v1, v1, v2, v3, v3])
+    assert list(res.order_by("num").to_list("test")) == sorted([v1, v1, v2, v3, v3])
     assert res.schema["test"] == type_
 
 
@@ -831,7 +831,7 @@ def test_nested_case_on_else_mutate(chain, v1, v2, v3, type_):
 )
 def test_ifelse_mutate(chain, if_val, else_val, type_):
     res = chain.mutate(test=ifelse(dc.C("num") < 2, if_val, else_val))
-    assert list(res.order_by("test").collect("test")) == sorted(
+    assert list(res.order_by("test").to_list("test")) == sorted(
         [if_val, else_val, else_val, else_val, else_val]
     )
     assert res.schema["test"] == type_
@@ -846,7 +846,7 @@ def test_ifelse_mutate(chain, if_val, else_val, type_):
 )
 def test_ifelse_mutate_with_columns_as_values(chain, if_val, else_val, type_, result):
     res = chain.mutate(test=ifelse(dc.C("num") < 3, if_val, else_val))
-    assert list(res.order_by("test").collect("test")) == result
+    assert list(res.order_by("test").to_list("test")) == result
     assert res.schema["test"] == type_
 
 
@@ -859,7 +859,7 @@ def test_isnone_mutate(col):
     )
 
     res = chain.mutate(test=isnone(col))
-    assert list(res.order_by("test").collect("test")) == sorted(
+    assert list(res.order_by("test").to_list("test")) == sorted(
         [False, False, False, True, True]
     )
     assert res.schema["test"] is bool
@@ -874,7 +874,7 @@ def test_isnone_with_ifelse_mutate(col):
     )
 
     res = chain.mutate(test=ifelse(isnone(col), "NONE", "NOT_NONE"))
-    assert list(res.order_by("num").collect("test")) == ["NOT_NONE"] * 3 + ["NONE"] * 2
+    assert list(res.order_by("num").to_list("test")) == ["NOT_NONE"] * 3 + ["NONE"] * 2
     assert res.schema["test"] is str
 
 
@@ -885,7 +885,7 @@ def test_array_contains():
     )
 
     assert list(
-        chain.mutate(res=contains("arr", 3)).order_by("val").collect("res")
+        chain.mutate(res=contains("arr", 3)).order_by("val").to_list("res")
     ) == [
         0,
         0,
@@ -894,11 +894,11 @@ def test_array_contains():
         1,
     ]
     assert list(
-        chain.mutate(res=contains(dc.C("arr"), 3)).order_by("val").collect("res")
+        chain.mutate(res=contains(dc.C("arr"), 3)).order_by("val").to_list("res")
     ) == [0, 0, 1, 1, 1]
     assert list(
-        chain.mutate(res=contains(dc.C("arr"), 10)).order_by("val").collect("res")
+        chain.mutate(res=contains(dc.C("arr"), 10)).order_by("val").to_list("res")
     ) == [0, 0, 0, 0, 0]
     assert list(
-        chain.mutate(res=contains(dc.C("arr"), None)).order_by("val").collect("res")
+        chain.mutate(res=contains(dc.C("arr"), None)).order_by("val").to_list("res")
     ) == [0, 0, 0, 0, 0]


### PR DESCRIPTION
closes #1139

See for details https://github.com/iterative/datachain/issues/1139#issuecomment-2989273928

It also make DataChain iterable (__iter__). So, user can just run `for file, data in ds: ...` without `ds.to_iter()`

## Summary by Sourcery

Replace the legacy collect API with new iterator and list-based methods and deprecate collect to unify DataChain output flows

New Features:
- Introduce DataChain.to_iter to yield rows as an iterator
- Add DataChain.to_list to retrieve all rows as a list
- Add DataChain.to_values to extract a flat list from a single column
- Make DataChain iterable via __iter__ to use directly in for loops

Enhancements:
- Deprecate the collect() method with a warning and forward its behavior to to_iter
- Rename internal collect_flatten to _leaf_values and update downstream calls accordingly

Tests:
- Update test suite to use to_iter(), to_list(), and to_values() instead of collect() across unit and functional tests