### PR TITLE
fix(retry): use source original version for retry records

### DIFF
--- a/tests/func/test_retry.py
+++ b/tests/func/test_retry.py
@@ -37,6 +37,16 @@ def _create_sample_data(test_session, ids=None, contents=None):
     dc.read_values(id=ids, content=contents, session=test_session).save("sample_data")
 
 
+def _simple_process(id: int, content: str, attempt: int = 1) -> ProcessingResult:
+    """Helper function for simple processing in retry tests."""
+    return ProcessingResult(
+        processed_content=content.upper(),
+        processed_at=datetime.now(tz=timezone.utc).isoformat(),
+        error="",
+        attempt=attempt,
+    )
+
+
 def test_retry_with_error_records(test_session):
     """Test retry functionality with records that have errors."""
 
@@ -77,21 +87,13 @@ def test_retry_with_missing_records(test_session):
     """Test retry functionality with missing records."""
     _create_sample_data(test_session)
 
-    def simple_process(id: int, content: str, attempt: int) -> ProcessingResult:
-        return ProcessingResult(
-            processed_content=content.upper(),
-            processed_at=datetime.now(tz=timezone.utc).isoformat(),
-            error="",
-            attempt=attempt,
-        )
-
     # Process only first 2 records
     # Create partial result dataset (missing id=3)
     partial_result = (
         dc.read_dataset("sample_data", session=test_session)
         .setup(attempt=lambda: 1)
         .filter(C("id") < 3)
-        .map(result=simple_process)
+        .map(result=_simple_process)
         .save("partial_result")
     )
 
@@ -107,7 +109,7 @@ def test_retry_with_missing_records(test_session):
             delta_retry=True,
         )
         .setup(attempt=lambda: 2)
-        .map(result=simple_process)
+        .map(result=_simple_process)
         .save("partial_result")
     )
 
@@ -132,21 +134,13 @@ def test_retry_with_missing_and_new_records(test_session):
     to test that retry and delta don't pick records twice."""
     _create_sample_data(test_session)
 
-    def simple_process(id: int, content: str, attempt: int) -> ProcessingResult:
-        return ProcessingResult(
-            processed_content=content.upper(),
-            processed_at=datetime.now(tz=timezone.utc).isoformat(),
-            error="",
-            attempt=attempt,
-        )
-
     # Process only first 2 records
     # Create partial result dataset (missing id=3)
     partial_result = (
         dc.read_dataset("sample_data", session=test_session)
         .setup(attempt=lambda: 1)
         .filter(C("id") < 3)
-        .map(result=simple_process)
+        .map(result=_simple_process)
         .save("partial_result")
     )
 
@@ -166,7 +160,7 @@ def test_retry_with_missing_and_new_records(test_session):
             delta_retry=True,
         )
         .setup(attempt=lambda: 2)
-        .map(result=simple_process)
+        .map(result=_simple_process)
         .save("partial_result")
     )
 
@@ -229,14 +223,6 @@ def test_retry_first_dataset_creation(test_session):
     """Test retry when dataset doesn't exist yet (first creation)."""
     _create_sample_data(test_session, ids=[1, 2], contents=["first", "second"])
 
-    def simple_process(id: int, content: str) -> ProcessingResult:
-        return ProcessingResult(
-            processed_content=content.upper(),
-            processed_at=datetime.now(tz=timezone.utc).isoformat(),
-            error="",
-            attempt=1,
-        )
-
     # First run with retry enabled on non-existent dataset
     # Should process all records
     retry_chain = (
@@ -247,7 +233,8 @@ def test_retry_first_dataset_creation(test_session):
             delta_on="id",
             delta_retry="result.error",
         )
-        .map(result=simple_process)
+        .setup(attempt=lambda: 1)
+        .map(result=_simple_process)
         .save("new_dataset")
     )
 
@@ -354,3 +341,87 @@ def test_retry_with_delta_functionality(test_session):
         (2, "", 1),
         (3, "", 2),
     }
+
+
+def test_delta_and_delta_retry_no_duplicates(test_session):
+    """Test that delta and delta_retry work together without creating duplicates
+    when the same records are picked up for different reasons:
+    - delta_retry=True picks up unprocessed records missing from result dataset
+    - delta=True picks up modified records from source dataset
+    """
+    _create_sample_data(test_session)
+
+    # First pass - process only records 1 and 2
+    partial_result = (
+        dc.read_dataset("sample_data", session=test_session)
+        .setup(attempt=lambda: 1)
+        .filter(C("id") < 3)  # Only process id=1,2, leaving id=3,4 unprocessed
+        .map(result=_simple_process)
+        .save("delta_retry_combined_result")
+    )
+
+    assert partial_result.count() == 2
+    initial_results = set(partial_result.to_iter("id", "result.attempt"))
+    assert initial_results == {(1, 1), (2, 1)}
+
+    # Modify the source data - update content for records 3 and 4
+    # This will make delta=True pick them up as "changed"
+    # But delta_retry=True will also pick them up as "missing from result"
+    modified_ids = [1, 2, 3, 4]
+    modified_contents = [
+        "first item",  # unchanged
+        "second item",  # unchanged
+        "MODIFIED third item",  # modified - delta will pick this up
+        "MODIFIED fourth item",  # modified - delta will pick this up
+    ]
+    _create_sample_data(test_session, modified_ids, modified_contents)
+
+    # Second pass with both delta=True and delta_retry=True
+    # Records 3,4 should be picked up by BOTH:
+    # - delta_retry=True (because they're missing from result dataset)
+    # - delta=True (because their content was modified in source)
+    # But they should only be processed ONCE (no duplicates)
+    combined_result = (
+        dc.read_dataset(
+            "sample_data",
+            session=test_session,
+            delta=True,
+            delta_on="id",
+            delta_retry=True,
+        )
+        .setup(attempt=lambda: 2)
+        .map(result=_simple_process)
+        .save("delta_retry_combined_result")
+    )
+
+    # Should have 4 total records: 2 from first pass + 2 newly processed
+    assert combined_result.count() == 4
+
+    # Get all results and verify no duplicates
+    all_results = set(
+        combined_result.to_iter("id", "result.attempt", "result.processed_content")
+    )
+
+    # Records 1,2 should have attempt=1 (from first pass)
+    # Records 3,4 should have attempt=2 (from second pass) and MODIFIED content
+    expected_results = {
+        (1, 1, "FIRST ITEM"),
+        (2, 1, "SECOND ITEM"),
+        (3, 2, "MODIFIED THIRD ITEM"),
+        (4, 2, "MODIFIED FOURTH ITEM"),
+    }
+
+    assert all_results == expected_results
+
+    # Verify counts by attempt
+    first_attempt_count = combined_result.filter(C("result.attempt") == 1).count()
+    second_attempt_count = combined_result.filter(C("result.attempt") == 2).count()
+
+    assert first_attempt_count == 2  # Records 1,2 from first pass
+    assert second_attempt_count == 2  # Records 3,4 from second pass (no duplicates)
+
+    # Verify that each id appears exactly once
+    ids_in_result = list(combined_result.to_values("id"))
+    assert len(ids_in_result) == 4
+    assert len(set(ids_in_result)) == 4  # No duplicate IDs
+    assert set(ids_in_result) == {1, 2, 3, 4}


### PR DESCRIPTION
Closes https://github.com/iterative/datachain/issues/1162

## Summary by Sourcery

Fix delta retry logic to reference the original source dataset version, exclude diff-driven records from retry to prevent duplicate processing, and enhance the retry test suite with reusable helpers and new scenarios.

Bug Fixes:
- Use the correct source dataset version when building retry chains instead of the latest version.
- Subtract the diff chain from retry chains to avoid processing the same record twice.


Tests:
- Introduce `_create_sample_data` and `_simple_process` helpers to DRY up retry tests.
- Add tests covering missing-record retries with newly added source data.
- Add tests ensuring combined `delta=True` and `delta_retry=True` do not produce duplicate records.
- Refactor existing retry tests (`error_records`, `no_records_to_retry`, `first_dataset_creation`) to use helper functions and streamline setup.