### PR TITLE
Metastore function to calculate number of datasets for each project

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -861,7 +861,7 @@ class AbstractDBMetastore(AbstractMetastore):
             .group_by(d.c.project_id)
         )
 
-        return dict(self.db.execute(query, conn=conn))
+        return dict(list(self.db.execute(query, conn=conn)))
 
     #
     # Datasets

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -861,7 +861,7 @@ class AbstractDBMetastore(AbstractMetastore):
             .group_by(d.c.project_id)
         )
 
-        return dict(list(self.db.execute(query, conn=conn)))
+        return dict(self.db.execute(query, conn=conn))
 
     #
     # Datasets


### PR DESCRIPTION
Added new function to metastore with signature:
```python
def project_datasets_count(self, conn=None) -> dict[int, int]:
```
This simple function returns number of dataset versions crated for each distinct project (id). This is needed for Studio to filter out empty namespaces and projects in dataset sidebar, and we can also use it to show number of datasets in them in UI if we want.

## Summary by Sourcery

Implement project_datasets_count in the metastore to compute dataset version counts per project, adjust list_projects signature to accept an optional namespace_id, and add corresponding functional tests.

New Features:
- Add project_datasets_count abstract method to Metastore interface
- Implement project_datasets_count to return dataset version counts per project

Enhancements:
- Default namespace_id parameter to None in list_projects signature

Tests:
- Add helper to create multiple dataset versions and a functional test for project_datasets_count