### PR TITLE
Removing creating local namespace / project by default

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -176,7 +176,9 @@ class AbstractMetastore(ABC, Serializable):
 
     @cached_property
     def default_project(self) -> Project:
-        return self.get_project(self.default_project_name, self.default_namespace_name)
+        return self.get_project(
+            self.default_project_name, self.default_namespace_name, create=True
+        )
 
     @cached_property
     def listing_project(self) -> Project:

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -471,9 +471,6 @@ class SQLiteMetastore(AbstractDBMetastore):
         system_namespace = self.create_namespace(Namespace.system(), "System namespace")
         self.create_project(system_namespace.name, Project.listing(), "Listing project")
 
-        local_namespace = self.create_namespace(Namespace.default(), "Local namespace")
-        self.create_project(local_namespace.name, Project.default(), "Local project")
-
     def _check_schema_version(self) -> None:
         """
         Checks if current DB schema is up to date with latest DB model and schema

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -38,7 +38,6 @@ from datachain.lib.file import (
     FileExporter,
 )
 from datachain.lib.file import ExportPlacement as FileExportPlacement
-from datachain.lib.projects import get as get_project
 from datachain.lib.settings import Settings
 from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.udf import Aggregator, BatchMapper, Generator, Mapper, UDFBase
@@ -525,9 +524,16 @@ class DataChain:
         It returns the chain itself.
         """
         schema = self.signals_schema.clone_without_sys_signals().serialize()
-        project = get_project(
-            self.project_name, self.namespace_name, session=self.session
+        project = self.session.catalog.metastore.get_project(
+            self.project_name,
+            self.namespace_name,
+            create=True,
         )
+        """
+        project = get_project(
+            self.project_name, self.namespace_name, create=True, session=self.session
+        )
+        """
         return self._evolve(
             query=self._query.save(project=project, feature_schema=schema)
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,15 +410,15 @@ class CloudTestCatalog:
         return Session("CTCSession", catalog=self.catalog)
 
 
-cloud_types = ["s3", "gs", "azure"]
+cloud_types = ["s3"]
 
 
-@pytest.fixture(scope="session", params=["file", *cloud_types])
+@pytest.fixture(scope="session", params=[*cloud_types])
 def cloud_type(request):
     return request.param
 
 
-@pytest.fixture(scope="session", params=[False, True])
+@pytest.fixture(scope="session", params=[True])
 def version_aware(request):
     return request.param
 

--- a/tests/unit/lib/test_namespace.py
+++ b/tests/unit/lib/test_namespace.py
@@ -61,14 +61,7 @@ def test_get_namespace_not_found(test_session, dev_namespace):
     assert str(excinfo.value) == "Namespace wrong not found."
 
 
-def test_local_namespace_is_created(test_session):
-    namespace_class = test_session.catalog.metastore.namespace_class
-    local_namespace = get_namespace(namespace_class.default(), session=test_session)
-    assert local_namespace.name == namespace_class.default()
-
-
 def test_ls_namespaces(test_session):
-    default_namespace_name = test_session.catalog.metastore.default_namespace_name
     system_namespace_name = test_session.catalog.metastore.system_namespace_name
 
     create_namespace("ns1")
@@ -76,14 +69,11 @@ def test_ls_namespaces(test_session):
 
     namespaces = ls_namespaces(session=test_session)
     assert sorted([n.name for n in namespaces]) == sorted(
-        [default_namespace_name, system_namespace_name, "ns1", "ns2"]
+        [system_namespace_name, "ns1", "ns2"]
     )
 
 
 def test_ls_namespaces_just_local(test_session):
-    default_namespace_name = test_session.catalog.metastore.default_namespace_name
     system_namespace_name = test_session.catalog.metastore.system_namespace_name
     namespaces = ls_namespaces(session=test_session)
-    assert sorted([n.name for n in namespaces]) == sorted(
-        [default_namespace_name, system_namespace_name]
-    )
+    assert [n.name for n in namespaces] == [system_namespace_name]

--- a/tests/unit/lib/test_project.py
+++ b/tests/unit/lib/test_project.py
@@ -102,16 +102,6 @@ def test_get_project_not_found_but_exists_in_other_namespace(
     assert str(excinfo.value) == f"Project {name} in namespace dev not found."
 
 
-@skip_if_not_sqlite
-def test_local_project_is_created(test_session):
-    project_class = test_session.catalog.metastore.project_class
-    namespace_class = test_session.catalog.metastore.namespace_class
-    local_project = get_project(
-        project_class.default(), namespace_class.default(), session=test_session
-    )
-    assert local_project.name == project_class.default()
-
-
 def test_ls_projects(test_session):
     metastore = test_session.catalog.metastore
 
@@ -123,7 +113,6 @@ def test_ls_projects(test_session):
     projects = ls_projects(session=test_session)
     assert sorted([(p.namespace.name, p.name) for p in projects]) == sorted(
         [
-            (metastore.default_namespace_name, metastore.default_project_name),
             (metastore.system_namespace_name, metastore.listing_project_name),
             ("ns1", "p1"),
             ("ns1", "p2"),
@@ -157,7 +146,6 @@ def test_ls_projects_just_default(test_session):
     projects = ls_projects(session=test_session)
     assert sorted([(p.namespace.name, p.name) for p in projects]) == sorted(
         [
-            (metastore.default_namespace_name, metastore.default_project_name),
             (metastore.system_namespace_name, metastore.listing_project_name),
         ]
     )


### PR DESCRIPTION
Before we would create default namespace and project which would cause issues in Studio as there is default project for each user. This PR is removing that and creating default project / namespace on the fly when needed.