### PR TITLE
Include names in `datachain job clusters`

### DIFF
--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -430,6 +430,7 @@ def list_clusters(team_name: Optional[str]):
     rows = [
         {
             "ID": cluster.get("id"),
+            "Name": cluster.get("name"),
             "Status": cluster.get("status"),
             "Cloud Provider": cluster.get("cloud_provider"),
             "Cloud Credentials": cluster.get("cloud_credentials"),


### PR DESCRIPTION
Counterpart of https://github.com/iterative/studio/pull/11791

## Summary by Sourcery

New Features:
- Add a "Name" column to the output of the `datachain job clusters` command.