### PR TITLE
Do not prefetch empty files

### DIFF
--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -309,7 +309,7 @@ async def _prefetch_input(
     after_prefetch: "Callable[[], None]" = noop,
 ) -> T:
     for obj in row:
-        if isinstance(obj, File) and await obj._prefetch(download_cb):
+        if isinstance(obj, File) and obj.path and await obj._prefetch(download_cb):
             after_prefetch()
     return row
 


### PR DESCRIPTION
Tiny fix to do not prefetch empty files (files with empty `path`).

We still need to check download and caching to create a proper fix with proper tests, this is just a tiny fix for a specific case.

Fixes this error:
```
Traceback (most recent call last):
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dataset.py", line 341, in process_udf_outputs
    for udf_output in udf_results:
                      ^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/query/dispatch.py", line 422, in notify_and_process
    for row in udf_results:
               ^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 99, in run
    yield from self.inner.run(
    ...<6 lines>...
    )
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 398, in run
    for id_, *udf_args in prepared_inputs:
                          ^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 348, in _prefetch_inputs
    for row in row_iter:
               ^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/asyn.py", line 185, in iterate
    raise exc
  File "/Users/vlad/work/iterative/datachain/src/datachain/asyn.py", line 122, in run
    self.gather_exceptions(done)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/asyn.py", line 150, in gather_exceptions
    raise exc
  File "/Users/vlad/work/iterative/datachain/src/datachain/asyn.py", line 103, in worker
    result = await self.func(item)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/udf.py", line 312, in _prefetch_input
    if isinstance(obj, File) and await obj._prefetch(download_cb):
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/file.py", line 461, in _prefetch
    await client._download(file, callback=download_cb or self._download_cb)
  File "/Users/vlad/work/iterative/datachain/src/datachain/client/fsspec.py", line 411, in _download
    await self._put_in_cache(file, callback=callback)
  File "/Users/vlad/work/iterative/datachain/src/datachain/client/fsspec.py", line 425, in _put_in_cache
    await self.cache.download(file, self, callback=callback)
  File "/Users/vlad/work/iterative/datachain/src/datachain/cache.py", line 81, in download
    from_path = file.get_uri()
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/file.py", line 525, in get_uri
    return f"{self.source}/{self.get_path_normalized()}"
                            ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/vlad/work/iterative/datachain/src/datachain/lib/file.py", line 507, in get_path_normalized
    raise FileError("path must not be empty", self.source, self.path)
datachain.lib.file.FileError: Error in file '/': path must not be empty
```

## Summary by Sourcery

Bug Fixes:
- Prevent `_prefetch_input` from downloading File objects when their `path` is empty