### PR TITLE
Improving error logs when getting dataset fails

### DIFF
--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -144,7 +144,7 @@ def read_dataset(
                 ds_project = get_project(project_name, namespace_name, session=session)
             except ProjectNotFoundError:
                 raise DatasetNotFoundError(
-                    f"Dataset {name} not found in namespace {namespace_name} and",
+                    f"Dataset {name} not found in namespace {namespace_name} and"
                     f" project {project_name}",
                 ) from None
 


### PR DESCRIPTION
This avoids vague error messages like `datachain.error.DatasetNotFoundError: Dataset dogs-catss not found in project 1501`. Now full namespace name and project name is in the error message to help user debug.