### PR TITLE
Fix 'aggregate' function if limit or offset was used

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -11,6 +11,7 @@ from collections.abc import Generator, Iterable, Iterator, Sequence
 from copy import copy
 from functools import wraps
 from secrets import token_hex
+from types import GeneratorType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -557,8 +558,8 @@ class UDFStep(Step, ABC):
         """
         assert self.partition_by is not None
 
-        if isinstance(self.partition_by, Sequence):
-            list_partition_by = self.partition_by
+        if isinstance(self.partition_by, (list, tuple, GeneratorType)):
+            list_partition_by = list(self.partition_by)
         else:
             list_partition_by = [self.partition_by]
 
@@ -575,7 +576,10 @@ class UDFStep(Step, ABC):
             f.dense_rank().over(order_by=partition_by).label(PARTITION_COLUMN_ID),
         ]
         self.catalog.warehouse.db.execute(
-            tbl.insert().from_select(cols, query.with_only_columns(*cols))
+            tbl.insert().from_select(
+                cols,
+                query.offset(None).limit(None).with_only_columns(*cols),
+            )
         )
 
         return tbl
@@ -602,12 +606,20 @@ class UDFStep(Step, ABC):
             partition_tbl = self.create_partitions_table(query)
             temp_tables.append(partition_tbl.name)
 
-            subq = query.subquery()
+            # Limit and offset are not applied to the partition table,
+            # so we need to apply them to the main query later.
+            limit = query._limit
+            offset = query._offset
+
+            subq = query.limit(None).offset(None).subquery()
             query = (
                 sqlalchemy.select(*subq.c)
                 .outerjoin(partition_tbl, partition_tbl.c.sys__id == subq.c.sys__id)
                 .add_columns(*partition_columns())
             )
+
+            # Apply limit and offset to the main query.
+            query = query.offset(offset).limit(limit)
 
         query, tables = self.process_input_query(query)
         temp_tables.extend(t.name for t in tables)


### PR DESCRIPTION
Fix `aggregate` function (`.agg()`) if `limit` or `offset` was used.

Example of failed query:

```
from typing import Iterator

import datachain as dc
from datachain import func, File


def my_agg(p: list[str], s: list[int]) -> Iterator[tuple[str, int]]:
    yield str(p), sum(s)

chain = (
    dc.read_storage("s3://bucket/")
    .limit(20)
    .agg(
        my_agg,
        params={"file.path": str, "file.size": int,},
        output={"res": str, "total": int},
        partition_by=dc.C("file.path")
    )
    .save("tmp")
)
```