### PR TITLE
Fix table copy: do not use batching if no 'sys.id' field found

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -774,7 +774,15 @@ class SQLiteWarehouse(AbstractWarehouse):
         query: Select,
         progress_cb: Optional[Callable[[int], None]] = None,
     ) -> None:
-        if len(query._group_by_clause) > 0:
+        col_id = (
+            query.selected_columns.sys__id
+            if "sys__id" in query.selected_columns
+            else None
+        )
+
+        # If there is no sys__id column, we cannot copy the table in batches,
+        # and we need to copy all rows at once. Same if there is a group by clause.
+        if col_id is None or len(query._group_by_clause) > 0:
             select_q = query.with_only_columns(
                 *[c for c in query.selected_columns if c.name != "sys__id"]
             )
@@ -782,12 +790,7 @@ class SQLiteWarehouse(AbstractWarehouse):
             self.db.execute(q)
             return
 
-        if "sys__id" in query.selected_columns:
-            col_id = query.selected_columns.sys__id
-        else:
-            col_id = sqlalchemy.column("sys__id")
         select_ids = query.with_only_columns(col_id)
-
         ids = self.db.execute(select_ids).fetchall()
 
         select_q = (


### PR DESCRIPTION
Fix for the https://github.com/iterative/datachain/issues/1198

When we do table copy where is an optimization to copy rows in batches. If no `sys__id` field found in table, this optimization does not works.

In this PR I am fixing this issue: copy whole table at once if no `sys__id` field found in table.