### PR TITLE
feat(audio): audio file and fragment with streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ cython_debug/
 
 # pt files produced by ultralytics examples
 *.pt
+
+.DS_Store/

--- a/examples/multimodal/audio-to-text.py
+++ b/examples/multimodal/audio-to-text.py
@@ -1,0 +1,62 @@
+"""
+To run this example, install:
+
+`datachain[examples]`
+
+It demonstrates how to use DataChain models like Audio, AudioFile,
+and AudioFragment to efficiently access audio files, chunk them into
+fragments, pass them to a model to get text.
+"""
+
+from collections.abc import Iterator
+
+import torch
+from transformers import Pipeline, pipeline
+
+import datachain as dc
+from datachain import Audio, AudioFile, AudioFragment, C
+
+
+def info(file: AudioFile) -> Audio:
+    return file.get_info()
+
+
+def fragments(file: AudioFile, meta: Audio) -> Iterator[AudioFragment]:
+    start = meta.duration / 3
+    fragment = file.get_fragment(start, start + 10)
+    yield fragment
+
+
+def process(fragment: AudioFragment, pipeline: Pipeline) -> str:
+    audio_array, sample_rate = fragment.get_np()
+
+    # Convert to mono if stereo (average the channels)
+    if len(audio_array.shape) > 1 and audio_array.shape[1] > 1:
+        audio_array = audio_array.mean(axis=1)
+
+    # Pass the numpy array with exact sampling rate from fragment
+    result = pipeline({"raw": audio_array, "sampling_rate": sample_rate})
+    return str(result["text"])
+
+
+# We disable caching and prefetching to ensure that we read only bytes
+# that we need for processing. Methods like `get_info` and `get_fragment`
+# don't require reading the entire file.
+(
+    dc.read_storage("gs://datachain-demo/musdb18", type="audio", anon=True)
+    .filter(C("file.path").glob("*.wav"))
+    .limit(3)
+    .settings(cache=False, prefetch=False, parallel=True)
+    .map(meta=info)
+    .gen(fragment=fragments)
+    .setup(
+        pipeline=lambda: pipeline(
+            "automatic-speech-recognition",
+            "openai/whisper-small",
+            torch_dtype=torch.float32,
+            device="cpu",
+        )
+    )
+    .map(text=process)
+    .show()
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ torch = [
   "torchvision",
   "transformers>=4.36.0"
 ]
+audio = [
+  "torchaudio"
+]
 remote = [
   "lz4",
   "requests>=2.22.0"
@@ -92,7 +95,7 @@ video = [
   "opencv-python"
 ]
 tests = [
-  "datachain[torch,remote,vector,hf,video]",
+  "datachain[torch,audio,remote,vector,hf,video]",
   "pytest>=8,<9",
   "pytest-sugar>=0.9.6",
   "pytest-cov>=4.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ torch = [
   "transformers>=4.36.0"
 ]
 audio = [
-  "torchaudio"
+  "torchaudio",
+  "soundfile"
 ]
 remote = [
   "lz4",

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -21,6 +21,9 @@ from datachain.lib.dc import (
 )
 from datachain.lib.file import (
     ArrowRow,
+    Audio,
+    AudioFile,
+    AudioFragment,
     File,
     FileError,
     Image,
@@ -43,6 +46,9 @@ __all__ = [
     "AbstractUDF",
     "Aggregator",
     "ArrowRow",
+    "Audio",
+    "AudioFile",
+    "AudioFragment",
     "C",
     "Column",
     "DataChain",

--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -54,10 +54,10 @@ def audio_info(file: "Union[File, AudioFile]") -> "Audio":
     )
 
 
-def audio_segment_np(
+def audio_fragment_np(
     audio: "AudioFile", start: float = 0, duration: Optional[float] = None
 ) -> "tuple[ndarray, int]":
-    """Load audio segment as numpy array.
+    """Load audio fragment as numpy array.
     Multi-channel audio is transposed to (samples, channels)."""
     if start < 0:
         raise ValueError("start must be a non-negative float")
@@ -94,18 +94,18 @@ def audio_segment_np(
             return audio_np, int(sr)
     except Exception as exc:
         raise FileError(
-            "unable to read audio segment", audio.source, audio.path
+            "unable to read audio fragment", audio.source, audio.path
         ) from exc
 
 
-def audio_segment_bytes(
+def audio_fragment_bytes(
     audio: "AudioFile",
     start: float = 0,
     duration: Optional[float] = None,
     format: str = "wav",
 ) -> bytes:
-    """Convert audio segment to bytes using soundfile."""
-    y, sr = audio_segment_np(audio, start, duration)
+    """Convert audio fragment to bytes using soundfile."""
+    y, sr = audio_fragment_np(audio, start, duration)
 
     import io
 
@@ -139,7 +139,7 @@ def save_audio_fragment(
     )
 
     try:
-        audio_bytes = audio_segment_bytes(audio, start, duration, format)
+        audio_bytes = audio_fragment_bytes(audio, start, duration, format)
 
         from datachain.lib.file import AudioFile
 

--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import posixpath
+from typing import TYPE_CHECKING
+
+from datachain.lib.file import FileError
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+
+    from datachain.lib.file import Audio, AudioFile, File
+
+try:
+    import torchaudio
+except ImportError as exc:
+    raise ImportError(
+        "Missing dependencies for processing audio.\n"
+        "To install run:\n\n"
+        "  pip install 'datachain[audio]'\n"
+    ) from exc
+
+
+def audio_info(file: File | AudioFile) -> Audio:
+    """
+    Returns audio file information.
+
+    Args:
+        file (AudioFile): Audio file object.
+
+    Returns:
+        Audio: Audio file information.
+    """
+    # Import here to avoid circular imports
+    from datachain.lib.file import Audio
+
+    file = file.as_audio_file()
+
+    try:
+        with file.open() as f:
+            info = torchaudio.info(f)
+
+            sample_rate = int(info.sample_rate)
+            channels = int(info.num_channels)
+            frames = int(info.num_frames)
+            duration = float(frames / sample_rate) if sample_rate > 0 else 0.0
+
+            # Get format information
+            format_name = getattr(info, "format", "")
+            codec_name = getattr(info, "encoding", "")
+            bit_rate = getattr(info, "bits_per_sample", 0) * sample_rate * channels
+
+    except Exception as exc:
+        raise FileError(
+            "unable to extract metadata from audio file", file.source, file.path
+        ) from exc
+
+    return Audio(
+        sample_rate=sample_rate,
+        channels=channels,
+        duration=duration,
+        samples=frames,
+        format=format_name,
+        codec=codec_name,
+        bit_rate=bit_rate,
+    )
+
+
+def audio_segment_np(
+    audio: AudioFile, start: float = 0, duration: float | None = None
+) -> tuple[ndarray, int]:
+    """
+    Reads audio segment from a file and returns as numpy array.
+
+    Args:
+        audio (AudioFile): Audio file object.
+        start (float): Start time in seconds (default: 0).
+        duration (float, optional): Duration in seconds. If None, reads to end.
+
+    Returns:
+        tuple[ndarray, int]: Audio data and sample rate.
+    """
+    if start < 0:
+        raise ValueError("start must be a non-negative float")
+
+    if duration is not None and duration <= 0:
+        raise ValueError("duration must be a positive float")
+
+    # Ensure we have an AudioFile instance
+    if hasattr(audio, "as_audio_file"):
+        audio = audio.as_audio_file()
+
+    try:
+        with audio.open() as f:
+            info = torchaudio.info(f)
+            sample_rate = info.sample_rate
+
+            # Calculate frame offset and number of frames
+            frame_offset = int(start * sample_rate)
+            num_frames = int(duration * sample_rate) if duration is not None else -1
+
+            # Reset position before loading (critical for FileWrapper)
+            f.seek(0)
+
+            # Load the audio segment
+            waveform, sr = torchaudio.load(
+                f, frame_offset=frame_offset, num_frames=num_frames
+            )
+
+            audio_np = waveform.numpy()
+
+            # If stereo, take the mean across channels or return multi-channel
+            if audio_np.shape[0] > 1:
+                # For compatibility, we can either return multi-channel or mono
+                # Here returning multi-channel as (samples, channels)
+                audio_np = audio_np.T
+            else:
+                # Mono: shape (samples,)
+                audio_np = audio_np.squeeze()
+
+            return audio_np, int(sr)
+    except Exception as exc:
+        raise FileError(
+            "unable to read audio segment", audio.source, audio.path
+        ) from exc
+
+
+def audio_segment_bytes(
+    audio: AudioFile,
+    start: float = 0,
+    duration: float | None = None,
+    format: str = "wav",
+) -> bytes:
+    """
+    Reads audio segment from a file and returns as audio bytes.
+
+    Args:
+        audio (AudioFile): Audio file object.
+        start (float): Start time in seconds (default: 0).
+        duration (float, optional): Duration in seconds. If None, reads to end.
+        format (str): Audio format (default: 'wav').
+
+    Returns:
+        bytes: Audio segment as bytes.
+    """
+    y, sr = audio_segment_np(audio, start, duration)
+
+    import io
+
+    import soundfile as sf
+
+    buffer = io.BytesIO()
+    sf.write(buffer, y, sr, format=format)
+    return buffer.getvalue()
+
+
+def save_audio_fragment(
+    audio: AudioFile,
+    start: float,
+    end: float,
+    output: str,
+    format: str | None = None,
+) -> AudioFile:
+    """
+    Saves audio interval as a new audio file. If output is a remote path,
+    the audio file will be uploaded to the remote storage.
+
+    Args:
+        audio (AudioFile): Audio file object.
+        start (float): Start time in seconds.
+        end (float): End time in seconds.
+        output (str): Output path, can be a local path or a remote path.
+        format (str, optional): Output format (default: None). If not provided,
+                                the format will be inferred from the audio fragment
+                                file extension.
+
+    Returns:
+        AudioFile: Audio fragment model.
+    """
+    if start < 0 or end < 0 or start >= end:
+        raise ValueError(f"Invalid time range: ({start:.3f}, {end:.3f})")
+
+    if format is None:
+        format = audio.get_file_ext()
+
+    duration = end - start
+    start_ms = int(start * 1000)
+    end_ms = int(end * 1000)
+    output_file = posixpath.join(
+        output, f"{audio.get_file_stem()}_{start_ms:06d}_{end_ms:06d}.{format}"
+    )
+
+    try:
+        audio_bytes = audio_segment_bytes(audio, start, duration, format)
+
+        from datachain.lib.file import AudioFile
+
+        return AudioFile.upload(audio_bytes, output_file, catalog=audio._catalog)
+
+    except Exception as exc:
+        raise FileError(
+            "unable to save audio fragment", audio.source, audio.path
+        ) from exc

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -880,29 +880,6 @@ class AudioFile(File):
 
         return audio_info(self)
 
-    def get_segment(
-        self, start: float = 0, duration: Optional[float] = None
-    ) -> "AudioSegment":
-        """
-        Returns an audio segment from the specified time range.
-
-        Args:
-            start (float): The start time in seconds (default: 0).
-            duration (float, optional): The duration in seconds. If None,
-                                       reads to the end of the audio.
-
-        Returns:
-            AudioSegment: A Model representing the audio segment.
-        """
-        if start < 0:
-            raise ValueError("start must be a non-negative float")
-
-        if duration is not None and duration <= 0:
-            raise ValueError("duration must be a positive float")
-
-        end = start + duration if duration is not None else None
-        return AudioSegment(audio=self, start=start, end=end)
-
     def get_fragment(self, start: float, end: float) -> "AudioFragment":
         """
         Returns an audio fragment from the specified time range.
@@ -957,55 +934,6 @@ class AudioFile(File):
         while start < end:
             yield self.get_fragment(start, min(start + duration, end))
             start += duration
-
-
-class AudioSegment(DataModel):
-    """
-    A data model for representing an audio segment.
-
-    This model represents a segment of audio with a start time and optional duration.
-    It allows access to audio segments and provides functionality for reading
-    audio data as numpy arrays or bytes.
-
-    Attributes:
-        audio (AudioFile): The audio file containing the audio segment.
-        start (float): The starting time of the audio segment in seconds.
-        end (float, optional): The ending time of the audio segment in seconds.
-                              If None, reads to the end of the audio.
-    """
-
-    audio: AudioFile
-    start: float
-    end: Optional[float]
-
-    def get_np(self) -> tuple["ndarray", int]:
-        """
-        Returns the audio segment as a NumPy array with sample rate.
-
-        Returns:
-            tuple[ndarray, int]: A tuple containing the audio data as a NumPy array
-                               and the sample rate.
-        """
-        from .audio import audio_segment_np
-
-        duration = None if self.end is None else self.end - self.start
-        return audio_segment_np(self.audio, self.start, duration)
-
-    def read_bytes(self, format: str = "wav") -> bytes:
-        """
-        Returns the audio segment as audio bytes.
-
-        Args:
-            format (str): The desired audio format (e.g., 'wav', 'mp3').
-                         Defaults to 'wav'.
-
-        Returns:
-            bytes: The encoded audio segment as bytes.
-        """
-        from .audio import audio_segment_bytes
-
-        duration = None if self.end is None else self.end - self.start
-        return audio_segment_bytes(self.audio, self.start, duration, format)
 
 
 class AudioFragment(DataModel):

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -864,13 +864,16 @@ class AudioFile(File):
     A data model for handling audio files.
 
     This model inherits from the `File` model and provides additional functionality
-    for reading audio files, extracting audio segments, and splitting audio into
+    for reading audio files, extracting audio fragments, and splitting audio into
     fragments.
     """
 
     def get_info(self) -> "Audio":
         """
-        Retrieves metadata and information about the audio file.
+        Retrieves metadata and information about the audio file. It does not
+        download the file if possible, only reads its header. It is thus might be
+        a good idea to disable caching and prefetching for UDF if you only need
+        audio metadata.
 
         Returns:
             Audio: A Model containing audio metadata such as duration,
@@ -882,7 +885,10 @@ class AudioFile(File):
 
     def get_fragment(self, start: float, end: float) -> "AudioFragment":
         """
-        Returns an audio fragment from the specified time range.
+        Returns an audio fragment from the specified time range. It does not
+        download the file, neither it actually extracts the fragment. It returns
+        a Model representing the audio fragment, which can be used to read or save
+        it later.
 
         Args:
             start (float): The start time of the fragment in seconds.
@@ -962,10 +968,10 @@ class AudioFragment(DataModel):
             tuple[ndarray, int]: A tuple containing the audio data as a NumPy array
                                and the sample rate.
         """
-        from .audio import audio_segment_np
+        from .audio import audio_fragment_np
 
         duration = self.end - self.start
-        return audio_segment_np(self.audio, self.start, duration)
+        return audio_fragment_np(self.audio, self.start, duration)
 
     def read_bytes(self, format: str = "wav") -> bytes:
         """
@@ -978,10 +984,10 @@ class AudioFragment(DataModel):
         Returns:
             bytes: The encoded audio fragment as bytes.
         """
-        from .audio import audio_segment_bytes
+        from .audio import audio_fragment_bytes
 
         duration = self.end - self.start
-        return audio_segment_bytes(self.audio, self.start, duration, format)
+        return audio_fragment_bytes(self.audio, self.start, duration, format)
 
     def save(self, output: str, format: Optional[str] = None) -> "AudioFile":
         """

--- a/tests/func/test_audio.py
+++ b/tests/func/test_audio.py
@@ -1,0 +1,115 @@
+import io
+from collections.abc import Iterator
+
+import numpy as np
+import soundfile as sf
+
+import datachain as dc
+from datachain.lib.audio import audio_segment_np
+from datachain.lib.file import Audio, AudioFile, AudioFragment
+
+
+def generate_test_wav(
+    duration: float = 1.0, sample_rate: int = 16000, frequency: float = 440.0
+) -> bytes:
+    samples = int(duration * sample_rate)
+    t = np.linspace(0, duration, samples, False)
+    audio_data = np.sin(2 * np.pi * frequency * t).astype(np.float32)
+
+    buffer = io.BytesIO()
+    sf.write(buffer, audio_data, sample_rate, format="wav")
+    return buffer.getvalue()
+
+
+def extract_audio_info(file: AudioFile) -> Audio:
+    return file.get_info()
+
+
+def generate_fragments(file: AudioFile) -> Iterator[AudioFragment]:
+    fragment_duration = 0.5
+    yield from file.get_fragments(duration=fragment_duration)
+
+
+def test_audio_datachain_workflow(test_session, tmp_path):
+    audio_files = []
+    for i, (duration, freq) in enumerate([(2.0, 440.0), (3.0, 880.0)]):
+        audio_data = generate_test_wav(
+            duration=duration, sample_rate=16000, frequency=freq
+        )
+        audio_path = tmp_path / f"test_audio_{i}.wav"
+        audio_path.write_bytes(audio_data)
+        audio_files.append(str(audio_path))
+
+    # Use DataChain to read the audio files from filesystem
+    chain = dc.read_storage(tmp_path.as_uri(), session=test_session, type="audio")
+
+    # Extract Audio metadata
+    chain_with_info = chain.map(
+        info=extract_audio_info,
+        params=["file"],
+        output={"info": Audio},
+    )
+
+    # Verify we have the expected files and metadata
+    results = list(chain_with_info.to_iter("file", "info"))
+    assert len(results) == 2
+
+    # Check that all files have expected audio metadata
+    for file, info in results:
+        assert isinstance(file, AudioFile)
+        assert isinstance(info, Audio)
+        assert info.sample_rate == 16000
+        assert info.channels == 1
+        assert info.duration > 0
+        assert info.samples > 0
+
+    # Generate audio fragments
+    fragments_chain = chain.gen(
+        fragment=generate_fragments,
+        params=["file"],
+        output={"fragment": AudioFragment},
+    )
+
+    # Get all fragments and verify their properties
+    fragments = list(fragments_chain.to_values("fragment"))
+
+    # We should have multiple fragments (2s file creates 4, 3s file creates 6)
+    expected_total_fragments = 4 + 6  # 10 total fragments
+    assert len(fragments) == expected_total_fragments
+
+    # Verify each fragment has correct properties
+    for fragment in fragments:
+        assert isinstance(fragment, AudioFragment)
+        assert isinstance(fragment.audio, AudioFile)
+        assert fragment.start >= 0
+        assert fragment.end > fragment.start
+        assert fragment.end - fragment.start <= 0.5  # fragment duration
+
+    # Test saving fragments
+    temp_output_dir = tmp_path / "fragments"
+    temp_output_dir.mkdir()
+
+    # Save first fragment as a test
+    first_fragment = fragments[0]
+    saved_file = first_fragment.save(str(temp_output_dir))
+
+    assert isinstance(saved_file, AudioFile)
+    assert saved_file.path.startswith("test_audio_")
+    assert saved_file.path.endswith(".wav")
+
+    # Verify the saved fragment has expected content
+    saved_info = saved_file.get_info()
+    expected_duration = first_fragment.end - first_fragment.start
+    # Allow small tolerance
+    assert abs(saved_info.duration - expected_duration) < 0.1
+    assert saved_info.sample_rate == 16000
+    assert saved_info.channels == 1
+
+    # Verify the audio content matches by comparing numpy arrays
+    original_np, original_sr = first_fragment.get_np()
+    saved_np, saved_sr = audio_segment_np(saved_file)
+
+    assert original_sr == saved_sr == 16000
+    assert len(original_np) == len(saved_np)
+    # Allow some tolerance for audio processing differences
+    assert np.allclose(original_np, saved_np, atol=1e-3)

--- a/tests/func/test_audio.py
+++ b/tests/func/test_audio.py
@@ -5,7 +5,7 @@ import numpy as np
 import soundfile as sf
 
 import datachain as dc
-from datachain.lib.audio import audio_segment_np
+from datachain.lib.audio import audio_fragment_np
 from datachain.lib.file import Audio, AudioFile, AudioFragment
 
 
@@ -107,7 +107,7 @@ def test_audio_datachain_workflow(test_session, tmp_path):
 
     # Verify the audio content matches by comparing numpy arrays
     original_np, original_sr = first_fragment.get_np()
-    saved_np, saved_sr = audio_segment_np(saved_file)
+    saved_np, saved_sr = audio_fragment_np(saved_file)
 
     assert original_sr == saved_sr == 16000
     assert len(original_np) == len(saved_np)

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -1,0 +1,269 @@
+import io
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from datachain.lib.audio import (
+    audio_info,
+    audio_segment_bytes,
+    audio_segment_np,
+    save_audio_fragment,
+)
+from datachain.lib.file import Audio, AudioFile, FileError
+
+
+def generate_test_wav(
+    duration: float = 1.0, sample_rate: int = 16000, frequency: float = 440.0
+) -> bytes:
+    """Generate a simple sine wave WAV file as bytes."""
+    samples = int(duration * sample_rate)
+    t = np.linspace(0, duration, samples, False)
+    audio_data = np.sin(2 * np.pi * frequency * t).astype(np.float32)
+
+    buffer = io.BytesIO()
+    sf.write(buffer, audio_data, sample_rate, format="wav")
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def audio_file(tmp_path, catalog):
+    """Create a temporary audio file for testing."""
+    audio_data = generate_test_wav(duration=2.0, sample_rate=16000)
+    audio_path = tmp_path / "test_audio.wav"
+    audio_path.write_bytes(audio_data)
+
+    file = AudioFile(path=str(audio_path), source="file://")
+    # _set_stream is required to enable file.open() operations
+    file._set_stream(catalog, caching_enabled=False)
+    return file
+
+
+@pytest.fixture
+def stereo_audio_file(tmp_path, catalog):
+    """Create a temporary stereo audio file for testing."""
+    duration = 1.0
+    sample_rate = 16000
+    samples = int(duration * sample_rate)
+    t = np.linspace(0, duration, samples, False)
+
+    # Create stereo signal (left and right channels)
+    left_channel = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    right_channel = np.sin(2 * np.pi * 880 * t).astype(np.float32)
+    stereo_data = np.column_stack([left_channel, right_channel])
+
+    audio_path = tmp_path / "stereo_test.wav"
+    sf.write(audio_path, stereo_data, sample_rate, format="wav")
+
+    # Create a real AudioFile object
+    file = AudioFile(path=str(audio_path), source="file://")
+    # _set_stream is required to enable file.open() operations
+    file._set_stream(catalog, caching_enabled=False)
+    return file
+
+
+def test_audio_info(audio_file):
+    """Test audio metadata extraction."""
+    result = audio_info(audio_file)
+
+    # Verify the returned Audio object has expected metadata
+    assert isinstance(result, Audio)
+    assert result.sample_rate == 16000
+    assert result.channels == 1
+    assert abs(result.duration - 2.0) < 0.1  # Allow small tolerance
+    assert result.samples == 32000
+
+
+def test_audio_segment_np_full(audio_file):
+    """Test loading full audio segment as numpy array."""
+    audio_np, sr = audio_segment_np(audio_file)
+
+    assert isinstance(audio_np, np.ndarray)
+    assert sr == 16000
+    assert len(audio_np.shape) == 1  # Mono audio should be 1D
+    assert len(audio_np) == 32000  # 2 seconds at 16kHz
+
+
+def test_audio_segment_np_partial(audio_file):
+    """Test loading partial audio segment."""
+    # Load 0.5 seconds starting from 0.5 seconds
+    audio_np, sr = audio_segment_np(audio_file, start=0.5, duration=0.5)
+
+    assert isinstance(audio_np, np.ndarray)
+    assert sr == 16000
+    assert len(audio_np) == 8000  # 0.5 seconds at 16kHz
+
+
+def test_audio_segment_np_validation(audio_file):
+    """Test input validation for audio_segment_np."""
+    with pytest.raises(ValueError, match="start must be a non-negative float"):
+        audio_segment_np(audio_file, start=-1.0)
+
+    with pytest.raises(ValueError, match="duration must be a positive float"):
+        audio_segment_np(audio_file, duration=0.0)
+
+
+def test_audio_segment_np_with_file_interface(audio_file):
+    """Test audio_segment_np with File interface."""
+    # Test that the audio_file fixture (which is already an AudioFile) works
+    audio_np, sr = audio_segment_np(audio_file)
+
+    assert isinstance(audio_np, np.ndarray)
+    assert sr == 16000
+
+
+def test_audio_segment_np_multichannel(stereo_audio_file):
+    """Test multichannel audio handling."""
+    audio_np, sr = audio_segment_np(stereo_audio_file)
+
+    # Should be transposed to (samples, channels)
+    assert audio_np.shape == (16000, 2)  # 1 second at 16kHz, 2 channels
+    assert sr == 16000
+
+
+def test_audio_segment_bytes(audio_file):
+    """Test converting audio segment to bytes."""
+    audio_bytes = audio_segment_bytes(audio_file, start=0.0, duration=1.0)
+
+    assert isinstance(audio_bytes, bytes)
+    assert len(audio_bytes) > 0
+
+    # Verify it's a valid WAV file by loading it back
+    buffer = io.BytesIO(audio_bytes)
+    data, sr = sf.read(buffer)
+    assert sr == 16000
+    assert len(data) == 16000  # 1 second at 16kHz
+
+
+def test_audio_segment_bytes_custom_format(audio_file):
+    """Test converting audio segment to different format."""
+    audio_bytes = audio_segment_bytes(audio_file, format="flac")
+
+    assert isinstance(audio_bytes, bytes)
+    assert len(audio_bytes) > 0
+
+
+def test_save_audio_fragment(audio_file, tmp_path):
+    """Test saving audio fragment."""
+    with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
+        # Mock the upload to return a new AudioFile
+        mock_uploaded_file = AudioFile(
+            path="test_audio_000500_001500.wav", source="file://"
+        )
+        mock_upload.return_value = mock_uploaded_file
+
+        result = save_audio_fragment(
+            audio_file, start=0.5, end=1.5, output=str(tmp_path), format="wav"
+        )
+
+        # Verify AudioFile.upload was called
+        mock_upload.assert_called_once()
+        call_args = mock_upload.call_args
+
+        # Check the uploaded data is bytes
+        assert isinstance(call_args[0][0], bytes)
+
+        # Check the filename pattern
+        filename = call_args[0][1]
+        assert "test_audio_000500_001500.wav" in filename
+
+        # Check catalog is passed
+        assert call_args[1]["catalog"] == audio_file._catalog
+
+        assert result == mock_uploaded_file
+
+
+def test_save_audio_fragment_validation(audio_file, tmp_path):
+    """Test input validation for save_audio_fragment."""
+    with pytest.raises(ValueError, match="Invalid time range"):
+        save_audio_fragment(audio_file, start=-1.0, end=1.0, output=str(tmp_path))
+
+    with pytest.raises(ValueError, match="Invalid time range"):
+        save_audio_fragment(audio_file, start=2.0, end=1.0, output=str(tmp_path))
+
+
+def test_save_audio_fragment_auto_format(tmp_path, catalog):
+    """Test saving audio fragment with auto-detected format."""
+    # Create a FLAC audio file for this test
+    audio_data = generate_test_wav(duration=1.0, sample_rate=16000)
+    audio_path = tmp_path / "test_audio.flac"
+    # Convert to FLAC format
+    buffer = io.BytesIO(audio_data)
+    temp_data, sr = sf.read(buffer)
+    sf.write(audio_path, temp_data, sr, format="flac")
+
+    audio_file = AudioFile(path=str(audio_path), source="file://")
+    # _set_stream is required to enable file.open() operations
+    audio_file._set_stream(catalog, caching_enabled=False)
+
+    with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
+        mock_upload.return_value = AudioFile(path="test_output.flac", source="file://")
+
+        save_audio_fragment(audio_file, start=0.0, end=1.0, output=str(tmp_path))
+
+        # Should use format from file extension
+        call_args = mock_upload.call_args
+        filename = call_args[0][1]
+        assert filename.endswith(".flac")
+
+
+def test_audio_info_file_error(audio_file):
+    """Test audio_info handles file errors properly."""
+    # Mock torchaudio.info to raise an exception
+    with patch(
+        "datachain.lib.audio.torchaudio.info", side_effect=Exception("Test error")
+    ):
+        with pytest.raises(
+            FileError, match="unable to extract metadata from audio file"
+        ):
+            audio_info(audio_file)
+
+
+def test_audio_segment_np_file_error(audio_file):
+    """Test audio_segment_np handles file errors properly."""
+    with patch(
+        "datachain.lib.audio.torchaudio.info", side_effect=Exception("Test error")
+    ):
+        with pytest.raises(FileError, match="unable to read audio segment"):
+            audio_segment_np(audio_file)
+
+
+def test_save_audio_fragment_file_error(audio_file, tmp_path):
+    """Test save_audio_fragment handles errors properly."""
+    with patch(
+        "datachain.lib.audio.audio_segment_bytes", side_effect=Exception("Test error")
+    ):
+        with pytest.raises(FileError, match="unable to save audio fragment"):
+            save_audio_fragment(audio_file, start=0.0, end=1.0, output=str(tmp_path))
+
+
+@pytest.mark.parametrize("start,duration", [(0.0, 1.0), (0.5, 0.5), (1.0, 1.0)])
+def test_audio_segment_np_different_durations(audio_file, start, duration):
+    """Test audio loading with different start times and durations."""
+    audio_np, sr = audio_segment_np(audio_file, start=start, duration=duration)
+
+    assert isinstance(audio_np, np.ndarray)
+    assert sr == 16000
+    expected_samples = int(duration * 16000)
+    assert len(audio_np) == expected_samples
+
+
+@pytest.mark.parametrize("format_type", ["wav", "flac", "ogg"])
+def test_audio_segment_bytes_formats(audio_file, format_type):
+    """Test audio conversion to different formats."""
+    audio_bytes = audio_segment_bytes(audio_file, format=format_type)
+
+    assert isinstance(audio_bytes, bytes)
+    assert len(audio_bytes) > 0
+
+
+def test_audio_info_stereo(stereo_audio_file):
+    """Test audio info extraction for stereo files."""
+    result = audio_info(stereo_audio_file)
+
+    # Verify the returned Audio object has expected metadata
+    assert isinstance(result, Audio)
+    assert result.sample_rate == 16000
+    assert result.channels == 2  # Stereo
+    assert result.samples == 16000

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -67,7 +67,6 @@ def test_audio_info(audio_file):
     """Test audio metadata extraction."""
     result = audio_info(audio_file)
 
-    # Verify the returned Audio object has expected metadata
     assert isinstance(result, Audio)
     assert result.sample_rate == 16000
     assert result.channels == 1
@@ -185,10 +184,8 @@ def test_save_audio_fragment_validation(audio_file, tmp_path):
 
 def test_save_audio_fragment_auto_format(tmp_path, catalog):
     """Test saving audio fragment with auto-detected format."""
-    # Create a FLAC audio file for this test
     audio_data = generate_test_wav(duration=1.0, sample_rate=16000)
     audio_path = tmp_path / "test_audio.flac"
-    # Convert to FLAC format
     buffer = io.BytesIO(audio_data)
     temp_data, sr = sf.read(buffer)
     sf.write(audio_path, temp_data, sr, format="flac")
@@ -210,7 +207,6 @@ def test_save_audio_fragment_auto_format(tmp_path, catalog):
 
 def test_audio_info_file_error(audio_file):
     """Test audio_info handles file errors properly."""
-    # Mock torchaudio.info to raise an exception
     with patch(
         "datachain.lib.audio.torchaudio.info", side_effect=Exception("Test error")
     ):


### PR DESCRIPTION
Add Audio and AudioFragment support, to make code like below work with full streaming (no file download happening):

```python
from collections.abc import Iterator

import torch
from transformers import Pipeline, pipeline

import datachain as dc
from datachain import AudioFile, AudioFragment


def fragments(file: AudioFile) -> Iterator[AudioFragment]:
    yield file.get_fragment(300, 400)


def process(fragment: AudioFragment, pipeline: Pipeline) -> str:
    """Process audio fragment using direct numpy conversion."""
    audio_array, sample_rate = fragment.get_np()

    # Convert to mono if stereo (average the channels)
    if len(audio_array.shape) > 1 and audio_array.shape[1] > 1:
        audio_array = audio_array.mean(axis=1)

    # Pass the numpy array with exact sampling rate from fragment
    result = pipeline({
        "array": audio_array,
        "sampling_rate": sample_rate
    })
    return str(result)

(
    dc
    .read_storage("s3://ivan-test-versioned/sounds", type="audio")
    .settings(cache=False, prefetch=False)
    .gen(fragment=fragments)
    .setup(pipeline=lambda: pipeline(
        "audio-classification",
        model="superb/wav2vec2-base-superb-ks",
        torch_dtype=torch.float32,
        device="cpu"
    ))
    .map(type=process)
    .show()
)
```

## TODO:

- [x] Add tests
- [x] Add example like above
- [ ] Add FE support for AudioFragment model to show preview it from the middle point cc @yathomasi 