### PR TITLE
trust Studio names, don't validate locally

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1555,12 +1555,14 @@ class Catalog:
             remote_ds.project.namespace.name,
             description=remote_ds.project.namespace.descr,
             uuid=remote_ds.project.namespace.uuid,
+            validate=False,
         )
         project = self.metastore.create_project(
             namespace.name,
             remote_ds.project.name,
             description=remote_ds.project.descr,
             uuid=remote_ds.project.uuid,
+            validate=False,
         )
 
         try:


### PR DESCRIPTION
Fixes issues with pulling Studio datasets:


```python
import datachain as dc

dataset = dc.read_dataset("@shcheklein.default.test_dataset", update=True)
```

Triggering:

```python
Traceback (most recent call last):
  File "/Users/ivan/Projects/datachain/test.py", line 4, in <module>
    dataset = dc.read_dataset("@eldada-brainspace.default.parquet-processed-ecg", update=True)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ivan/Projects/datachain/src/datachain/lib/dc/datasets.py", line 186, in read_dataset
    query = DatasetQuery(
            ^^^^^^^^^^^^^
  File "/Users/ivan/Projects/datachain/src/datachain/query/dataset.py", line 1142, in __init__
    self.catalog.get_dataset_with_remote_fallback(
  File "/Users/ivan/Projects/datachain/src/datachain/catalog/catalog.py", line 1153, in get_dataset_with_remote_fallback
    self.pull_dataset(
  File "/Users/ivan/Projects/datachain/src/datachain/catalog/catalog.py", line 1554, in pull_dataset
    namespace = self.metastore.create_namespace(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ivan/Projects/datachain/src/datachain/data_storage/metastore.py", line 734, in create_namespace
    Namespace.validate_name(name)
  File "/Users/ivan/Projects/datachain/src/datachain/namespace.py", line 28, in validate_name
    raise InvalidNamespaceNameError(
datachain.error.InvalidNamespaceNameError: Character @ is reserved and not allowed in namespace name
```

## TODO

- [ ] Add tests as a followup

## Summary by Sourcery

Skip local namespace and project name validation when pulling remote Studio datasets to allow reserved characters in names

Bug Fixes:
- Pass validate=False to create_namespace to bypass local namespace name checks
- Pass validate=False to create_project to bypass local project name checks