### PR TITLE
migrate to 4.0 datasets from HF

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,9 +30,6 @@ jobs:
           enable-cache: true
           cache-suffix: benchmarks
           cache-dependency-glob: pyproject.toml
-          # revert after this is fixed
-          # https://github.com/wntrblm/nox/issues/953
-          version: ">=0.6,<0.7"
 
       - name: Install nox and dvc
         run: uv pip install dvc[gs] nox --system

--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -75,8 +75,21 @@ jobs:
           path: './backend/datachain'
           fetch-depth: 0
 
-      - name: Set up FFmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
+      - name: Install FFmpeg on Windows
+        if: runner.os == 'Windows'
+        run: choco install ffmpeg
+
+      - name: Install FFmpeg on macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install ffmpeg
+          echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
+
+      - name: Install FFmpeg on Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y ffmpeg
 
       - name: Set up Python ${{ matrix.pyv }}
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,6 @@ jobs:
           enable-cache: true
           cache-suffix: lint
           cache-dependency-glob: pyproject.toml
-          # revert after this is fixed
-          # https://github.com/wntrblm/nox/issues/953
-          version: ">=0.6,<0.7"
 
       - name: Install nox
         run: uv pip install nox --system
@@ -81,9 +78,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Set up FFmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-
       - name: Set up Python ${{ matrix.pyv }}
         uses: actions/setup-python@v5
         with:
@@ -95,9 +89,22 @@ jobs:
           enable-cache: true
           cache-suffix: tests-${{ matrix.pyv }}
           cache-dependency-glob: pyproject.toml
-          # revert after this is fixed
-          # https://github.com/wntrblm/nox/issues/953
-          version: ">=0.6,<0.7"
+
+      - name: Install FFmpeg on Windows
+        if: runner.os == 'Windows'
+        run: choco install ffmpeg
+
+      - name: Install FFmpeg on macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install ffmpeg
+          echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
+
+      - name: Install FFmpeg on Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y ffmpeg
 
       - name: Install nox
         run: uv pip install nox --system
@@ -165,9 +172,6 @@ jobs:
           enable-cache: true
           cache-suffix: examples-${{ matrix.pyv }}
           cache-dependency-glob: pyproject.toml
-          # revert after this is fixed
-          # https://github.com/wntrblm/nox/issues/953
-          version: ">=0.6,<0.7"
 
       - name: Install nox
         run: uv pip install nox --system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,9 @@ vector = [
 ]
 hf = [
   "numba>=0.60.0",
-  "datasets[audio,vision]>=2.21.0",
+  "datasets[vision]>=4.0.0",
+  # https://github.com/pytorch/torchcodec/issues/640
+  "datasets[audio]>=4.0.0 ; (sys_platform == 'linux' or sys_platform == 'darwin')",
   "fsspec>=2024.12.0"
 ]
 video = [


### PR DESCRIPTION
Fixing broken HF integration after 4.0 release https://github.com/huggingface/datasets/releases/tag/4.0.0

## Summary by Sourcery

Migrate the Hugging Face dataset integration to be compatible with datasets v4.0 by updating the dependency version and adapting feature conversion logic and data models to the new API structure.

Bug Fixes:
- Restore Hugging Face integration compatibility after upgrading to datasets v4.0

Enhancements:
- Replace deprecated Sequence feature handling with generic dict and List-based logic in convert_feature and _feature_to_chain_type
- Remove HFAudio.path field and adjust HFAudio instantiation to accept only array and sampling_rate

Build:
- Bump datasets[audio,vision] dependency to >=4.0.0 in pyproject.toml