### PR TITLE
fix docs for Git repository job run arg

### DIFF
--- a/docs/commands/job/run.md
+++ b/docs/commands/job/run.md
@@ -31,6 +31,7 @@ This command runs a job in Studio using the specified query file. You can config
 * `--req-file REQ_FILE` - Python requirements file
 * `--req REQ` - Python package requirements
 * `--priority PRIORITY` - Priority for the job in range 0-5. Lower value is higher priority (default: 5)
+* `--repository URL` - Repository URL to clone before running the job.
 * `-h`, `--help` - Show the help message and exit.
 * `-v`, `--verbose` - Be verbose.
 * `-q`, `--quiet` - Be quiet.
@@ -65,6 +66,18 @@ datachain job run --env API_KEY=123 --req pandas numpy query.py
 6. Run a job with a repository (will be cloned in the job working directory):
 ```bash
 datachain job run --repository https://github.com/iterative/datachain query.py
+```
+
+To specify a branch / revision:
+
+```bash
+datachain job run --repository https://github.com/iterative/datachain@main query.py
+```
+
+Git URLs are also supported:
+
+```bash
+datachain job run --repository git@github.com:iterative/datachain.git@main query.py
 ```
 
 7. Run a job with higher priority


### PR DESCRIPTION
Docs update for `job run` command.

## Summary by Sourcery

Add documentation for the new `--repository` option in the `datachain job run` command, including examples for specifying branches and using Git URLs.

Documentation:
- Document the `--repository` flag for `job run` and its usage to clone a repository before execution.
- Provide examples for specifying a branch or revision via URL suffix and using SSH Git URLs with revision suffixes.