### PR TITLE
fix(setup): allow empty values for args

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -446,14 +446,14 @@ class SignalSchema:
                 res[db_name] = python_to_sql(type_)
         return res
 
-    def row_to_objs(self, row: Sequence[Any]) -> list[DataValue]:
+    def row_to_objs(self, row: Sequence[Any]) -> list[Any]:
         self._init_setup_values()
 
-        objs: list[DataValue] = []
+        objs: list[Any] = []
         pos = 0
         for name, fr_type in self.values.items():
-            if self.setup_values and (val := self.setup_values.get(name, None)):
-                objs.append(val)
+            if self.setup_values and name in self.setup_values:
+                objs.append(self.setup_values.get(name))
             elif (fr := ModelStore.to_pydantic(fr_type)) is not None:
                 j, pos = unflatten_to_json_pos(fr, row, pos)
                 objs.append(fr(**j))

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -13,7 +13,6 @@ from datachain.asyn import AsyncMapper
 from datachain.cache import temporary_cache
 from datachain.dataset import RowDict
 from datachain.lib.convert.flatten import flatten
-from datachain.lib.data_model import DataValue
 from datachain.lib.file import File
 from datachain.lib.utils import AbstractUDF, DataChainError, DataChainParamsError
 from datachain.query.batch import (
@@ -266,7 +265,7 @@ class UDFBase(AbstractUDF):
 
     def _parse_row(
         self, row_dict: RowDict, catalog: "Catalog", cache: bool, download_cb: Callback
-    ) -> list[DataValue]:
+    ) -> list[Any]:
         assert self.params
         row = [row_dict[p] for p in self.params.to_udf_spec()]
         obj_row = self.params.row_to_objs(row)

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -990,9 +990,9 @@ def test_row_to_objs():
 
 
 def test_row_to_objs_setup():
-    spec = {"name": str, "age": float, "init_val": int, "fr": MyType2}
+    spec = {"name": str, "age": float, "init_val": int, "fr": MyType2, "empty": dict}
     setup_value = 84635
-    setup = {"init_val": lambda: setup_value}
+    setup = {"init_val": lambda: setup_value, "empty": dict}
     schema = SignalSchema(spec, setup)
 
     val = MyType2(name="Fred", deep=MyType1(aa=129, bb="qwe"))
@@ -1005,7 +1005,7 @@ def test_row_to_objs_setup():
     res = schema.row_to_objs(row)
     assert schema.setup_values is not None
 
-    assert res == ["myname", 12.5, setup_value, val]
+    assert res == ["myname", 12.5, setup_value, val, {}]
 
 
 def test_setup_not_callable():


### PR DESCRIPTION
Allow sending empty (`{}`, `None`, `""`, etc) values to setup. Before it was failing with an index error. 

