### PR TITLE
Aggregate table into single group if no partition_by set

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -823,9 +823,8 @@ class DataChain:
             chain.save("new_dataset")
             ```
         """
-        # Convert string partition_by parameters to Column objects
-        processed_partition_by = partition_by
         if partition_by is not None:
+            # Convert string partition_by parameters to Column objects
             if isinstance(partition_by, (str, Function, ColumnElement)):
                 list_partition_by = [partition_by]
             else:
@@ -844,6 +843,8 @@ class DataChain:
                     processed_partition_columns.append(col)
 
             processed_partition_by = processed_partition_columns
+        else:
+            processed_partition_by = []
 
         udf_obj = self._udf_to_obj(Aggregator, func, params, output, signal_map)
         return self._evolve(


### PR DESCRIPTION
Fix for the https://github.com/iterative/datachain/issues/1212

## Summary by Sourcery

Fix aggregation to group all rows into a single partition when partition_by is unset and add a corresponding unit test

Bug Fixes:
- Default to a single aggregation group when no partition_by is specified

Enhancements:
- Treat None partition_by as an empty list inside agg

Tests:
- Add test to verify aggregation behavior without partition_by combines all rows into one group