### PR TITLE
determine file format for cloud fs

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -717,6 +717,23 @@ class ImageFile(File):
         destination = stringify_path(destination)
 
         client: Client = self._catalog.get_client(destination, **(client_config or {}))
+
+        # If format is not provided, determine it from the file extension
+        if format is None:
+            from pathlib import PurePosixPath
+
+            from PIL import Image as PilImage
+
+            ext = PurePosixPath(destination).suffix.lower()
+            format = PilImage.registered_extensions().get(ext)
+
+        if not format:
+            raise FileError(
+                f"Can't determine format for destination '{destination}'",
+                self.source,
+                self.path,
+            )
+
         with client.fs.open(destination, mode="wb") as f:
             self.read().save(f, format=format)
 


### PR DESCRIPTION
Fixes https://github.com/iterative/datachain/issues/1228

PIL `save` requires format to be passed explicitly if file pointer is used in it (it can't get the file name for some file systems in this case).

## Summary by Sourcery

Implement automatic image format detection based on file extension when saving to cloud filesystems and add functional tests to verify image saving with different format parameters.

New Features:
- Automatically infer image format from the destination file extension if not specified when saving images to cloud filesystems

Bug Fixes:
- Fix PIL save to explicitly provide format when using file pointer to avoid missing filename issues on certain filesystems

Tests:
- Add parametrized functional tests for saving and verifying images on cloud storage (S3, GCS, Azure) with None, JPEG, and PNG formats