### PR TITLE
if anon is set to False disable anon access

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -2388,7 +2388,7 @@ class DataChain:
         placement: FileExportPlacement = "fullpath",
         link_type: Literal["copy", "symlink"] = "copy",
         num_threads: Optional[int] = EXPORT_FILES_MAX_THREADS,
-        anon: bool = False,
+        anon: Optional[bool] = None,
         client_config: Optional[dict] = None,
     ) -> None:
         """Export files from a specified signal to a directory. Files can be
@@ -2403,7 +2403,11 @@ class DataChain:
                 Falls back to `'copy'` if symlinking fails.
             num_threads : number of threads to use for exporting files.
                 By default it uses 5 threads.
-            anon: If true, we will treat cloud bucket as public one
+            anon: If True, we will treat cloud bucket as public one. Default behavior
+                depends on the previous session configuration (e.g. happens in the
+                initial `read_storage`) and particular cloud storage client
+                implementation (e.g. S3 fallbacks to anonymous access if no credentials
+                were found).
             client_config: Optional configuration for the destination storage client
 
         Example:
@@ -2421,8 +2425,8 @@ class DataChain:
         ):
             raise ValueError("Files with the same name found")
 
-        if anon:
-            client_config = (client_config or {}) | {"anon": True}
+        if anon is not None:
+            client_config = (client_config or {}) | {"anon": anon}
 
         progress_bar = tqdm(
             desc=f"Exporting files to {output}: ",

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -33,7 +33,7 @@ def read_storage(
     recursive: Optional[bool] = True,
     column: str = "file",
     update: bool = False,
-    anon: bool = False,
+    anon: Optional[bool] = None,
     delta: Optional[bool] = False,
     delta_on: Optional[Union[str, Sequence[str]]] = (
         "file.path",
@@ -124,8 +124,8 @@ def read_storage(
 
     file_type = get_file_type(type)
 
-    if anon:
-        client_config = (client_config or {}) | {"anon": True}
+    if anon is not None:
+        client_config = (client_config or {}) | {"anon": anon}
     session = Session.get(session, client_config=client_config, in_memory=in_memory)
     catalog = session.catalog
     cache = catalog.cache


### PR DESCRIPTION
Caught this issue with code like this:

```python
import os
import datachain as dc
from datachain import C

os.environ["AWS_PROFILE"] = "<name>"

(
    dc
      .read_storage("gs://datachain-demo/openimages-v6-test-jsonpairs/", anon=True, type="image")
      .filter(C("file.path").glob("*.jpg"))
      .to_parquet("images.parquet")
)

dc.read_parquet("images.parquet").to_storage("s3://ivan-test-versioned/output/images/", anon=False)
```

`anon=False` doesn't work in the second `to_storage("s3://ivan-test-versioned/output/images/", anon=False)` and `anon=True` is enforced from the global session setup in the first read storage.

## Summary by Sourcery

Enable explicit control over anonymous access in storage operations by changing anon default to None and applying it only when specified, thereby allowing anon=False to override session settings.

New Features:
- Allow explicit disabling of anonymous access by passing anon=False to read_storage and to_storage

Enhancements:
- Change default anon parameter to None so default behavior inherits from session or client implementation

Documentation:
- Update docstrings for anon parameters to describe new default behavior