### PR TITLE
Refactoring `Catalog.get_dataset()`

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -680,8 +680,9 @@ class Catalog:
                 ds_namespace, ds_project, ds_name = parse_dataset_name(ds_name)
                 assert ds_namespace
                 assert ds_project
-                project = self.metastore.get_project(ds_project, ds_namespace)
-                dataset = self.get_dataset(ds_name, project)
+                dataset = self.get_dataset(
+                    ds_name, namespace_name=ds_namespace, project_name=ds_project
+                )
                 if not ds_version:
                     ds_version = dataset.latest_version
                 dataset_sources = self.warehouse.get_dataset_sources(
@@ -807,7 +808,11 @@ class Catalog:
             )
         default_version = DEFAULT_DATASET_VERSION
         try:
-            dataset = self.get_dataset(name, project)
+            dataset = self.get_dataset(
+                name,
+                namespace_name=project.namespace.name if project else None,
+                project_name=project.name if project else None,
+            )
             default_version = dataset.next_version_patch
             if update_version == "major":
                 default_version = dataset.next_version_major
@@ -1016,7 +1021,11 @@ class Catalog:
             dc.save(name)
         except Exception as e:  # noqa: BLE001
             try:
-                ds = self.get_dataset(name, project)
+                ds = self.get_dataset(
+                    name,
+                    namespace_name=project.namespace.name,
+                    project_name=project.name,
+                )
                 self.metastore.update_dataset_status(
                     ds,
                     DatasetStatus.FAILED,
@@ -1033,7 +1042,11 @@ class Catalog:
             except DatasetNotFoundError:
                 raise e from None
 
-        ds = self.get_dataset(name, project)
+        ds = self.get_dataset(
+            name,
+            namespace_name=project.namespace.name,
+            project_name=project.name,
+        )
 
         self.update_dataset_version_with_warehouse_info(
             ds,
@@ -1041,7 +1054,11 @@ class Catalog:
             sources="\n".join(sources),
         )
 
-        return self.get_dataset(name, project)
+        return self.get_dataset(
+            name,
+            namespace_name=project.namespace.name,
+            project_name=project.name,
+        )
 
     def get_full_dataset_name(
         self,
@@ -1077,22 +1094,23 @@ class Catalog:
         return namespace_name, project_name, name
 
     def get_dataset(
-        self, name: str, project: Optional[Project] = None
+        self,
+        name: str,
+        namespace_name: Optional[str] = None,
+        project_name: Optional[str] = None,
     ) -> DatasetRecord:
         from datachain.lib.listing import is_listing_dataset
 
-        project = project or self.metastore.default_project
+        namespace_name = namespace_name or self.metastore.default_namespace_name
+        project_name = project_name or self.metastore.default_project_name
 
         if is_listing_dataset(name):
-            project = self.metastore.listing_project
+            namespace_name = self.metastore.system_namespace_name
+            project_name = self.metastore.listing_project_name
 
-        try:
-            return self.metastore.get_dataset(name, project.id if project else None)
-        except DatasetNotFoundError:
-            raise DatasetNotFoundError(
-                f"Dataset {name} not found in namespace {project.namespace.name}"
-                f" and project {project.name}"
-            ) from None
+        return self.metastore.get_dataset(
+            name, namespace_name=namespace_name, project_name=project_name
+        )
 
     def get_dataset_with_remote_fallback(
         self,
@@ -1113,8 +1131,11 @@ class Catalog:
 
         if self.metastore.is_local_dataset(namespace_name) or not update:
             try:
-                project = self.metastore.get_project(project_name, namespace_name)
-                ds = self.get_dataset(name, project)
+                ds = self.get_dataset(
+                    name,
+                    namespace_name=namespace_name,
+                    project_name=project_name,
+                )
                 if not version or ds.has_version(version):
                     return ds
             except (NamespaceNotFoundError, ProjectNotFoundError, DatasetNotFoundError):
@@ -1139,7 +1160,9 @@ class Catalog:
                 local_ds_version=version,
             )
             return self.get_dataset(
-                name, self.metastore.get_project(project_name, namespace_name)
+                name,
+                namespace_name=namespace_name,
+                project_name=project_name,
             )
 
         return self.get_remote_dataset(namespace_name, project_name, name)
@@ -1148,7 +1171,11 @@ class Catalog:
         """Returns dataset that contains version with specific uuid"""
         for dataset in self.ls_datasets():
             if dataset.has_version_with_uuid(uuid):
-                return self.get_dataset(dataset.name, dataset.project)
+                return self.get_dataset(
+                    dataset.name,
+                    namespace_name=dataset.project.namespace.name,
+                    project_name=dataset.project.name,
+                )
         raise DatasetNotFoundError(f"Dataset with version uuid {uuid} not found.")
 
     def get_remote_dataset(
@@ -1173,7 +1200,11 @@ class Catalog:
     def get_dataset_dependencies(
         self, name: str, version: str, project: Optional[Project] = None, indirect=False
     ) -> list[Optional[DatasetDependency]]:
-        dataset = self.get_dataset(name, project)
+        dataset = self.get_dataset(
+            name,
+            namespace_name=project.namespace.name if project else None,
+            project_name=project.name if project else None,
+        )
 
         direct_dependencies = self.metastore.get_direct_dataset_dependencies(
             dataset, version
@@ -1340,7 +1371,11 @@ class Catalog:
         project: Optional[Project] = None,
         client_config=None,
     ) -> list[str]:
-        dataset = self.get_dataset(name, project)
+        dataset = self.get_dataset(
+            name,
+            namespace_name=project.namespace.name if project else None,
+            project_name=project.name if project else None,
+        )
 
         return self.warehouse.export_dataset_table(
             bucket_uri, dataset, version, client_config
@@ -1349,7 +1384,11 @@ class Catalog:
     def dataset_table_export_file_names(
         self, name: str, version: str, project: Optional[Project] = None
     ) -> list[str]:
-        dataset = self.get_dataset(name, project)
+        dataset = self.get_dataset(
+            name,
+            namespace_name=project.namespace.name if project else None,
+            project_name=project.name if project else None,
+        )
         return self.warehouse.dataset_table_export_file_names(dataset, version)
 
     def remove_dataset(
@@ -1359,7 +1398,11 @@ class Catalog:
         version: Optional[str] = None,
         force: Optional[bool] = False,
     ):
-        dataset = self.get_dataset(name, project)
+        dataset = self.get_dataset(
+            name,
+            namespace_name=project.namespace.name if project else None,
+            project_name=project.name if project else None,
+        )
         if not version and not force:
             raise ValueError(f"Missing dataset version from input for dataset {name}")
         if version and not dataset.has_version(version):
@@ -1395,7 +1438,11 @@ class Catalog:
         if attrs is not None:
             update_data["attrs"] = attrs  # type: ignore[assignment]
 
-        dataset = self.get_dataset(name, project)
+        dataset = self.get_dataset(
+            name,
+            namespace_name=project.namespace.name if project else None,
+            project_name=project.name if project else None,
+        )
         return self.update_dataset(dataset, **update_data)
 
     def ls(
@@ -1549,7 +1596,9 @@ class Catalog:
         )
 
         try:
-            local_dataset = self.get_dataset(local_ds_name, project=project)
+            local_dataset = self.get_dataset(
+                local_ds_name, namespace_name=namespace.name, project_name=project.name
+            )
             if local_dataset and local_dataset.has_version(local_ds_version):
                 raise DataChainError(
                     f"Local dataset {local_ds_uri} already exists with different uuid,"

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1198,12 +1198,17 @@ class Catalog:
         return DatasetRecord.from_dict(dataset_info)
 
     def get_dataset_dependencies(
-        self, name: str, version: str, project: Optional[Project] = None, indirect=False
+        self,
+        name: str,
+        version: str,
+        namespace_name: Optional[str] = None,
+        project_name: Optional[str] = None,
+        indirect=False,
     ) -> list[Optional[DatasetDependency]]:
         dataset = self.get_dataset(
             name,
-            namespace_name=project.namespace.name if project else None,
-            project_name=project.name if project else None,
+            namespace_name=namespace_name,
+            project_name=project_name,
         )
 
         direct_dependencies = self.metastore.get_direct_dataset_dependencies(
@@ -1218,10 +1223,13 @@ class Catalog:
                 # dependency has been removed
                 continue
             if d.is_dataset:
-                project = self.metastore.get_project(d.project, d.namespace)
                 # only datasets can have dependencies
                 d.dependencies = self.get_dataset_dependencies(
-                    d.name, d.version, project, indirect=indirect
+                    d.name,
+                    d.version,
+                    namespace_name=d.namespace,
+                    project_name=d.project,
+                    indirect=indirect,
                 )
 
         return direct_dependencies

--- a/src/datachain/cli/commands/datasets.py
+++ b/src/datachain/cli/commands/datasets.py
@@ -107,8 +107,9 @@ def list_datasets_local(catalog: "Catalog", name: Optional[str] = None):
 def list_datasets_local_versions(catalog: "Catalog", name: str):
     namespace_name, project_name, name = catalog.get_full_dataset_name(name)
 
-    project = catalog.metastore.get_project(project_name, namespace_name)
-    ds = catalog.get_dataset(name, project)
+    ds = catalog.get_dataset(
+        name, namespace_name=namespace_name, project_name=project_name
+    )
     for v in ds.versions:
         yield (name, v.version)
 

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -301,7 +301,13 @@ class AbstractMetastore(ABC, Serializable):
         """
 
     @abstractmethod
-    def get_dataset(self, name: str, project_id: Optional[int] = None) -> DatasetRecord:
+    def get_dataset(
+        self,
+        name: str,  # normal, not full dataset name
+        namespace_name: Optional[str] = None,
+        project_name: Optional[str] = None,
+        conn=None,
+    ) -> DatasetRecord:
         """Gets a single dataset by name."""
 
     @abstractmethod
@@ -912,11 +918,14 @@ class AbstractDBMetastore(AbstractMetastore):
         **kwargs,  # TODO registered = True / False
     ) -> DatasetRecord:
         """Creates new dataset."""
-        project_id = project_id or self.default_project.id
+        if not project_id:
+            project = self.default_project
+        else:
+            project = self.get_project_by_id(project_id)
 
         query = self._datasets_insert().values(
             name=name,
-            project_id=project_id,
+            project_id=project.id,
             status=status,
             feature_schema=json.dumps(feature_schema or {}),
             created_at=datetime.now(timezone.utc),
@@ -935,7 +944,9 @@ class AbstractDBMetastore(AbstractMetastore):
             query = query.on_conflict_do_nothing(index_elements=["project_id", "name"])
         self.db.execute(query)
 
-        return self.get_dataset(name, project_id)
+        return self.get_dataset(
+            name, namespace_name=project.namespace.name, project_name=project.name
+        )
 
     def create_dataset_version(  # noqa: PLR0913
         self,
@@ -992,7 +1003,12 @@ class AbstractDBMetastore(AbstractMetastore):
             )
         self.db.execute(query, conn=conn)
 
-        return self.get_dataset(dataset.name, dataset.project.id, conn=conn)
+        return self.get_dataset(
+            dataset.name,
+            namespace_name=dataset.project.namespace.name,
+            project_name=dataset.project.name,
+            conn=conn,
+        )
 
     def remove_dataset(self, dataset: DatasetRecord) -> None:
         """Removes dataset."""
@@ -1216,21 +1232,30 @@ class AbstractDBMetastore(AbstractMetastore):
     def get_dataset(
         self,
         name: str,  # normal, not full dataset name
-        project_id: Optional[int] = None,
+        namespace_name: Optional[str] = None,
+        project_name: Optional[str] = None,
         conn=None,
     ) -> DatasetRecord:
         """
         Gets a single dataset in project by dataset name.
         """
-        project_id = project_id or self.default_project.id
+        namespace_name = namespace_name or self.default_namespace_name
+        project_name = project_name or self.default_project_name
 
         d = self._datasets
+        n = self._namespaces
+        p = self._projects
         query = self._base_dataset_query()
-        query = query.where(d.c.name == name, d.c.project_id == project_id)  # type: ignore [attr-defined]
+        query = query.where(
+            d.c.name == name,
+            n.c.name == namespace_name,
+            p.c.name == project_name,
+        )  # type: ignore [attr-defined]
         ds = self._parse_dataset(self.db.execute(query, conn=conn))
         if not ds:
             raise DatasetNotFoundError(
-                f"Dataset {name} not found in project with id {project_id}"
+                f"Dataset {name} not found in namespace {namespace_name}"
+                f" and project {project_name}"
             )
 
         return ds

--- a/src/datachain/delta.py
+++ b/src/datachain/delta.py
@@ -157,7 +157,9 @@ def _get_source_info(
     source_ds_name = dep.name
     source_ds_version = dep.version
     source_ds_latest_version = catalog.get_dataset(
-        source_ds_name, project=source_ds_project
+        source_ds_name,
+        namespace_name=source_ds_project.namespace.name,
+        project_name=source_ds_project.name,
     ).latest_version
 
     return (
@@ -216,7 +218,9 @@ def delta_retry_update(
 
     # Check if dataset exists
     try:
-        dataset = catalog.get_dataset(name, project=project)
+        dataset = catalog.get_dataset(
+            name, namespace_name=namespace_name, project_name=project_name
+        )
         latest_version = dataset.latest_version
     except DatasetNotFoundError:
         # First creation of result dataset

--- a/src/datachain/delta.py
+++ b/src/datachain/delta.py
@@ -77,7 +77,8 @@ def _get_delta_chain(
 
 def _get_retry_chain(
     name: str,
-    project: Project,
+    namespace_name: str,
+    project_name: str,
     latest_version: str,
     source_ds_name: str,
     source_ds_project: Project,
@@ -96,8 +97,8 @@ def _get_retry_chain(
     # Read the latest version of the result dataset for retry logic
     result_dataset = datachain.read_dataset(
         name,
-        namespace=project.namespace.name,
-        project=project.name,
+        namespace=namespace_name,
+        project=project_name,
         version=latest_version,
     )
     source_dc = datachain.read_dataset(
@@ -128,7 +129,8 @@ def _get_retry_chain(
 
 def _get_source_info(
     name: str,
-    project: Project,
+    namespace_name: str,
+    project_name: str,
     latest_version: str,
     catalog,
 ) -> tuple[
@@ -145,7 +147,11 @@ def _get_source_info(
         Returns (None, None, None, None) if source dataset was removed.
     """
     dependencies = catalog.get_dataset_dependencies(
-        name, latest_version, project=project, indirect=False
+        name,
+        latest_version,
+        namespace_name=namespace_name,
+        project_name=project_name,
+        indirect=False,
     )
 
     dep = dependencies[0]
@@ -213,7 +219,7 @@ def delta_retry_update(
     """
 
     catalog = dc.session.catalog
-    project = catalog.metastore.get_project(project_name, namespace_name)
+    # project = catalog.metastore.get_project(project_name, namespace_name)
     dc._query.apply_listing_pre_step()
 
     # Check if dataset exists
@@ -238,7 +244,7 @@ def delta_retry_update(
         source_ds_version,
         source_ds_latest_version,
         dependencies,
-    ) = _get_source_info(name, project, latest_version, catalog)
+    ) = _get_source_info(name, namespace_name, project_name, latest_version, catalog)
 
     # If source_ds_name is None, starting dataset was removed
     if source_ds_name is None:
@@ -268,7 +274,8 @@ def delta_retry_update(
     if delta_retry:
         retry_chain = _get_retry_chain(
             name,
-            project,
+            namespace_name,
+            project_name,
             latest_version,
             source_ds_name,
             source_ds_project,
@@ -294,8 +301,8 @@ def delta_retry_update(
 
     latest_dataset = datachain.read_dataset(
         name,
-        namespace=project.namespace.name,
-        project=project.name,
+        namespace=namespace_name,
+        project=project_name,
         version=latest_version,
     )
     compared_chain = latest_dataset.diff(

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -271,7 +271,11 @@ class DataChain:
         """Underlying dataset, if there is one."""
         if not self.name:
             return None
-        return self.session.catalog.get_dataset(self.name, self._query.project)
+        return self.session.catalog.get_dataset(
+            self.name,
+            namespace_name=self._query.project.namespace.name,
+            project_name=self._query.project.name,
+        )
 
     def __or__(self, other: "Self") -> "Self":
         """Return `self.union(other)`."""

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -357,7 +357,14 @@ def delete_dataset(
         ) from None
 
     if not force:
-        version = version or catalog.get_dataset(name, ds_project).latest_version
+        version = (
+            version
+            or catalog.get_dataset(
+                name,
+                namespace_name=ds_project.namespace.name,
+                project_name=ds_project.name,
+            ).latest_version
+        )
     else:
         version = None
     catalog.remove_dataset(name, ds_project, version=version, force=force)
@@ -403,9 +410,7 @@ def move_dataset(
     namespace, project, name = catalog.get_full_dataset_name(src)
     dest_namespace, dest_project, dest_name = catalog.get_full_dataset_name(dest)
 
-    dataset = catalog.get_dataset(
-        name, catalog.metastore.get_project(project, namespace)
-    )
+    dataset = catalog.get_dataset(name, namespace_name=namespace, project_name=project)
 
     catalog.update_dataset(
         dataset,

--- a/src/datachain/listing.py
+++ b/src/datachain/listing.py
@@ -65,17 +65,13 @@ class Listing:
 
     @cached_property
     def dataset(self) -> "DatasetRecord":
-        from datachain.error import DatasetNotFoundError
-
         assert self.dataset_name
         project = self.metastore.listing_project
-        try:
-            return self.metastore.get_dataset(self.dataset_name, project.id)
-        except DatasetNotFoundError:
-            raise DatasetNotFoundError(
-                f"Dataset {self.dataset_name} not found in namespace"
-                f" {project.namespace.name} and project {project.name}"
-            ) from None
+        return self.metastore.get_dataset(
+            self.dataset_name,
+            namespace_name=project.namespace.name,
+            project_name=project.name,
+        )
 
     @cached_property
     def dataset_rows(self):

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1709,12 +1709,13 @@ class DatasetQuery:
                     indirect=False,
                 ):
                     if dep:
-                        dep_project = self.catalog.metastore.get_project(
-                            dep.project, dep.namespace
-                        )
                         dependencies.add(
                             (
-                                self.catalog.get_dataset(dep.name, dep_project),
+                                self.catalog.get_dataset(
+                                    dep.name,
+                                    namespace_name=dep.namespace,
+                                    project_name=dep.project,
+                                ),
                                 dep.version,
                             )
                         )
@@ -1756,7 +1757,11 @@ class DatasetQuery:
             if (
                 name
                 and version
-                and self.catalog.get_dataset(name, project).has_version(version)
+                and self.catalog.get_dataset(
+                    name,
+                    namespace_name=project.namespace.name,
+                    project_name=project.name,
+                ).has_version(version)
             ):
                 raise RuntimeError(f"Dataset {name} already has version {version}")
         except DatasetNotFoundError:
@@ -1810,11 +1815,15 @@ class DatasetQuery:
                 # overriding dependencies
                 self.dependencies = set()
                 for dep in dependencies:
-                    dep_project = self.catalog.metastore.get_project(
-                        dep.project, dep.namespace
-                    )
                     self.dependencies.add(
-                        (self.catalog.get_dataset(dep.name, dep_project), dep.version)
+                        (
+                            self.catalog.get_dataset(
+                                dep.name,
+                                namespace_name=dep.namespace,
+                                project_name=dep.project,
+                            ),
+                            dep.version,
+                        )
                     )
 
             self._add_dependencies(dataset, version)  # type: ignore [arg-type]

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1703,7 +1703,8 @@ class DatasetQuery:
                 for dep in self.catalog.get_dataset_dependencies(
                     dep_dataset.name,
                     dep_dataset_version,
-                    dep_dataset.project,
+                    namespace_name=dep_dataset.project.namespace.name,
+                    project_name=dep_dataset.project.name,
                     indirect=False,
                 ):
                     if dep:

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -168,7 +168,11 @@ def test_pull_dataset_success(
             )
 
     project = catalog.metastore.get_project(REMOTE_PROJECT_NAME, REMOTE_NAMESPACE_NAME)
-    dataset = catalog.get_dataset(local_ds_name or "dogs", project=project)
+    dataset = catalog.get_dataset(
+        local_ds_name or "dogs",
+        namespace_name=project.namespace.name,
+        project_name=project.name,
+    )
     assert dataset.project.namespace.uuid == REMOTE_NAMESPACE_UUID
     assert dataset.project.uuid == REMOTE_PROJECT_UUID
 
@@ -248,7 +252,9 @@ def test_datachain_read_dataset_pull(
 
     # Check that dataset is available locally after pulling
     project = catalog.metastore.get_project(REMOTE_PROJECT_NAME, REMOTE_NAMESPACE_NAME)
-    dataset = catalog.get_dataset("dogs", project)
+    dataset = catalog.get_dataset(
+        "dogs", namespace_name=project.namespace.name, project_name=project.name
+    )
     assert dataset.name == "dogs"
 
 
@@ -373,7 +379,9 @@ def test_pull_dataset_already_exists_locally(
     )
 
     project = catalog.metastore.get_project(REMOTE_PROJECT_NAME, REMOTE_NAMESPACE_NAME)
-    other = catalog.get_dataset("other", project)
+    other = catalog.get_dataset(
+        "other", namespace_name=project.namespace.name, project_name=project.name
+    )
     other_version = other.get_version("1.0.0")
     assert other_version.uuid == REMOTE_DATASET_UUID
     assert other_version.num_objects == 4
@@ -381,7 +389,9 @@ def test_pull_dataset_already_exists_locally(
 
     # dataset with same uuid created only once, on first pull with local name "other"
     with pytest.raises(DatasetNotFoundError):
-        catalog.get_dataset("dogs", project)
+        catalog.get_dataset(
+            "dogs", namespace_name=project.namespace.name, project_name=project.name
+        )
 
 
 @pytest.mark.parametrize("cloud_type, version_aware", [("s3", False)], indirect=True)


### PR DESCRIPTION
Refactoring `Catalog.get_dataset()` to accept `project_name` and `namespace_name` instead of already instantiated `Project`. This is because in more than one place we have project and namespace name available, but don't have whole `Project` instance and we needed to fetch it from DB because of that which was basically +1 SQL command that could've been avoided.


## Summary by Sourcery

Refactor dataset lookup to use namespace and project names instead of passing Project objects throughout the codebase

Enhancements:
- Change Catalog.get_dataset signature to accept namespace_name and project_name parameters
- Update Metastore.get_dataset interface and queries to use namespace and project names
- Modify all internal callers and tests to pass namespace_name and project_name rather than Project instances