### PR TITLE
fix audio format detection

### DIFF
--- a/tests/func/test_audio.py
+++ b/tests/func/test_audio.py
@@ -62,6 +62,7 @@ def test_audio_datachain_workflow(test_session, tmp_path):
         assert info.channels == 1
         assert info.duration > 0
         assert info.samples > 0
+        assert info.format == "wav"
 
     # Generate audio fragments
     fragments_chain = chain.gen(


### PR DESCRIPTION
Fixes empty format field after getting audio info for `AudioFile`.

## Summary by Sourcery

Use a dedicated mapping function to determine audio format from torchaudio encoding or file extension, ensure format is never empty, and extend tests to cover the new detection logic.

Bug Fixes:
- Populate audio format field based on encoding and file extension fallback

Enhancements:
- Introduce helper function to map torchaudio encoding and file extension to format
- Improve bit rate calculation to handle missing bits_per_sample values

Tests:
- Add unit tests for audio format detection across various encodings and extensions
- Verify format is set in end-to-end audio workflow test