### PR TITLE
fix error message for missing udf-output name

### DIFF
--- a/src/datachain/lib/udf_signature.py
+++ b/src/datachain/lib/udf_signature.py
@@ -82,8 +82,7 @@ class UdfSignature:  # noqa: PLW1641
             for name, type_ in udf_output_map.keys():
                 if not name:
                     raise UdfSignatureError(
-                        chain,
-                        f"undefined column name in signature (type `{type_}`)"
+                        chain, f"undefined column name in signature (type `{type_}`)"
                     )
         else:
             if not func_outs_sign:

--- a/src/datachain/lib/udf_signature.py
+++ b/src/datachain/lib/udf_signature.py
@@ -79,6 +79,12 @@ class UdfSignature:  # noqa: PLW1641
             udf_output_map = UdfSignature._validate_output(
                 chain, signal_name, func, func_outs_sign, output
             )
+            for name, type_ in udf_output_map.keys():
+                if not name:
+                    raise UdfSignatureError(
+                        chain,
+                        f"undefined column name in signature (type `{type_}`)"
+                    )
         else:
             if not func_outs_sign:
                 raise UdfSignatureError(

--- a/src/datachain/lib/udf_signature.py
+++ b/src/datachain/lib/udf_signature.py
@@ -79,7 +79,7 @@ class UdfSignature:  # noqa: PLW1641
             udf_output_map = UdfSignature._validate_output(
                 chain, signal_name, func, func_outs_sign, output
             )
-            for name, type_ in udf_output_map.keys():
+            for name, type_ in udf_output_map.values():
                 if not name:
                     raise UdfSignatureError(
                         chain, f"undefined column name in signature (type `{type_}`)"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Raise a UdfSignatureError with a descriptive message when a UDF output column name is undefined in the signature.