### PR TITLE
audio conversion without fragment-ing

### DIFF
--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -174,7 +174,7 @@ def save_audio_fragment(
 ) -> "AudioFile":
     """Save audio fragment with timestamped filename.
     Supports local and remote storage upload.
-    
+
     If start is negative, converts the entire audio file to the specified format
     without clipping."""
     if format is None:
@@ -188,9 +188,7 @@ def save_audio_fragment(
             )
 
         # Handle full file conversion when start < 0 and end < 0
-        output_file = posixpath.join(
-            output, f"{audio.get_file_stem()}.{format}"
-        )
+        output_file = posixpath.join(output, f"{audio.get_file_stem()}.{format}")
         try:
             audio_bytes = audio_to_bytes(audio, format)
         except Exception as exc:
@@ -204,14 +202,14 @@ def save_audio_fragment(
                 f"Can't save audio fragment for '{audio.path}', "
                 f"invalid time range: ({start:.3f}, {end:.3f})"
             )
-        
+
         duration = end - start
         start_ms = int(start * 1000)
         end_ms = int(end * 1000)
         output_file = posixpath.join(
             output, f"{audio.get_file_stem()}_{start_ms:06d}_{end_ms:06d}.{format}"
         )
-        
+
         try:
             audio_bytes = audio_fragment_bytes(audio, start, duration, format)
         except Exception as exc:

--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -173,27 +173,27 @@ def save_audio(
     end: float = -1,
 ) -> "AudioFile":
     """Save audio fragment or convert entire audio file.
-    
+
     Supports two modes:
     1. Fragment extraction (start >= 0): Extracts audio between start and end times,
        saves with timestamped filename: {stem}_{start_ms}_{end_ms}.{format}
     2. Full file conversion (start < 0): Converts entire audio to specified format,
        saves as: {stem}.{format}
-    
+
     Args:
         audio: Source AudioFile object
         start: Start time in seconds. If negative, triggers full file conversion
         end: End time in seconds (ignored when start < 0)
         output: Output directory path
         format: Output format (e.g., 'wav', 'mp3'). Defaults to source format
-    
+
     Returns:
         AudioFile: Uploaded audio file object
-    
+
     Raises:
         ValueError: Invalid time range for fragment extraction
         FileError: Unable to process audio file
-    
+
     Supports local and remote storage upload."""
     if format is None:
         format = audio.get_file_ext()

--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -170,31 +170,23 @@ def save_audio(
     start: float = 0,
     end: Optional[float] = None,
 ) -> "AudioFile":
-    """Save audio fragment or convert entire audio file.
-
-    Supports three modes:
-    1. Full file conversion (start=0, end=None): Converts entire audio to specified format,
-       saves as: {stem}.{format}
-    2. Extract from start to end of file (start>0, end=None): Extracts audio from start time to end,
-       saves as: {stem}_{start_ms}_end.{format}
-    3. Fragment extraction (start>=0, end is not None): Extracts audio between start and end times,
-       saves as: {stem}_{start_ms}_{end_ms}.{format}
+    """Save audio file or extract fragment to specified format.
 
     Args:
         audio: Source AudioFile object
         output: Output directory path
-        format: Output format (e.g., 'wav', 'mp3'). Defaults to source format
-        start: Start time in seconds. Must be non-negative. Defaults to 0
+        format: Output format ('wav', 'mp3', etc). Defaults to source format
+        start: Start time in seconds (>= 0). Defaults to 0
         end: End time in seconds. If None, extracts to end of file
 
     Returns:
-        AudioFile: Uploaded audio file object
+        AudioFile: New audio file with format conversion/extraction applied
 
-    Raises:
-        ValueError: Invalid time range (negative start or end < start)
-        FileError: Unable to process audio file
-
-    Supports local and remote storage upload."""
+    Examples:
+        save_audio(audio, "/path", "mp3")                       # Entire file to MP3
+        save_audio(audio, "s3://bucket/path", "wav", start=2.5) # From 2.5s to end
+        save_audio(audio, "/path", "flac", start=1, end=3)      # Extract 1-3s fragment
+    """
     if format is None:
         format = audio.get_file_ext()
 

--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -98,7 +98,7 @@ def _encoding_to_format(encoding: str, file_ext: str) -> str:
     return file_ext if file_ext else "unknown"
 
 
-def audio_fragment_np(
+def audio_to_np(
     audio: "AudioFile", start: float = 0, duration: Optional[float] = None
 ) -> "tuple[ndarray, int]":
     """Load audio fragment as numpy array.
@@ -152,7 +152,7 @@ def audio_to_bytes(
 
     If duration is None, converts from start to end of file.
     If start is 0 and duration is None, converts entire file."""
-    y, sr = audio_fragment_np(audio, start, duration)
+    y, sr = audio_to_np(audio, start, duration)
 
     import io
 

--- a/src/datachain/lib/audio.py
+++ b/src/datachain/lib/audio.py
@@ -149,7 +149,7 @@ def audio_to_bytes(
     duration: Optional[float] = None,
 ) -> bytes:
     """Convert audio to bytes using soundfile.
-    
+
     If duration is None, converts from start to end of file.
     If start is 0 and duration is None, converts entire file."""
     y, sr = audio_fragment_np(audio, start, duration)
@@ -204,7 +204,7 @@ def save_audio(
             f"Can't save audio for '{audio.path}', "
             f"start time must be non-negative: {start:.3f}"
         )
-    
+
     # Handle full file conversion when end is None and start is 0
     if end is None and start == 0:
         output_file = posixpath.join(output, f"{audio.get_file_stem()}.{format}")
@@ -216,7 +216,9 @@ def save_audio(
             ) from exc
     elif end is None:
         # Extract from start to end of file
-        output_file = posixpath.join(output, f"{audio.get_file_stem()}_{int(start * 1000):06d}_end.{format}")
+        output_file = posixpath.join(
+            output, f"{audio.get_file_stem()}_{int(start * 1000):06d}_end.{format}"
+        )
         try:
             audio_bytes = audio_to_bytes(audio, format, start=start, duration=None)
         except Exception as exc:

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -964,7 +964,12 @@ class AudioFile(File):
             yield self.get_fragment(start, min(start + duration, end))
             start += duration
 
-    def save(self, output: str, format: Optional[str] = None) -> "AudioFile":
+    def save( # type: ignore[override]
+        self,
+        output: str,
+        format: Optional[str] = None,
+        client_config: Optional[dict] = None
+    ) -> "AudioFile":
         """
         Saves the audio as a new file of a specified format.
 
@@ -982,7 +987,7 @@ class AudioFile(File):
         """
         from .audio import save_audio
 
-        return save_audio(self.audio, output, format)
+        return save_audio(self, output, format)
 
 
 class AudioFragment(DataModel):
@@ -1027,10 +1032,10 @@ class AudioFragment(DataModel):
         Returns:
             bytes: The encoded audio fragment as bytes.
         """
-        from .audio import audio_fragment_bytes
+        from .audio import audio_to_bytes
 
         duration = self.end - self.start
-        return audio_fragment_bytes(self.audio, self.start, duration, format)
+        return audio_to_bytes(self.audio, format, self.start, duration)
 
     def save(self, output: str, format: Optional[str] = None) -> "AudioFile":
         """

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -968,26 +968,30 @@ class AudioFile(File):
         self,
         output: str,
         format: Optional[str] = None,
+        start: float = 0,
+        end: Optional[float] = None,
         client_config: Optional[dict] = None,
     ) -> "AudioFile":
-        """
-        Saves the audio as a new file of a specified format.
-
-        If `output` is a remote path, the file will be uploaded to remote storage.
+        """Save audio file or extract fragment to specified format.
 
         Args:
-            output (str): The destination path, which can be a local file path
-                          or a remote URL.
-            format (str, optional): The output audio format (e.g., 'wav', 'mp3').
-                                    If None, the format is inferred from the
-                                    file extension.
+            output: Output directory path
+            format: Output format ('wav', 'mp3', etc). Defaults to source format
+            start: Start time in seconds (>= 0). Defaults to 0
+            end: End time in seconds. If None, extracts to end of file
+            client_config: Optional client configuration
 
         Returns:
-            AudioFile: A Model representing the saved audio file.
+            AudioFile: New audio file with format conversion/extraction applied
+
+        Examples:
+            audio.save("/path", "mp3")                        # Entire file to MP3
+            audio.save("s3://bucket/path", "wav", start=2.5)  # From 2.5s to end as WAV
+            audio.save("/path", "flac", start=1, end=3)       # 1-3s fragment as FLAC
         """
         from .audio import save_audio
 
-        return save_audio(self, output, format)
+        return save_audio(self, output, format, start, end)
 
 
 class AudioFragment(DataModel):

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -964,11 +964,11 @@ class AudioFile(File):
             yield self.get_fragment(start, min(start + duration, end))
             start += duration
 
-    def save( # type: ignore[override]
+    def save(  # type: ignore[override]
         self,
         output: str,
         format: Optional[str] = None,
-        client_config: Optional[dict] = None
+        client_config: Optional[dict] = None,
     ) -> "AudioFile":
         """
         Saves the audio as a new file of a specified format.

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -964,6 +964,26 @@ class AudioFile(File):
             yield self.get_fragment(start, min(start + duration, end))
             start += duration
 
+    def save(self, output: str, format: Optional[str] = None) -> "AudioFile":
+        """
+        Saves the audio as a new file of a specified format.
+
+        If `output` is a remote path, the file will be uploaded to remote storage.
+
+        Args:
+            output (str): The destination path, which can be a local file path
+                          or a remote URL.
+            format (str, optional): The output audio format (e.g., 'wav', 'mp3').
+                                    If None, the format is inferred from the
+                                    file extension.
+
+        Returns:
+            AudioFile: A Model representing the saved audio file.
+        """
+        from .audio import save_audio
+
+        return save_audio(self.audio, output, format)
+
 
 class AudioFragment(DataModel):
     """
@@ -1028,9 +1048,9 @@ class AudioFragment(DataModel):
         Returns:
             AudioFile: A Model representing the saved audio file.
         """
-        from .audio import save_audio_fragment
+        from .audio import save_audio
 
-        return save_audio_fragment(self.audio, self.start, self.end, output, format)
+        return save_audio(self.audio, output, format, self.start, self.end)
 
 
 class VideoFrame(DataModel):

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -1016,10 +1016,10 @@ class AudioFragment(DataModel):
             tuple[ndarray, int]: A tuple containing the audio data as a NumPy array
                                and the sample rate.
         """
-        from .audio import audio_fragment_np
+        from .audio import audio_to_np
 
         duration = self.end - self.start
-        return audio_fragment_np(self.audio, self.start, duration)
+        return audio_to_np(self.audio, self.start, duration)
 
     def read_bytes(self, format: str = "wav") -> bytes:
         """

--- a/tests/func/test_audio.py
+++ b/tests/func/test_audio.py
@@ -5,7 +5,7 @@ import numpy as np
 import soundfile as sf
 
 import datachain as dc
-from datachain.lib.audio import audio_fragment_np
+from datachain.lib.audio import audio_to_np
 from datachain.lib.file import Audio, AudioFile, AudioFragment
 
 
@@ -108,7 +108,7 @@ def test_audio_datachain_workflow(test_session, tmp_path):
 
     # Verify the audio content matches by comparing numpy arrays
     original_np, original_sr = first_fragment.get_np()
-    saved_np, saved_sr = audio_fragment_np(saved_file)
+    saved_np, saved_sr = audio_to_np(saved_file)
 
     assert original_sr == saved_sr == 16000
     assert len(original_np) == len(saved_np)

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -228,6 +228,27 @@ def test_save_audio_start_to_end(audio_file, tmp_path):
         assert result == mock_uploaded_file
 
 
+def test_audiofile_save(audio_file, tmp_path):
+    with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
+        mock_uploaded_file = AudioFile(path="test_audio.mp3", source="file://")
+        mock_upload.return_value = mock_uploaded_file
+
+        result = audio_file.save(output=str(tmp_path), format="mp3", start=1.0, end=2.0)
+
+        # Verify AudioFile.upload was called
+        mock_upload.assert_called_once()
+        call_args = mock_upload.call_args
+
+        # Check that the audio bytes were generated
+        assert isinstance(call_args[0][0], bytes)
+
+        # Check that the output file has correct format and timestamps
+        output_file = call_args[0][1]
+        assert output_file == str(tmp_path) + "/test_audio_001000_002000.mp3"
+
+        assert result == mock_uploaded_file
+
+
 def test_save_audio_auto_format(tmp_path, catalog):
     """Test saving audio with auto-detected format."""
     audio_data = generate_test_wav(duration=1.0, sample_rate=16000)

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -6,9 +6,9 @@ import pytest
 import soundfile as sf
 
 from datachain.lib.audio import (
-    audio_fragment_np,
     audio_info,
     audio_to_bytes,
+    audio_to_np,
     save_audio,
 )
 from datachain.lib.file import Audio, AudioFile, FileError
@@ -76,7 +76,7 @@ def test_audio_info(audio_file):
 
 def test_audio_fragment_np_full(audio_file):
     """Test loading full audio fragment as numpy array."""
-    audio_np, sr = audio_fragment_np(audio_file)
+    audio_np, sr = audio_to_np(audio_file)
 
     assert isinstance(audio_np, np.ndarray)
     assert sr == 16000
@@ -87,7 +87,7 @@ def test_audio_fragment_np_full(audio_file):
 def test_audio_fragment_np_partial(audio_file):
     """Test loading partial audio fragment."""
     # Load 0.5 seconds starting from 0.5 seconds
-    audio_np, sr = audio_fragment_np(audio_file, start=0.5, duration=0.5)
+    audio_np, sr = audio_to_np(audio_file, start=0.5, duration=0.5)
 
     assert isinstance(audio_np, np.ndarray)
     assert sr == 16000
@@ -97,16 +97,16 @@ def test_audio_fragment_np_partial(audio_file):
 def test_audio_fragment_np_validation(audio_file):
     """Test input validation for audio_fragment_np."""
     with pytest.raises(ValueError, match="start must be a non-negative float"):
-        audio_fragment_np(audio_file, start=-1.0)
+        audio_to_np(audio_file, start=-1.0)
 
     with pytest.raises(ValueError, match="duration must be a positive float"):
-        audio_fragment_np(audio_file, duration=0.0)
+        audio_to_np(audio_file, duration=0.0)
 
 
 def test_audio_fragment_np_with_file_interface(audio_file):
     """Test audio_fragment_np with File interface."""
     # Test that the audio_file fixture (which is already an AudioFile) works
-    audio_np, sr = audio_fragment_np(audio_file)
+    audio_np, sr = audio_to_np(audio_file)
 
     assert isinstance(audio_np, np.ndarray)
     assert sr == 16000
@@ -114,7 +114,7 @@ def test_audio_fragment_np_with_file_interface(audio_file):
 
 def test_audio_fragment_np_multichannel(stereo_audio_file):
     """Test multichannel audio handling."""
-    audio_np, sr = audio_fragment_np(stereo_audio_file)
+    audio_np, sr = audio_to_np(stereo_audio_file)
 
     # Should be transposed to (samples, channels)
     assert audio_np.shape == (16000, 2)  # 1 second at 16kHz, 2 channels
@@ -268,7 +268,7 @@ def test_audio_fragment_np_file_error(audio_file):
         "datachain.lib.audio.torchaudio.info", side_effect=Exception("Test error")
     ):
         with pytest.raises(FileError, match="unable to read audio fragment"):
-            audio_fragment_np(audio_file)
+            audio_to_np(audio_file)
 
 
 def test_save_audio_file_error(audio_file, tmp_path):
@@ -283,7 +283,7 @@ def test_save_audio_file_error(audio_file, tmp_path):
 @pytest.mark.parametrize("start,duration", [(0.0, 1.0), (0.5, 0.5), (1.0, 1.0)])
 def test_audio_fragment_np_different_durations(audio_file, start, duration):
     """Test audio loading with different start times and durations."""
-    audio_np, sr = audio_fragment_np(audio_file, start=start, duration=duration)
+    audio_np, sr = audio_to_np(audio_file, start=start, duration=duration)
 
     assert isinstance(audio_np, np.ndarray)
     assert sr == 16000

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -6,9 +6,9 @@ import pytest
 import soundfile as sf
 
 from datachain.lib.audio import (
-    audio_to_bytes,
     audio_fragment_np,
     audio_info,
+    audio_to_bytes,
     save_audio,
 )
 from datachain.lib.file import Audio, AudioFile, FileError
@@ -175,9 +175,7 @@ def test_save_audio(audio_file, tmp_path):
 
 def test_save_audio_validation(audio_file, tmp_path):
     """Test input validation for save_audio."""
-    with pytest.raises(
-        ValueError, match="start time must be non-negative"
-    ):
+    with pytest.raises(ValueError, match="start time must be non-negative"):
         save_audio(audio_file, output=str(tmp_path), start=-1.0, end=1.0)
 
     with pytest.raises(ValueError, match="Can't save audio.*invalid time range"):
@@ -209,7 +207,9 @@ def test_save_audio_full_file_conversion(audio_file, tmp_path):
 def test_save_audio_start_to_end(audio_file, tmp_path):
     """Test saving audio from start time to end of file (end=None, start>0)."""
     with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
-        mock_uploaded_file = AudioFile(path="test_audio_000500_end.wav", source="file://")
+        mock_uploaded_file = AudioFile(
+            path="test_audio_000500_end.wav", source="file://"
+        )
         mock_upload.return_value = mock_uploaded_file
 
         result = save_audio(audio_file, output=str(tmp_path), format="wav", start=0.5)

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -175,14 +175,10 @@ def test_save_audio(audio_file, tmp_path):
 
 def test_save_audio_validation(audio_file, tmp_path):
     """Test input validation for save_audio."""
-    with pytest.raises(
-        ValueError, match="Can't save audio.*invalid time range"
-    ):
+    with pytest.raises(ValueError, match="Can't save audio.*invalid time range"):
         save_audio(audio_file, output=str(tmp_path), start=-1.0, end=1.0)
 
-    with pytest.raises(
-        ValueError, match="Can't save audio.*invalid time range"
-    ):
+    with pytest.raises(ValueError, match="Can't save audio.*invalid time range"):
         save_audio(audio_file, output=str(tmp_path), start=2.0, end=1.0)
 
 

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -6,7 +6,7 @@ import pytest
 import soundfile as sf
 
 from datachain.lib.audio import (
-    audio_fragment_bytes,
+    audio_to_bytes,
     audio_fragment_np,
     audio_info,
     save_audio,
@@ -121,9 +121,9 @@ def test_audio_fragment_np_multichannel(stereo_audio_file):
     assert sr == 16000
 
 
-def test_audio_fragment_bytes(audio_file):
+def test_audio_to_bytes(audio_file):
     """Test converting audio fragment to bytes."""
-    audio_bytes = audio_fragment_bytes(audio_file, start=0.0, duration=1.0)
+    audio_bytes = audio_to_bytes(audio_file, "wav", 0.0, 1.0)
 
     assert isinstance(audio_bytes, bytes)
     assert len(audio_bytes) > 0
@@ -135,9 +135,9 @@ def test_audio_fragment_bytes(audio_file):
     assert len(data) == 16000  # 1 second at 16kHz
 
 
-def test_audio_fragment_bytes_custom_format(audio_file):
+def test_audio_to_bytes_custom_format(audio_file):
     """Test converting audio fragment to different format."""
-    audio_bytes = audio_fragment_bytes(audio_file, format="flac")
+    audio_bytes = audio_to_bytes(audio_file, "flac")
 
     assert isinstance(audio_bytes, bytes)
     assert len(audio_bytes) > 0
@@ -175,11 +175,57 @@ def test_save_audio(audio_file, tmp_path):
 
 def test_save_audio_validation(audio_file, tmp_path):
     """Test input validation for save_audio."""
-    with pytest.raises(ValueError, match="Can't save audio.*invalid time range"):
+    with pytest.raises(
+        ValueError, match="start time must be non-negative"
+    ):
         save_audio(audio_file, output=str(tmp_path), start=-1.0, end=1.0)
 
     with pytest.raises(ValueError, match="Can't save audio.*invalid time range"):
         save_audio(audio_file, output=str(tmp_path), start=2.0, end=1.0)
+
+
+def test_save_audio_full_file_conversion(audio_file, tmp_path):
+    """Test saving audio with full file conversion (end=None)."""
+    with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
+        mock_uploaded_file = AudioFile(path="test_audio.wav", source="file://")
+        mock_upload.return_value = mock_uploaded_file
+
+        result = save_audio(audio_file, output=str(tmp_path), format="wav")
+
+        # Verify AudioFile.upload was called
+        mock_upload.assert_called_once()
+        call_args = mock_upload.call_args
+
+        # Check that the audio bytes were generated
+        assert isinstance(call_args[0][0], bytes)
+
+        # Check that the output file has no timestamps (full file conversion)
+        output_file = call_args[0][1]
+        assert output_file == str(tmp_path) + "/test_audio.wav"
+
+        assert result == mock_uploaded_file
+
+
+def test_save_audio_start_to_end(audio_file, tmp_path):
+    """Test saving audio from start time to end of file (end=None, start>0)."""
+    with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
+        mock_uploaded_file = AudioFile(path="test_audio_000500_end.wav", source="file://")
+        mock_upload.return_value = mock_uploaded_file
+
+        result = save_audio(audio_file, output=str(tmp_path), format="wav", start=0.5)
+
+        # Verify AudioFile.upload was called
+        mock_upload.assert_called_once()
+        call_args = mock_upload.call_args
+
+        # Check that the audio bytes were generated
+        assert isinstance(call_args[0][0], bytes)
+
+        # Check that the output file has timestamp and "_end" suffix
+        output_file = call_args[0][1]
+        assert output_file == str(tmp_path) + "/test_audio_000500_end.wav"
+
+        assert result == mock_uploaded_file
 
 
 def test_save_audio_auto_format(tmp_path, catalog):
@@ -228,7 +274,7 @@ def test_audio_fragment_np_file_error(audio_file):
 def test_save_audio_file_error(audio_file, tmp_path):
     """Test save_audio handles errors properly."""
     with patch(
-        "datachain.lib.audio.audio_fragment_bytes", side_effect=Exception("Test error")
+        "datachain.lib.audio.audio_to_bytes", side_effect=Exception("Test error")
     ):
         with pytest.raises(FileError, match="unable to save audio fragment"):
             save_audio(audio_file, output=str(tmp_path), start=0.0, end=1.0)
@@ -246,9 +292,9 @@ def test_audio_fragment_np_different_durations(audio_file, start, duration):
 
 
 @pytest.mark.parametrize("format_type", ["wav", "flac", "ogg"])
-def test_audio_fragment_bytes_formats(audio_file, format_type):
+def test_audio_to_bytes_formats(audio_file, format_type):
     """Test audio conversion to different formats."""
-    audio_bytes = audio_fragment_bytes(audio_file, format=format_type)
+    audio_bytes = audio_to_bytes(audio_file, format_type)
 
     assert isinstance(audio_bytes, bytes)
     assert len(audio_bytes) > 0

--- a/tests/unit/lib/test_audio.py
+++ b/tests/unit/lib/test_audio.py
@@ -9,7 +9,7 @@ from datachain.lib.audio import (
     audio_fragment_bytes,
     audio_fragment_np,
     audio_info,
-    save_audio_fragment,
+    save_audio,
 )
 from datachain.lib.file import Audio, AudioFile, FileError
 
@@ -143,8 +143,8 @@ def test_audio_fragment_bytes_custom_format(audio_file):
     assert len(audio_bytes) > 0
 
 
-def test_save_audio_fragment(audio_file, tmp_path):
-    """Test saving audio fragment."""
+def test_save_audio(audio_file, tmp_path):
+    """Test saving audio (fragment extraction mode)."""
     with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
         # Mock the upload to return a new AudioFile
         mock_uploaded_file = AudioFile(
@@ -152,8 +152,8 @@ def test_save_audio_fragment(audio_file, tmp_path):
         )
         mock_upload.return_value = mock_uploaded_file
 
-        result = save_audio_fragment(
-            audio_file, start=0.5, end=1.5, output=str(tmp_path), format="wav"
+        result = save_audio(
+            audio_file, output=str(tmp_path), format="wav", start=0.5, end=1.5
         )
 
         # Verify AudioFile.upload was called
@@ -173,21 +173,21 @@ def test_save_audio_fragment(audio_file, tmp_path):
         assert result == mock_uploaded_file
 
 
-def test_save_audio_fragment_validation(audio_file, tmp_path):
-    """Test input validation for save_audio_fragment."""
+def test_save_audio_validation(audio_file, tmp_path):
+    """Test input validation for save_audio."""
     with pytest.raises(
-        ValueError, match="Can't save audio fragment.*invalid time range"
+        ValueError, match="Can't save audio.*invalid time range"
     ):
-        save_audio_fragment(audio_file, start=-1.0, end=1.0, output=str(tmp_path))
+        save_audio(audio_file, output=str(tmp_path), start=-1.0, end=1.0)
 
     with pytest.raises(
-        ValueError, match="Can't save audio fragment.*invalid time range"
+        ValueError, match="Can't save audio.*invalid time range"
     ):
-        save_audio_fragment(audio_file, start=2.0, end=1.0, output=str(tmp_path))
+        save_audio(audio_file, output=str(tmp_path), start=2.0, end=1.0)
 
 
-def test_save_audio_fragment_auto_format(tmp_path, catalog):
-    """Test saving audio fragment with auto-detected format."""
+def test_save_audio_auto_format(tmp_path, catalog):
+    """Test saving audio with auto-detected format."""
     audio_data = generate_test_wav(duration=1.0, sample_rate=16000)
     audio_path = tmp_path / "test_audio.flac"
     buffer = io.BytesIO(audio_data)
@@ -201,7 +201,7 @@ def test_save_audio_fragment_auto_format(tmp_path, catalog):
     with patch("datachain.lib.file.AudioFile.upload") as mock_upload:
         mock_upload.return_value = AudioFile(path="test_output.flac", source="file://")
 
-        save_audio_fragment(audio_file, start=0.0, end=1.0, output=str(tmp_path))
+        save_audio(audio_file, output=str(tmp_path), start=0.0, end=1.0)
 
         # Should use format from file extension
         call_args = mock_upload.call_args
@@ -229,13 +229,13 @@ def test_audio_fragment_np_file_error(audio_file):
             audio_fragment_np(audio_file)
 
 
-def test_save_audio_fragment_file_error(audio_file, tmp_path):
-    """Test save_audio_fragment handles errors properly."""
+def test_save_audio_file_error(audio_file, tmp_path):
+    """Test save_audio handles errors properly."""
     with patch(
         "datachain.lib.audio.audio_fragment_bytes", side_effect=Exception("Test error")
     ):
         with pytest.raises(FileError, match="unable to save audio fragment"):
-            save_audio_fragment(audio_file, start=0.0, end=1.0, output=str(tmp_path))
+            save_audio(audio_file, output=str(tmp_path), start=0.0, end=1.0)
 
 
 @pytest.mark.parametrize("start,duration", [(0.0, 1.0), (0.5, 0.5), (1.0, 1.0)])


### PR DESCRIPTION
This code generalizes save_audio_fragment() to use cases when conversion to "mp3" is needed but fragmenting is not.

Also, extends AudioFile.save() and more docs.


## Summary by Sourcery

Add support for converting entire audio files without fragmenting, and refactor save_audio_fragment to unify full-file and segment conversion flows with improved validation and error handling.

New Features:
- Introduce audio_to_bytes helper to convert whole audio files to bytes.
- Allow save_audio_fragment to convert the entire file when start is negative.

Enhancements:
- Refactor save_audio_fragment logic to consolidate fragment and full-file conversion paths.
- Improve time-range validation and error handling in save_audio_fragment.