### PR TITLE
Make job run more resiliant to timeout

### DIFF
--- a/docs/commands/job/run.md
+++ b/docs/commands/job/run.md
@@ -14,6 +14,7 @@ usage: datachain job run [-h] [-v] [-q] [--team TEAM] [--env-file ENV_FILE]
                          [--req-file REQ_FILE] [--req REQ [REQ ...]]
                          [--priority PRIORITY]
                          [--start-time START_TIME] [--cron CRON]
+                         [--no-wait]
                          file
 ```
 
@@ -40,6 +41,7 @@ This command runs a job in Studio using the specified query file. You can config
 * `--priority PRIORITY` - Priority for the job in range 0-5. Lower value is higher priority (default: 5)
 * `--start-time START_TIME` - Time to schedule the task in YYYY-MM-DDTHH:mm format or natural language.
 * `--cron CRON` - Cron expression for the cron task.
+* `--no-wait` - Do not wait for the job to finish.
 * `-h`, `--help` - Show the help message and exit.
 * `-v`, `--verbose` - Be verbose.
 * `-q`, `--quiet` - Be quiet.
@@ -129,6 +131,12 @@ datachain job run --cron "@monthly" query.py
 ```bash
 # Start the cron job after tomorrow 3pm
 datachain job run --start-time "tomorrow 3pm" --cron "0 0 * * *" query.py
+```
+
+12. Start the job and do not wait for the job to complete
+```bash
+# Do not follow or tail the logs from Studio.
+datachain job run query.py --no-wait
 ```
 
 ## Notes

--- a/src/datachain/cli/parser/job.py
+++ b/src/datachain/cli/parser/job.py
@@ -109,6 +109,11 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
     studio_run_parser.add_argument(
         "--cron", action="store", help="Cron expression for the cron task."
     )
+    studio_run_parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Do not wait for the job to finish",
+    )
 
     studio_ls_help = "List jobs in Studio"
     studio_ls_description = "List jobs in Studio."

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -394,10 +394,7 @@ def create_job(
     print("Open the job in Studio at", response.data.get("job", {}).get("url"))
     print("=" * 40)
 
-    if no_wait:
-        return 0
-
-    return show_logs_from_client(client, job_id)
+    return 0 if no_wait else show_logs_from_client(client, job_id)
 
 
 def upload_files(client: StudioClient, files: list[str]) -> list[str]:


### PR DESCRIPTION
When a job starts following the logs and after certain idle timeout, it
exits previously. This now keeps the job run command restart the
connection if the job is not finished.
Closes #1259

## Summary by Sourcery

Allow the job run command to automatically retry log streaming until completion and introduce an option to skip waiting.

New Features:
- Add --no-wait flag to job run to start a job without tailing logs or waiting for it to finish

Enhancements:
- Wrap log streaming in a loop to reconnect after idle timeouts and exit only when the job reaches a finished state

Documentation:
- Document the new --no-wait option in the job run command reference