### PR TITLE
Hide duplicate job status messages in CLI output

### DIFF
--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -290,6 +290,7 @@ def show_logs_from_client(client, job_id):
     # Sync usage
     async def _run():
         latest_status = None
+        processed_statuses = set()
         while True:
             async for message in client.tail_job_logs(job_id):
                 if "logs" in message:
@@ -297,6 +298,9 @@ def show_logs_from_client(client, job_id):
                         print(log["message"], end="")
                 elif "job" in message:
                     latest_status = message["job"]["status"]
+                    if latest_status in processed_statuses:
+                        continue
+                    processed_statuses.add(latest_status)
                     print(f"\n>>>> Job is now in {latest_status} status.")
 
             if latest_status and JobStatus[latest_status].finished():


### PR DESCRIPTION
When jobs fail during worker provisioning and get rescheduled, the CLI output shows repeated status transitions (CREATED → SCHEDULED → CREATED) which creates confusing and noisy output for users. This happens due to the following flow:
- Job starts in CREATED status
- System schedules the job (SCHEDULED status)
- Worker provisioning fails (insufficient resources, quota exceeded, etc.)
- Job gets released back to CREATED status
- Process repeats, causing duplicate status messages

Added a processed_statuses set to track which job statuses have already been printed to the CLI output. This prevents duplicate status messages from appearing when jobs are rescheduled due to provisioning failures.

- Added logic to skip printing status if it has already been processed
- Only prints status changes that haven't been seen before

More context: https://iterativeai.slack.com/archives/C04A9RWEZBN/p1753686807725269

## Summary by Sourcery

Suppress duplicate job status messages in CLI output by tracking and printing each status only once

Bug Fixes:
- Prevent repeated status transitions from appearing when jobs are rescheduled due to provisioning failures

Enhancements:
- Add a processed_statuses set to record and skip already printed job statuses