### PR TITLE
Skip 'test_hf_audio' huggingface test

### DIFF
--- a/tests/func/test_hf.py
+++ b/tests/func/test_hf.py
@@ -119,6 +119,7 @@ def test_hf_image(tmp_path):
     assert row.image.img == image_to_bytes(img)
 
 
+@pytest.mark.skip("fails with 'NotImplementedError', need to investigate")
 @require_torchcodec
 def test_hf_audio(tmp_path):
     # See https://stackoverflow.com/questions/66191480/how-to-convert-a-numpy-array-to-a-mp3-file


### PR DESCRIPTION
```
    def __call__(self, /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
>       return self._op(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
E       NotImplementedError: There were no tensor arguments to this function (e.g., you passed an empty list of Tensors), but no fallback function is registered for schema torchcodec_ns::create_from_file.  This usually means that this function requires a non-empty list of Tensors, or that you (the operator writer) forgot to register a fallback function.  Available functions are [Meta, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradXLA, AutogradMPS, AutogradXPU, AutogradHPU, AutogradLazy, AutogradMTIA, AutogradMAIA, AutogradMeta, Tracer, AutocastCPU, AutocastMTIA, AutocastMAIA, AutocastXPU, AutocastMPS, AutocastCUDA, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
```

## Summary by Sourcery

Tests:
- Mark test_hf_audio as skipped due to a NotImplementedError failure