### PR TITLE
Revert "Skip 'test_hf_audio' huggingface test"

### DIFF
--- a/tests/func/test_hf.py
+++ b/tests/func/test_hf.py
@@ -119,7 +119,6 @@ def test_hf_image(tmp_path):
     assert row.image.img == image_to_bytes(img)
 
 
-@pytest.mark.skip("fails with 'NotImplementedError', need to investigate")
 @require_torchcodec
 def test_hf_audio(tmp_path):
     # See https://stackoverflow.com/questions/66191480/how-to-convert-a-numpy-array-to-a-mp3-file


### PR DESCRIPTION
Reverts iterative/datachain#1277

Torchcodec 0.6 was released.

## Summary by Sourcery

Tests:
- Remove skip marker from test_hf_audio to run the HF audio test again