### PR TITLE
Introduce batch_size in mb limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dependencies = [
   "dvc-studio-client>=0.21,<1",
   "tabulate",
   "websockets",
-  "tomli;python_version<'3.11'"
+  "tomli;python_version<'3.11'",
+  "Pympler"
 ]
 
 [project.optional-dependencies]

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -325,6 +325,7 @@ class DataChain:
         namespace: Optional[str] = None,
         project: Optional[str] = None,
         batch_rows: Optional[int] = None,
+        batch_mb: Optional[float] = None,
     ) -> "Self":
         """Change settings for chain.
 
@@ -344,7 +345,8 @@ class DataChain:
             project : project name.
             batch_rows : row limit per insert to balance speed and memory usage.
                       (default=2000)
-
+            batch_mb : memory limit per insert to balance speed and memory usage.
+                      (default=1000)
         Example:
             ```py
             chain = (
@@ -367,6 +369,7 @@ class DataChain:
                 namespace,
                 project,
                 batch_rows,
+                batch_mb,
             )
         )
         return self._evolve(settings=settings, _sys=sys)
@@ -721,7 +724,9 @@ class DataChain:
 
         return self._evolve(
             query=self._query.add_signals(
-                udf_obj.to_udf_wrapper(self._settings.batch_rows),
+                udf_obj.to_udf_wrapper(
+                    self._settings.batch_rows, self._settings.batch_mb
+                ),
                 **self._settings.to_dict(),
             ),
             signal_schema=self.signals_schema | udf_obj.output,
@@ -759,7 +764,9 @@ class DataChain:
             udf_obj.prefetch = prefetch
         return self._evolve(
             query=self._query.generate(
-                udf_obj.to_udf_wrapper(self._settings.batch_rows),
+                udf_obj.to_udf_wrapper(
+                    self._settings.batch_rows, self._settings.batch_mb
+                ),
                 **self._settings.to_dict(),
             ),
             signal_schema=udf_obj.output,
@@ -895,7 +902,9 @@ class DataChain:
         udf_obj = self._udf_to_obj(Aggregator, func, params, output, signal_map)
         return self._evolve(
             query=self._query.generate(
-                udf_obj.to_udf_wrapper(self._settings.batch_rows),
+                udf_obj.to_udf_wrapper(
+                    self._settings.batch_rows, self._settings.batch_mb
+                ),
                 partition_by=processed_partition_by,
                 **self._settings.to_dict(),
             ),
@@ -944,7 +953,9 @@ class DataChain:
 
         return self._evolve(
             query=self._query.add_signals(
-                udf_obj.to_udf_wrapper(self._settings.batch_rows, batch=batch),
+                udf_obj.to_udf_wrapper(
+                    self._settings.batch_rows, self._settings.batch_mb, batch=batch
+                ),
                 **self._settings.to_dict(),
             ),
             signal_schema=self.signals_schema | udf_obj.output,

--- a/src/datachain/lib/settings.py
+++ b/src/datachain/lib/settings.py
@@ -18,6 +18,7 @@ class Settings:
         namespace=None,
         project=None,
         batch_rows=None,
+        batch_mb=None,
     ):
         self._cache = cache
         self.parallel = parallel
@@ -26,7 +27,19 @@ class Settings:
         self.prefetch = prefetch
         self.namespace = namespace
         self.project = project
-        self._chunk_rows = batch_rows
+        self._batch_rows = batch_rows
+        self._batch_mb = batch_mb
+
+        if batch_mb is not None and not isinstance(batch_mb, (float, int)):
+            raise SettingsError(
+                "'batch_mb' argument must be float or None"
+                f", {batch_mb.__class__.__name__} was given"
+            )
+
+        if batch_mb is not None and batch_mb <= 0:
+            raise SettingsError(
+                f"'batch_mb' argument must be positive float, {batch_mb} was given"
+            )
 
         if not isinstance(cache, bool) and cache is not None:
             raise SettingsError(
@@ -78,7 +91,11 @@ class Settings:
 
     @property
     def batch_rows(self):
-        return self._chunk_rows if self._chunk_rows is not None else DEFAULT_CHUNK_ROWS
+        return self._batch_rows if self._batch_rows is not None else DEFAULT_CHUNK_ROWS
+
+    @property
+    def batch_mb(self):
+        return self._batch_mb
 
     def to_dict(self):
         res = {}
@@ -94,8 +111,10 @@ class Settings:
             res["namespace"] = self.namespace
         if self.project is not None:
             res["project"] = self.project
-        if self._chunk_rows is not None:
-            res["batch_rows"] = self._chunk_rows
+        if self._batch_rows is not None:
+            res["batch_rows"] = self._batch_rows
+        if self._batch_mb is not None:
+            res["batch_mb"] = self._batch_mb
         return res
 
     def add(self, settings: "Settings"):
@@ -107,5 +126,7 @@ class Settings:
         self.project = settings.project or self.project
         if settings.prefetch is not None:
             self.prefetch = settings.prefetch
-        if settings._chunk_rows is not None:
-            self._chunk_rows = settings._chunk_rows
+        if settings._batch_rows is not None:
+            self._batch_rows = settings._batch_rows
+        if settings._batch_mb is not None:
+            self._batch_mb = settings._batch_mb

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -65,12 +65,17 @@ class UDFProperties:
     def batch_rows(self):
         return self.udf.batch_rows
 
+    @property
+    def batch_mb(self):
+        return self.udf.batch_mb
+
 
 @attrs.define(slots=False)
 class UDFAdapter:
     inner: "UDFBase"
     output: UDFOutputSpec
     batch_rows: Optional[int] = None
+    batch_mb: Optional[float] = None
     batch: int = 1
 
     def get_batching(self, use_partitioning: bool = False) -> BatchingStrategy:
@@ -238,12 +243,14 @@ class UDFBase(AbstractUDF):
     def to_udf_wrapper(
         self,
         batch_rows: Optional[int] = None,
+        batch_mb: Optional[float] = None,
         batch: int = 1,
     ) -> UDFAdapter:
         return UDFAdapter(
             self,
             self.output.to_udf_spec(),
             batch_rows,
+            batch_mb,
             batch,
         )
 

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import posixpath
 import re
+import sys
 import uuid
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
@@ -2424,8 +2425,9 @@ def test_agg_sample(catalog_tmpfile, parallel, sample):
 
 def test_batch_for_map(test_session):
     # Create a chain with batch settings
+    batch_mb = sys.getsizeof(1) / 1024 * 10
     chain = dc.read_values(x=list(range(100)), session=test_session)
-    chain_with_settings = chain.settings(batch_rows=15)
+    chain_with_settings = chain.settings(batch_rows=15, batch_mb=batch_mb)
 
     def add_one(x):
         return x + 1

--- a/tests/unit/lib/test_settings.py
+++ b/tests/unit/lib/test_settings.py
@@ -8,25 +8,30 @@ def test_settings_defaults_and_custom():
     # Default values
     settings = Settings()
     assert settings.batch_rows == 2000
+    assert settings.batch_mb is None
 
     # Custom values
-    settings = Settings(batch_rows=500)
+    settings = Settings(batch_rows=500, batch_mb=100)
     assert settings.batch_rows == 500
+    assert settings.batch_mb == 100
 
     # to_dict method
     d = settings.to_dict()
     assert d["batch_rows"] == 500
+    assert d["batch_mb"] == 100
 
     # Chaining
     s2 = settings
     s3 = s2
     assert s3.batch_rows == 500
+    assert s3.batch_mb == 100
 
 
 def test_settings_validation():
     # Valid
-    settings = Settings(batch_rows=100)
+    settings = Settings(batch_rows=100, batch_mb=100)
     assert settings.batch_rows == 100
+    assert settings.batch_mb == 100
 
     # Invalid batch_rows
     with pytest.raises(SettingsError):
@@ -36,26 +41,36 @@ def test_settings_validation():
     with pytest.raises(SettingsError):
         Settings(batch_rows=0)
 
+    # Invalid batch_mb
+    with pytest.raises(SettingsError):
+        Settings(batch_mb="invalid")
+
+    # Zero batch_mb
+    with pytest.raises(SettingsError):
+        Settings(batch_mb=0)
+
 
 def test_settings_add():
     """Test Settings.add() method with batch_rows."""
     # Create base settings
-    base_settings = Settings(batch_rows=1000)
+    base_settings = Settings(batch_rows=1000, batch_mb=100)
 
     # Create settings to add
-    add_settings = Settings(batch_rows=2000)
+    add_settings = Settings(batch_rows=2000, batch_mb=200)
 
     # Add settings
     base_settings.add(add_settings)
 
     # Verify that values from add_settings override base_settings
     assert base_settings.batch_rows == 2000
+    assert base_settings.batch_mb == 200
 
     # Test with None values (should not override)
-    base_settings = Settings(batch_rows=1000)
-    none_settings = Settings(batch_rows=None)
+    base_settings = Settings(batch_rows=1000, batch_mb=100)
+    none_settings = Settings(batch_rows=None, batch_mb=None)
 
     base_settings.add(none_settings)
 
     # Verify that None values don't override existing values
     assert base_settings.batch_rows == 1000
+    assert base_settings.batch_mb == 100


### PR DESCRIPTION
Similar to how we implemented batch_rows, this implements batch_mb
settings which when available, enables the batching based on size as
well as system memory.

Closes #1262

## Summary by Sourcery

Enable batching by memory usage by introducing the batch_mb parameter and MemoryTracker integration

New Features:
- Add optional batch_mb parameter for memory-based batching alongside batch_rows
- Implement MemoryTracker to measure object sizes and enforce memory thresholds

Enhancements:
- Propagate batch_mb through Settings, core batch functions, UDF adapters, dataset processing, and DataChain API methods
- Add validation, properties, and merging logic for batch_mb in Settings

Build:
- Add Pympler dependency for memory sizing

Tests:
- Extend unit tests for Settings and functional tests to cover batch_mb behavior