### PR TITLE
feat: add to_database (aka to_sql)

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -21,6 +21,7 @@ from datachain.lib.file import File
 from datachain.lib.signal_schema import SignalSchema
 from datachain.node import DirType, DirTypeGroup, Node, NodeWithPath, get_path
 from datachain.query.batch import RowsOutput
+from datachain.query.schema import ColumnMeta
 from datachain.query.utils import get_query_id_column
 from datachain.sql.functions import path as pathfunc
 from datachain.sql.types import Int, SQLType
@@ -400,7 +401,7 @@ class AbstractWarehouse(ABC, Serializable):
         expressions: tuple[_ColumnsClauseArgument[Any], ...] = (
             sa.func.count(table.c.sys__id),
         )
-        size_column_names = [s.replace(".", "__") + "__size" for s in file_signals]
+        size_column_names = [ColumnMeta.to_db_name(s) + "__size" for s in file_signals]
         size_columns = [c for c in table.columns if c.name in size_column_names]
 
         if size_columns:

--- a/src/datachain/lib/dc/database.py
+++ b/src/datachain/lib/dc/database.py
@@ -72,7 +72,7 @@ def to_database(
     table_name: str,
     connection: "ConnectionType",
     *,
-    batch_size: int = DEFAULT_DATABASE_BATCH_SIZE,
+    batch_rows: int = DEFAULT_DATABASE_BATCH_SIZE,
     on_conflict: Optional[str] = None,
     column_mapping: Optional[dict[str, Optional[str]]] = None,
 ) -> None:
@@ -113,7 +113,7 @@ def to_database(
         try:
             table.create(conn, checkfirst=True)
             rows_iter = chain._leaf_values()
-            for batch in batched(rows_iter, batch_size):
+            for batch in batched(rows_iter, batch_rows):
                 _process_batch(
                     conn, table, batch, on_conflict, column_indices_and_names
                 )

--- a/src/datachain/lib/dc/database.py
+++ b/src/datachain/lib/dc/database.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import sqlalchemy
 
+DEFAULT_DATABASE_BATCH_SIZE = 10_000
+
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
@@ -63,7 +65,7 @@ def to_database(
     table_name: str,
     connection: "ConnectionType",
     *,
-    batch_size: int = 10000,
+    batch_size: int = DEFAULT_DATABASE_BATCH_SIZE,
     on_conflict: Optional[str] = None,
     column_mapping: Optional[dict[str, Optional[str]]] = None,
 ) -> None:

--- a/src/datachain/lib/dc/database.py
+++ b/src/datachain/lib/dc/database.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 @contextlib.contextmanager
 def _connect(
     connection: "ConnectionType",
-) -> "Iterator[Union[sqlalchemy.engine.Connection, sqlalchemy.orm.Session]]":
+) -> "Iterator[sqlalchemy.engine.Connection]":
     import sqlalchemy.orm
 
     with contextlib.ExitStack() as stack:
@@ -47,27 +47,178 @@ def _connect(
             yield engine.connect()
         elif isinstance(connection, sqlalchemy.Engine):
             yield stack.enter_context(connection.connect())
-        elif isinstance(connection, (sqlalchemy.Connection, sqlalchemy.orm.Session)):
+        elif isinstance(connection, sqlalchemy.Connection):
             # do not close the connection, as it is managed by the caller
             yield connection
+        elif isinstance(connection, sqlalchemy.orm.Session):
+            # For Session objects, we need to use the underlying connection
+            # Sessions don't support DDL operations directly
+            yield connection.connection()
         else:
             raise TypeError(f"Unsupported connection type: {type(connection).__name__}")
 
 
-def _infer_schema(
-    result: "sqlalchemy.engine.Result",
-    to_infer: list[str],
-    infer_schema_length: Optional[int] = 100,
-) -> tuple[list["sqlalchemy.Row"], dict[str, "DataType"]]:
-    from datachain.lib.convert.values_to_tuples import values_to_tuples
+def to_database(
+    chain: "DataChain",
+    table_name: str,
+    connection: "ConnectionType",
+    *,
+    batch_size: int = 10000,
+    on_conflict: Optional[str] = None,
+    column_mapping: Optional[dict[str, Optional[str]]] = None,
+) -> None:
+    """
+    Implementation function for exporting DataChain to database tables.
 
-    if not to_infer:
-        return [], {}
+    This is the core implementation that handles the actual database operations.
+    For user-facing documentation, see DataChain.to_database() method.
+    """
+    from datachain.utils import batched
 
-    rows = list(itertools.islice(result, infer_schema_length))
-    values = {col: [row._mapping[col] for row in rows] for col in to_infer}
-    _, output_schema, _ = values_to_tuples("", **values)
-    return rows, output_schema
+    if on_conflict and on_conflict not in ("ignore", "update"):
+        raise ValueError(
+            f"on_conflict must be 'ignore' or 'update', got: {on_conflict}"
+        )
+
+    # Get the schema from the chain
+    signals_schema = chain.signals_schema.clone_without_sys_signals()
+    all_columns = [
+        sqlalchemy.Column(c.name, c.type)  # type: ignore[union-attr]
+        for c in signals_schema.db_signals(as_columns=True)
+    ]
+
+    column_mapping = column_mapping or {}
+    # Normalize column mapping to handle DataChain format (dots) in keys
+    normalized_column_mapping = _normalize_column_mapping(column_mapping)
+    column_indices_and_names, columns = _prepare_columns(
+        all_columns, normalized_column_mapping
+    )
+
+    with _connect(connection) as conn:
+        metadata = sqlalchemy.MetaData()
+        table = sqlalchemy.Table(table_name, metadata, *columns)
+
+        # Check if table already exists to determine if we should clean up on error
+        inspector = sqlalchemy.inspect(conn)
+        if inspector is None:
+            raise RuntimeError("Failed to create database inspector")
+        table_existed_before = table_name in inspector.get_table_names()
+
+        try:
+            table.create(conn, checkfirst=True)
+            rows_iter = chain._leaf_values()
+
+            for batch in batched(rows_iter, batch_size):
+                _process_batch(
+                    conn, table, batch, on_conflict, column_indices_and_names
+                )
+
+            conn.commit()
+        except Exception:
+            # If table didn't exist before and we created it, clean it up on error
+            if not table_existed_before:
+                try:
+                    table.drop(conn, checkfirst=True)
+                    conn.commit()
+                except sqlalchemy.exc.SQLAlchemyError:
+                    # Ignore cleanup errors - the table may already be dropped
+                    # or there may be permission issues
+                    pass
+            raise
+
+
+def _normalize_column_mapping(column_mapping):
+    """
+    Convert column mapping keys from DataChain format (dots) to database format
+    (double underscores).
+
+    This allows users to specify column mappings using the intuitive DataChain
+    format like: {"nested_data.value": "data_value"} instead of
+    {"nested_data__value": "data_value"}
+    """
+    if not column_mapping:
+        return {}
+
+    normalized_mapping = {}
+    for key, value in column_mapping.items():
+        # Convert dots to double underscores for database column format
+        db_key = key.replace(".", "__")
+        normalized_mapping[db_key] = value
+
+    # If it's a defaultdict, preserve the default factory
+    if hasattr(column_mapping, "default_factory"):
+        from collections import defaultdict
+
+        default_factory = column_mapping.default_factory
+        result = defaultdict(default_factory)
+        result.update(normalized_mapping)
+        return result
+
+    return normalized_mapping
+
+
+def _prepare_columns(all_columns, column_mapping):
+    """Prepare column mapping and column definitions."""
+    column_indices_and_names = []  # List of (index, target_name) tuples
+    columns = []
+    for idx, col in enumerate(all_columns):
+        if col.name in column_mapping or hasattr(column_mapping, "default_factory"):
+            mapped_name = column_mapping[col.name]
+            if mapped_name:
+                columns.append(sqlalchemy.Column(mapped_name, col.type))
+                column_indices_and_names.append((idx, mapped_name))
+        else:
+            columns.append(col)
+            column_indices_and_names.append((idx, col.name))
+    return column_indices_and_names, columns
+
+
+def _process_batch(conn, table, batch, on_conflict, column_indices_and_names):
+    """Process a batch of rows with conflict resolution."""
+
+    def prepare_row(row_values):
+        """Convert a row tuple to a dictionary with proper DB column names."""
+        return {
+            target_name: row_values[idx]
+            for idx, target_name in column_indices_and_names
+        }
+
+    rows_to_insert = [prepare_row(row) for row in batch]
+
+    supports_conflict = on_conflict and conn.engine.name in ("postgresql", "sqlite")
+
+    if supports_conflict:
+        # Use dialect-specific insert for conflict resolution
+        if conn.engine.name == "postgresql":
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+            insert_stmt = pg_insert(table)
+        elif conn.engine.name == "sqlite":
+            from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+            insert_stmt = sqlite_insert(table)
+    else:
+        insert_stmt = table.insert()
+
+    if supports_conflict:
+        if on_conflict == "ignore":
+            insert_stmt = insert_stmt.on_conflict_do_nothing()
+        elif on_conflict == "update":
+            update_values = {
+                col.name: insert_stmt.excluded[col.name] for col in table.columns
+            }
+            insert_stmt = insert_stmt.on_conflict_do_update(set_=update_values)
+    elif on_conflict:
+        import warnings
+
+        warnings.warn(
+            f"Database does not support conflict resolution. "
+            f"Ignoring on_conflict='{on_conflict}' parameter.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    conn.execute(insert_stmt, rows_to_insert)
 
 
 def read_database(
@@ -151,3 +302,19 @@ def read_database(
             in_memory=in_memory,
             schema=inferred_schema | output,
         )
+
+
+def _infer_schema(
+    result: "sqlalchemy.engine.Result",
+    to_infer: list[str],
+    infer_schema_length: Optional[int] = 100,
+) -> tuple[list["sqlalchemy.Row"], dict[str, "DataType"]]:
+    from datachain.lib.convert.values_to_tuples import values_to_tuples
+
+    if not to_infer:
+        return [], {}
+
+    rows = list(itertools.islice(result, infer_schema_length))
+    values = {col: [row._mapping[col] for row in rows] for col in to_infer}
+    _, output_schema, _ = values_to_tuples("", **values)
+    return rows, output_schema

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -2294,7 +2294,7 @@ class DataChain:
         table_name: str,
         connection: "ConnectionType",
         *,
-        batch_size: int = DEFAULT_DATABASE_BATCH_SIZE,
+        batch_rows: int = DEFAULT_DATABASE_BATCH_SIZE,
         on_conflict: Optional[str] = None,
         column_mapping: Optional[dict[str, Optional[str]]] = None,
     ) -> None:
@@ -2311,7 +2311,7 @@ class DataChain:
                 library. If a DBAPI2 object, only sqlite3 is supported. The user is
                 responsible for engine disposal and connection closure for the
                 SQLAlchemy connectable; str connections are closed automatically.
-            batch_size: Number of rows to insert per batch for optimal performance.
+            batch_rows: Number of rows to insert per batch for optimal performance.
                 Larger batches are faster but use more memory. Default: 10,000.
             on_conflict: Strategy for handling duplicate rows (requires table
                 constraints):
@@ -2375,7 +2375,7 @@ class DataChain:
             self,
             table_name,
             connection,
-            batch_size=batch_size,
+            batch_rows=batch_rows,
             on_conflict=on_conflict,
             column_mapping=column_mapping,
         )

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -2306,17 +2306,17 @@ class DataChain:
 
         Parameters:
             table_name: Name of the database table to create/write to.
-            connection: Database connection. Supports:
-                - SQLAlchemy Engine, Connection, or Session objects
-                - Connection strings (e.g., "postgresql://user:pass@host/db")
-                - sqlite3.Connection objects
-                Note: For SQLAlchemy objects, you're responsible for engine disposal
-                and connection closure. String connections are managed automatically.
+            connection: SQLAlchemy connectable, str, or a sqlite3 connection
+                Using SQLAlchemy makes it possible to use any DB supported by that
+                library. If a DBAPI2 object, only sqlite3 is supported. The user is
+                responsible for engine disposal and connection closure for the
+                SQLAlchemy connectable; str connections are closed automatically.
             batch_size: Number of rows to insert per batch for optimal performance.
                 Larger batches are faster but use more memory. Default: 10,000.
             on_conflict: Strategy for handling duplicate rows (requires table
                 constraints):
-                - None: Raise error on conflict (default)
+                - None: Raise error (`sqlalchemy.exc.IntegrityError`) on conflict
+                  (default)
                 - "ignore": Skip duplicate rows silently
                 - "update": Update existing rows with new values
             column_mapping: Optional mapping to rename or skip columns:

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -34,7 +34,7 @@ from datachain.lib.data_model import DataModel, DataType, DataValue
 from datachain.lib.file import File
 from datachain.lib.model_store import ModelStore
 from datachain.lib.utils import DataChainParamsError
-from datachain.query.schema import DEFAULT_DELIMITER, Column
+from datachain.query.schema import DEFAULT_DELIMITER, Column, ColumnMeta
 from datachain.sql.types import SQLType
 
 if TYPE_CHECKING:
@@ -590,7 +590,7 @@ class SignalSchema:
 
         if name:
             if "." in name:
-                name = name.replace(".", "__")
+                name = ColumnMeta.to_db_name(name)
 
             signals = [
                 s

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -93,7 +93,6 @@ def test_multimodal(example):
 
 
 @pytest.mark.examples
-@pytest.mark.incremental_processing
 @pytest.mark.parametrize("example", incremental_processing_examples)
 def test_incremental_processing_examples(example):
     smoke_test(example)

--- a/tests/func/test_to_database.py
+++ b/tests/func/test_to_database.py
@@ -680,8 +680,10 @@ def test_to_database_invalid_on_conflict_value(connection, test_session):
         chain.to_database("test_table", connection, on_conflict="invalid")
 
 
-def test_to_database_with_null_values(connection, test_session):
+def test_to_database_with_null_values(connection, test_session, warehouse):
     """Test to_database handles NULL values correctly."""
+    from datachain.data_storage.sqlite import SQLiteWarehouse
+
     chain = dc.read_values(
         id=[1, 2, 3, 4],
         name=["Alice", None, "Charlie", "Diana"],
@@ -696,10 +698,14 @@ def test_to_database_with_null_values(connection, test_session):
         result = conn.execute(sqlalchemy.text("SELECT * FROM null_table ORDER BY id"))
         rows = result.fetchall()
 
+    # Different warehouse implementations handle NULL values differently
+    default_str_value = None if isinstance(warehouse, SQLiteWarehouse) else ""
+    default_int_value = None if isinstance(warehouse, SQLiteWarehouse) else 0
+
     assert len(rows) == 4
     assert rows[0] == (1, "Alice", 25)
-    assert rows[1] == (2, None, 30)
-    assert rows[2] == (3, "Charlie", None)
+    assert rows[1] == (2, default_str_value, 30)
+    assert rows[2] == (3, "Charlie", default_int_value)
     assert rows[3] == (4, "Diana", 28)
 
 

--- a/tests/func/test_to_database.py
+++ b/tests/func/test_to_database.py
@@ -148,7 +148,7 @@ def test_to_database_large_dataset(connection, test_session):
         session=test_session,
     )
 
-    chain.to_database("large_table", connection, batch_size=1000)
+    chain.to_database("large_table", connection, batch_rows=1000)
 
     engine = _get_engine_from_connection(connection)
     with engine.connect() as conn:

--- a/tests/func/test_to_database.py
+++ b/tests/func/test_to_database.py
@@ -124,7 +124,6 @@ def test_to_database_with_complex_types(connection, test_session):
 
     assert len(rows) == 3
 
-    # Verify the table schema: DataModel fields are flattened with double underscores
     engine = _get_engine_from_connection(connection)
     with engine.connect() as conn:
         result = conn.execute(sqlalchemy.text("PRAGMA table_info(user_profiles)"))
@@ -133,13 +132,11 @@ def test_to_database_with_complex_types(connection, test_session):
     expected_columns = ["id", "profile__name", "profile__settings", "profile__tags"]
     assert columns == expected_columns
 
-    # Verify a sample row to confirm data structure and JSON serialization
-    # Complex types (dict, list) are serialized as JSON strings
     first_row = rows[0]
     assert first_row[0] == 1
     assert first_row[1] == "Alice"
     assert first_row[2] == '{"theme": "dark", "notifications": true}'
-    assert first_row[3] == '["admin","vip"]'  # JSON array (no spaces after commas)
+    assert first_row[3] == '["admin","vip"]'
 
 
 def test_to_database_large_dataset(connection, test_session):

--- a/tests/func/test_to_database.py
+++ b/tests/func/test_to_database.py
@@ -1,0 +1,806 @@
+import sqlite3
+from contextlib import closing
+from typing import Any
+
+import pytest
+import sqlalchemy
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+import datachain as dc
+from datachain.lib.dc.database import to_database
+
+
+@pytest.fixture
+def db_uri():
+    return "sqlite:///:memory:"
+
+
+@pytest.fixture
+def db_engine(db_uri):
+    engine = sqlalchemy.create_engine(db_uri)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def db_connection(db_engine):
+    with closing(db_engine.connect()) as conn:
+        yield conn
+
+
+@pytest.fixture
+def db_session(db_engine):
+    with Session(bind=db_engine) as session:
+        yield session
+
+
+@pytest.fixture
+def sqlite3_connection():
+    with sqlite3.connect(":memory:") as conn:
+        yield conn
+
+
+@pytest.fixture(
+    params=(
+        "db_connection",
+        "db_engine",
+        "db_session",
+        "sqlite3_connection",
+    )
+)
+def connection(request):
+    return request.getfixturevalue(request.param)
+
+
+def test_basic_to_database(tmp_dir, connection):
+    """Test basic functionality with actual DataChain data."""
+    # Create DataChain with sample data
+    chain = dc.read_values(
+        id=[1, 2, 3], name=["Alice", "Bob", "Charlie"], age=[25, 30, 35]
+    )
+
+    # Export to database
+    to_database(chain, "users", connection)
+
+    # Verify data was written
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT * FROM users ORDER BY id")).fetchall()
+        assert len(result) == 3
+        assert result[0] == (1, "Alice", 25)
+        assert result[1] == (2, "Bob", 30)
+        assert result[2] == (3, "Charlie", 35)
+
+
+def test_to_database_with_uri(db_uri):
+    """Test basic functionality with URI connection string."""
+    # Create DataChain with sample data
+    chain = dc.read_values(
+        id=[1, 2, 3], name=["Alice", "Bob", "Charlie"], age=[25, 30, 35]
+    )
+
+    # Export to database - this should complete without errors
+    to_database(chain, "users", db_uri)
+
+    # URI connections create isolated databases, so we can't verify externally
+    # The absence of exceptions indicates success
+
+
+def test_to_database_with_complex_types(connection, test_session):
+    """Test to_database with complex data types including nested structures."""
+
+    class UserProfile(dc.DataModel):
+        name: str
+        settings: dict
+        tags: list[str]
+
+    chain = dc.read_values(
+        id=[1, 2, 3],
+        profile=[
+            UserProfile(
+                name="Alice",
+                settings={"theme": "dark", "notifications": True},
+                tags=["admin", "vip"],
+            ),
+            UserProfile(
+                name="Bob",
+                settings={"theme": "light", "notifications": False},
+                tags=["user"],
+            ),
+            UserProfile(
+                name="Charlie",
+                settings={"theme": "auto", "notifications": True},
+                tags=["user", "beta"],
+            ),
+        ],
+        session=test_session,
+    )
+
+    to_database(chain, "user_profiles", connection)
+
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(
+            sqlalchemy.text("SELECT * FROM user_profiles ORDER BY id")
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 3
+    # The exact format will depend on how DataModels are serialized to database
+
+
+def test_to_database_large_dataset(connection, test_session):
+    """Test to_database with large amount of data and custom batch size."""
+    large_size = 10000
+    chain = dc.read_values(
+        id=list(range(large_size)),
+        value=[f"value_{i}" for i in range(large_size)],
+        number=[i * 2.5 for i in range(large_size)],
+        session=test_session,
+    )
+
+    to_database(chain, "large_table", connection, batch_size=1000)
+
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT COUNT(*) FROM large_table"))
+        count = result.scalar()
+
+    assert count == large_size
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            sqlalchemy.text(
+                "SELECT * FROM large_table WHERE id IN (0, 999, 5000, 9999) ORDER BY id"
+            )
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 4
+    assert rows[0] == (0, "value_0", 0.0)
+    assert rows[1] == (999, "value_999", 2497.5)
+    assert rows[2] == (5000, "value_5000", 12500.0)
+    assert rows[3] == (9999, "value_9999", 24997.5)
+
+
+def test_to_database_on_conflict_ignore(db_engine, test_session):
+    """Test to_database with on_conflict='ignore' for duplicate handling."""
+    # Create table with primary key for conflict testing
+    with db_engine.connect() as conn:
+        with conn.begin():
+            conn.execute(
+                sqlalchemy.text("""
+                CREATE TABLE conflict_test (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT,
+                    value INTEGER
+                )
+            """)
+            )
+            conn.execute(
+                sqlalchemy.text(
+                    "INSERT INTO conflict_test VALUES "
+                    "(1, 'Alice', 100), (2, 'Bob', 200), (3, 'Charlie', 300)"
+                )
+            )
+
+    # Create overlapping data
+    conflict_chain = dc.read_values(
+        id=[2, 3, 4, 5],  # 2 and 3 will conflict
+        name=["Bob_Updated", "Charlie_Updated", "Diana", "Eve"],
+        value=[999, 888, 400, 500],
+        session=test_session,
+    )
+
+    # Insert with conflict resolution
+    to_database(conflict_chain, "conflict_test", db_engine, on_conflict="ignore")
+
+    # Verify original data is preserved and new data added
+    with db_engine.connect() as conn:
+        result = conn.execute(
+            sqlalchemy.text("SELECT * FROM conflict_test ORDER BY id")
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 5
+    assert rows[0] == (1, "Alice", 100)  # Original
+    assert rows[1] == (2, "Bob", 200)  # Original (conflict ignored)
+    assert rows[2] == (3, "Charlie", 300)  # Original (conflict ignored)
+    assert rows[3] == (4, "Diana", 400)  # New
+    assert rows[4] == (5, "Eve", 500)  # New
+
+
+def test_to_database_on_conflict_update(db_engine, test_session):
+    """Test to_database with on_conflict='update' for duplicate handling."""
+    # First insert with primary key table
+    with db_engine.connect() as conn:
+        with conn.begin():
+            conn.execute(
+                sqlalchemy.text("""
+                CREATE TABLE update_test (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT,
+                    value INTEGER
+                )
+            """)
+            )
+            conn.execute(
+                sqlalchemy.text(
+                    "INSERT INTO update_test VALUES "
+                    "(1, 'Alice', 100), (2, 'Bob', 200), (3, 'Charlie', 300)"
+                )
+            )
+
+    # Create overlapping data with updates
+    update_chain = dc.read_values(
+        id=[2, 3, 4, 5],  # 2 and 3 will update existing records
+        name=["Bob_Updated", "Charlie_Updated", "Diana", "Eve"],
+        value=[999, 888, 400, 500],
+        session=test_session,
+    )
+
+    # Insert with conflict resolution
+    to_database(update_chain, "update_test", db_engine, on_conflict="update")
+
+    # Verify data was updated and new data added
+    with db_engine.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT * FROM update_test ORDER BY id"))
+        rows = result.fetchall()
+
+    assert len(rows) == 5
+    assert rows[0] == (1, "Alice", 100)  # Original (unchanged)
+    assert rows[1] == (2, "Bob_Updated", 999)  # Updated
+    assert rows[2] == (3, "Charlie_Updated", 888)  # Updated
+    assert rows[3] == (4, "Diana", 400)  # New
+    assert rows[4] == (5, "Eve", 500)  # New
+
+
+def test_to_database_table_exists_different_schema(db_engine, test_session):
+    """Test to_database when table exists but has different schema."""
+    # Create table with different schema
+    with db_engine.connect() as conn:
+        with conn.begin():
+            conn.execute(
+                sqlalchemy.text("""
+                CREATE TABLE schema_mismatch (
+                    id INTEGER,
+                    old_column TEXT,
+                    extra_column REAL
+                )
+            """)
+            )
+            conn.execute(
+                sqlalchemy.text(
+                    "INSERT INTO schema_mismatch VALUES (1, 'existing', 1.5)"
+                )
+            )
+
+    # Create DataChain with different schema
+    chain = dc.read_values(
+        id=[2, 3],
+        name=["Alice", "Bob"],  # Different column name
+        session=test_session,
+    )
+
+    # This should raise an error due to schema mismatch
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        to_database(chain, "schema_mismatch", db_engine)
+
+
+def test_to_database_transaction_rollback_on_error(db_engine, test_session):
+    """Test that transaction is rolled back when an exception occurs."""
+    # Create a table with strict constraints
+    with db_engine.connect() as conn:
+        with conn.begin():
+            conn.execute(
+                sqlalchemy.text("""
+                CREATE TABLE strict_table (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    email TEXT UNIQUE NOT NULL
+                )
+            """)
+            )
+            # Insert some initial data
+            conn.execute(
+                sqlalchemy.text(
+                    "INSERT INTO strict_table VALUES (1, 'Initial', 'initial@test.com')"
+                )
+            )
+
+    # Count initial records
+    with db_engine.connect() as conn:
+        initial_count = conn.execute(
+            sqlalchemy.text("SELECT COUNT(*) FROM strict_table")
+        ).scalar()
+
+    assert initial_count == 1
+
+    # Create DataChain with data that will cause constraint violation
+    chain = dc.read_values(
+        id=[2, 3, 4],
+        name=["Alice", "Bob", "Charlie"],
+        # Second email is duplicate and will cause violation
+        email=["alice@test.com", "initial@test.com", "charlie@test.com"],
+        session=test_session,
+    )
+
+    # This should fail due to unique constraint violation
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        to_database(chain, "strict_table", db_engine)
+
+    # Verify transaction was rolled back - no new records should be inserted
+    with db_engine.connect() as conn:
+        final_count = conn.execute(
+            sqlalchemy.text("SELECT COUNT(*) FROM strict_table")
+        ).scalar()
+
+    assert final_count == 1  # Only the initial record should remain
+
+
+def test_to_database_empty_chain(connection, test_session):
+    """Test to_database with an empty DataChain."""
+    chain = dc.read_values(
+        id=[],
+        name=[],
+        session=test_session,
+    )
+
+    to_database(chain, "empty_table", connection)
+
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT COUNT(*) FROM empty_table"))
+        count = result.scalar()
+
+    assert count == 0
+
+
+def test_to_database_column_mapping(connection, test_session):
+    """Test to_database with column mapping functionality."""
+    chain = dc.read_values(
+        internal_id=[1, 2, 3],
+        full_name=["Alice Smith", "Bob Jones", "Charlie Brown"],
+        session=test_session,
+    )
+
+    # Export with column mapping
+    column_mapping = {"internal_id": "id", "full_name": "name"}
+
+    to_database(chain, "mapped_table", connection, column_mapping=column_mapping)
+
+    # Verify the columns were mapped correctly
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        # Check that the new column names exist
+        result = conn.execute(
+            sqlalchemy.text("SELECT id, name FROM mapped_table ORDER BY id")
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 3
+    assert rows[0] == (1, "Alice Smith")
+    assert rows[1] == (2, "Bob Jones")
+    assert rows[2] == (3, "Charlie Brown")
+
+
+def test_to_database_column_mapping_skip_columns(connection, test_session):
+    """Test column mapping with explicit column skipping using None."""
+    chain = dc.read_values(
+        id=[1, 2, 3],
+        name=["Alice", "Bob", "Charlie"],
+        age=[25, 30, 35],
+        internal_notes=["note1", "note2", "note3"],
+        session=test_session,
+    )
+
+    # Export with column mapping, skipping age and internal_notes columns
+    column_mapping = {
+        "id": "user_id",
+        "name": "full_name",
+        "age": None,  # Skip this column
+        "internal_notes": None,  # Skip this column too
+    }
+
+    to_database(
+        chain, "skipped_columns_table", connection, column_mapping=column_mapping
+    )
+
+    # Verify only mapped columns were exported
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        # Check column names in the table
+        result = conn.execute(
+            sqlalchemy.text("PRAGMA table_info(skipped_columns_table)")
+        )
+        columns = [row[1] for row in result.fetchall()]  # Column names are in index 1
+
+        assert "user_id" in columns
+        assert "full_name" in columns
+        assert "age" not in columns
+        assert "internal_notes" not in columns
+
+        # Verify data
+        result = conn.execute(
+            sqlalchemy.text(
+                "SELECT user_id, full_name FROM skipped_columns_table ORDER BY user_id"
+            )
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 3
+    assert rows[0] == (1, "Alice")
+    assert rows[1] == (2, "Bob")
+    assert rows[2] == (3, "Charlie")
+
+
+def test_to_database_column_mapping_defaultdict(connection, test_session):
+    """Test column mapping using defaultdict to skip columns by default."""
+    from collections import defaultdict
+
+    chain = dc.read_values(
+        id=[1, 2, 3],
+        name=["Alice", "Bob", "Charlie"],
+        age=[25, 30, 35],
+        internal_id=["i1", "i2", "i3"],
+        secret_key=["sk1", "sk2", "sk3"],
+        session=test_session,
+    )
+
+    # Use defaultdict to skip all columns by default except explicitly mapped ones
+    column_mapping = defaultdict(lambda: None)
+    column_mapping.update(
+        {
+            "id": "user_id",
+            "name": "user_name",
+        }
+    )
+
+    to_database(chain, "defaultdict_table", connection, column_mapping=column_mapping)
+
+    # Verify only explicitly mapped columns were exported
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(sqlalchemy.text("PRAGMA table_info(defaultdict_table)"))
+        columns = [row[1] for row in result.fetchall()]
+
+        assert "user_id" in columns
+        assert "user_name" in columns
+        assert "age" not in columns
+        assert "internal_id" not in columns
+        assert "secret_key" not in columns
+
+        # Verify data
+        result = conn.execute(
+            sqlalchemy.text(
+                "SELECT user_id, user_name FROM defaultdict_table ORDER BY user_id"
+            )
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 3
+    assert rows[0] == (1, "Alice")
+    assert rows[1] == (2, "Bob")
+    assert rows[2] == (3, "Charlie")
+
+
+def test_to_database_column_mapping_defaultdict_with_datachain_format(
+    connection, test_session
+):
+    """Test defaultdict column mapping with DataChain format (dots) in nested fields."""
+    from collections import defaultdict
+
+    class NestedInfo(dc.DataModel):
+        value: str
+        priority: int
+
+    chain = dc.read_values(
+        id=[1, 2],
+        name=["Alice", "Bob"],
+        age=[25, 30],
+        nested_info=[
+            NestedInfo(value="important", priority=1),
+            NestedInfo(value="normal", priority=2),
+        ],
+        secret_field=["secret1", "secret2"],
+        session=test_session,
+    )
+
+    # Use defaultdict with DataChain format (dots) for nested fields
+    column_mapping = defaultdict(lambda: None)
+    column_mapping.update(
+        {
+            "id": "user_id",
+            "name": "user_name",
+            "nested_info.value": "info_value",  # DataChain format with dots
+            # Skip age, nested_info.priority, and secret_field
+        }
+    )
+
+    to_database(
+        chain, "defaultdict_datachain_table", connection, column_mapping=column_mapping
+    )
+
+    # Verify only explicitly mapped columns were exported
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(
+            sqlalchemy.text("PRAGMA table_info(defaultdict_datachain_table)")
+        )
+        columns = [row[1] for row in result.fetchall()]
+
+        assert "user_id" in columns
+        assert "user_name" in columns
+        assert "info_value" in columns
+        # These should be skipped
+        assert "age" not in columns
+        assert "nested_info__priority" not in columns
+        assert "secret_field" not in columns
+
+        # Verify data
+        result = conn.execute(
+            sqlalchemy.text(
+                "SELECT user_id, user_name, info_value "
+                "FROM defaultdict_datachain_table ORDER BY user_id"
+            )
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 2
+    assert rows[0] == (1, "Alice", "important")
+    assert rows[1] == (2, "Bob", "normal")
+
+
+def test_to_database_column_mapping_complex_nested_names(connection, test_session):
+    """Test column mapping with complex/nested column names."""
+
+    class NestedData(dc.DataModel):
+        value: str
+        metadata: dict
+
+    chain = dc.read_values(
+        id=[1, 2, 3],
+        user_profile_name=["Alice", "Bob", "Charlie"],
+        system_config_theme=["dark", "light", "auto"],
+        nested_data=[
+            NestedData(value="data1", metadata={"type": "A"}),
+            NestedData(value="data2", metadata={"type": "B"}),
+            NestedData(value="data3", metadata={"type": "C"}),
+        ],
+        session=test_session,
+    )
+
+    # Map complex column names to simpler ones using DataChain format (dots)
+    column_mapping = {
+        "id": "id",
+        "user_profile_name": "name",
+        "system_config_theme": "theme",
+        "nested_data.value": "data_value",  # Use DataChain format with dots
+        "nested_data.metadata": "data_meta",  # Use DataChain format with dots
+    }
+
+    to_database(
+        chain, "complex_mapping_table", connection, column_mapping=column_mapping
+    )
+
+    # Verify the complex mappings worked
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(
+            sqlalchemy.text("PRAGMA table_info(complex_mapping_table)")
+        )
+        columns = [row[1] for row in result.fetchall()]
+
+        assert "id" in columns
+        assert "name" in columns
+        assert "theme" in columns
+        assert "data_value" in columns
+        assert "data_meta" in columns
+        # Original complex names should not be present
+        assert "user_profile_name" not in columns
+        assert "system_config_theme" not in columns
+
+        # Verify data was mapped correctly
+        result = conn.execute(
+            sqlalchemy.text(
+                "SELECT id, name, theme, data_value "
+                "FROM complex_mapping_table ORDER BY id"
+            )
+        )
+        rows = result.fetchall()
+
+    assert len(rows) == 3
+    assert rows[0][:4] == (1, "Alice", "dark", "data1")
+    assert rows[1][:4] == (2, "Bob", "light", "data2")
+    assert rows[2][:4] == (3, "Charlie", "auto", "data3")
+
+
+def test_to_database_column_mapping_datachain_format_backward_compatibility(
+    connection, test_session
+):
+    """Test that both DataChain format (dots) and database format (underscores)
+    work in column mapping."""
+
+    class NestedData(dc.DataModel):
+        value: str
+        config: dict
+
+    chain = dc.read_values(
+        id=[1, 2],
+        simple_field=["test1", "test2"],
+        nested_data=[
+            NestedData(value="val1", config={"setting": 1}),
+            NestedData(value="val2", config={"setting": 2}),
+        ],
+        session=test_session,
+    )
+
+    # Test DataChain format (dots) - this should work
+    column_mapping_dots = {
+        "id": "record_id",
+        "simple_field": "simple",
+        "nested_data.value": "nested_val",
+        "nested_data.config": "nested_cfg",
+    }
+
+    to_database(
+        chain, "dots_format_table", connection, column_mapping=column_mapping_dots
+    )
+
+    # Test database format (double underscores) - this should also work
+    column_mapping_underscores = {
+        "id": "record_id",
+        "simple_field": "simple",
+        "nested_data__value": "nested_val",
+        "nested_data__config": "nested_cfg",
+    }
+
+    to_database(
+        chain,
+        "underscores_format_table",
+        connection,
+        column_mapping=column_mapping_underscores,
+    )
+
+    # Verify both tables have the same structure and data
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        # Check dots format table
+        result_dots = conn.execute(
+            sqlalchemy.text(
+                "SELECT record_id, simple, nested_val FROM dots_format_table "
+                "ORDER BY record_id"
+            )
+        )
+        rows_dots = result_dots.fetchall()
+
+        # Check underscores format table
+        result_underscores = conn.execute(
+            sqlalchemy.text(
+                "SELECT record_id, simple, nested_val FROM underscores_format_table "
+                "ORDER BY record_id"
+            )
+        )
+        rows_underscores = result_underscores.fetchall()
+
+        # Both should have identical data
+        assert len(rows_dots) == 2
+        assert len(rows_underscores) == 2
+        assert rows_dots == rows_underscores
+        assert rows_dots[0][:3] == (1, "test1", "val1")
+        assert rows_dots[1][:3] == (2, "test2", "val2")
+
+
+def test_to_database_invalid_on_conflict_value(connection, test_session):
+    """Test that invalid on_conflict values raise ValueError."""
+    chain = dc.read_values(
+        id=[1, 2, 3],
+        name=["Alice", "Bob", "Charlie"],
+        session=test_session,
+    )
+
+    with pytest.raises(ValueError, match="on_conflict must be 'ignore' or 'update'"):
+        to_database(chain, "test_table", connection, on_conflict="invalid")
+
+
+def test_to_database_unsupported_conflict_resolution_warning(test_session):
+    """Test warning is issued when conflict resolution is not supported."""
+    # This test would need a database that doesn't support conflict resolution
+    # For now, we'll document this behavior since SQLite supports it
+    # In a real test, you would use a database engine that doesn't support
+    # conflict resolution and check for warnings
+
+    # Create a simple chain for potential future use
+    chain = dc.read_values(
+        id=[1, 2, 3],
+        name=["Alice", "Bob", "Charlie"],
+        session=test_session,
+    )
+
+    # This test would be implemented with a non-supporting database
+    # For now we just verify the chain was created successfully
+    assert len(list(chain.to_iter())) == 3
+
+
+def test_to_database_with_null_values(connection, test_session):
+    """Test to_database handles NULL values correctly."""
+    chain = dc.read_values(
+        id=[1, 2, 3, 4],
+        name=["Alice", None, "Charlie", "Diana"],
+        age=[25, 30, None, 28],
+        session=test_session,
+    )
+
+    to_database(chain, "null_table", connection)
+
+    engine = _get_engine_from_connection(connection)
+    with engine.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT * FROM null_table ORDER BY id"))
+        rows = result.fetchall()
+
+    assert len(rows) == 4
+    assert rows[0] == (1, "Alice", 25)
+    assert rows[1] == (2, None, 30)
+    assert rows[2] == (3, "Charlie", None)
+    assert rows[3] == (4, "Diana", 28)
+
+
+def test_to_database_table_cleanup_on_map_exception(db_engine, test_session):
+    """Test that newly created tables are cleaned up when an exception occurs
+    during DataChain iteration using map function."""
+    table_name = "cleanup_map_test_table"
+
+    # Verify table doesn't exist initially
+    inspector = sqlalchemy.inspect(db_engine)
+    assert table_name not in inspector.get_table_names()
+
+    # Create a function that will fail during processing
+    def process_item(id_val):
+        # Process first few rows normally, then fail on the third item
+        # This ensures table creation happens first, but exception occurs during
+        # processing
+        if id_val >= 3:
+            raise ValueError("Processing failed on third item")
+        return f"item_{id_val}"
+
+    # Create chain with enough data to trigger the failure after table creation
+    chain = dc.read_values(
+        id=[1, 2, 3, 4, 5],
+        session=test_session,
+    ).map(process_item, params=["id"], output={"data": str})
+
+    # The export should fail during processing, after table creation
+    with pytest.raises(dc.DataChainError, match="Processing failed on third item"):
+        to_database(chain, table_name, db_engine)
+
+    # Verify the table was cleaned up (removed) due to the exception
+    inspector = sqlalchemy.inspect(db_engine)
+    assert table_name not in inspector.get_table_names(), (
+        f"Table {table_name} should have been cleaned up after processing exception"
+    )
+
+
+def _get_engine_from_connection(connection: Any) -> sqlalchemy.Engine:
+    """Helper function to get SQLAlchemy engine from various connection types."""
+    if isinstance(connection, str):
+        return sqlalchemy.create_engine(connection)
+    if isinstance(connection, sqlalchemy.Engine):
+        return connection
+    if isinstance(connection, sqlalchemy.Connection):
+        return connection.engine
+    if isinstance(connection, Session):
+        if connection.bind is None:
+            raise ValueError("Session has no bound engine")
+        # Session.bind can be Engine or Connection, we need Engine
+        if isinstance(connection.bind, sqlalchemy.Engine):
+            return connection.bind
+        if isinstance(connection.bind, sqlalchemy.Connection):
+            return connection.bind.engine
+        raise TypeError(f"Unexpected bind type: {type(connection.bind)}")
+    if hasattr(connection, "execute"):  # sqlite3.Connection
+        # Create a temporary engine for verification
+        return sqlalchemy.create_engine("sqlite://", creator=lambda: connection)
+    raise TypeError(f"Unsupported connection type: {type(connection)}")


### PR DESCRIPTION
Adds `to_database` DataChain function to export chain into SQL databases.

## Summary by Sourcery

Provide a new `to_database` feature to DataChain for exporting data to SQL databases, with automated schema inference, batch inserts, conflict handling, customizable column mapping, and robust error recovery.

New Features:
- Add DataChain.to_database method for exporting DataChain records to SQL databases
- Introduce `to_database` core function with batch insertion, auto table creation, and conflict resolution
- Support multiple connection types including SQLAlchemy Engine, Connection, Session, URI strings, and sqlite3.Connection
- Enable customizable column mapping with nested field support and skip functionality

Enhancements:
- Normalize nested field names using ColumnMeta.to_db_name for consistent database naming
- Extend connection handling to accept SQLAlchemy sessions and sqlite3 connections
- Implement automatic rollback and table cleanup on errors during export

Documentation:
- Add detailed docstring with parameters, examples, and usage patterns for DataChain.to_database

Tests:
- Add comprehensive tests for `to_database` covering basic export, batch sizes, complex types, conflict strategies, schema mismatches, null handling, column mapping, and error cleanup