### PR TITLE
Remove the restriction on dependency for huggingface_hub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,6 +194,22 @@ jobs:
       - name: Install nox
         run: uv pip install nox --system
 
+      - name: Install FFmpeg on Windows
+        if: runner.os == 'Windows'
+        run: choco install ffmpeg
+
+      - name: Install FFmpeg on macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install ffmpeg
+          echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
+      
+      - name: Install FFmpeg on Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y ffmpeg
+
       - name: Set hf token
         if: matrix.group == 'llm_and_nlp'
         run: echo 'HF_TOKEN=${{ secrets.HF_TOKEN }}' >> "$GITHUB_ENV"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,7 +203,7 @@ jobs:
         run: |
           brew install ffmpeg
           echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
-      
+
       - name: Install FFmpeg on Ubuntu
         if: runner.os == 'Linux'
         run: |

--- a/examples/multimodal/audio-to-text.py
+++ b/examples/multimodal/audio-to-text.py
@@ -35,7 +35,10 @@ def process(fragment: AudioFragment, pipeline: Pipeline) -> str:
         audio_array = audio_array.mean(axis=1)
 
     # Pass the numpy array with exact sampling rate from fragment
-    result = pipeline({"raw": audio_array, "sampling_rate": sample_rate})
+    result = pipeline(
+        {"raw": audio_array, "sampling_rate": sample_rate},
+        generate_kwargs={"language": "en"},
+    )
     return str(result["text"])
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,7 +186,7 @@ plugins:
             - https://numpy.org/doc/stable/objects.inv
             - https://pandas.pydata.org/docs/objects.inv
             - https://arrow.apache.org/docs/objects.inv
-            # - https://docs.sqlalchemy.org/objects.inv  # SSL certificate issue
+            - https://docs.sqlalchemy.org/objects.inv  # SSL certificate issue
             - https://docs.pydantic.dev/latest/objects.inv
 
 watch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ examples = [
   "datachain[tests]",
   "defusedxml",
   "accelerate",
-  "huggingface_hub[hf_transfer]<0.34",
+  "huggingface_hub[hf_transfer,hf_xet]",
   "ultralytics",
   "open_clip_torch",
   "openai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ hf = [
   "datasets[vision]>=4.0.0",
   # https://github.com/pytorch/torchcodec/issues/640
   "datasets[audio]>=4.0.0 ; (sys_platform == 'linux' or sys_platform == 'darwin')",
+  "torchcodec ; (sys_platform == 'linux' or sys_platform == 'darwin')",
   "fsspec>=2024.12.0"
 ]
 video = [
@@ -134,8 +135,7 @@ examples = [
   "huggingface_hub[hf_transfer]",
   "ultralytics",
   "open_clip_torch",
-  "openai",
-  "torchcodec"
+  "openai"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ hf = [
   "datasets[vision]>=4.0.0",
   # https://github.com/pytorch/torchcodec/issues/640
   "datasets[audio]>=4.0.0 ; (sys_platform == 'linux' or sys_platform == 'darwin')",
-  "torchcodec ; (sys_platform == 'linux' or sys_platform == 'darwin')",
   "fsspec>=2024.12.0"
 ]
 video = [
@@ -135,7 +134,8 @@ examples = [
   "huggingface_hub[hf_transfer]",
   "ultralytics",
   "open_clip_torch",
-  "openai"
+  "openai",
+  "torchcodec ; (sys_platform == 'linux' or sys_platform == 'darwin')"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ examples = [
   "ultralytics",
   "open_clip_torch",
   "openai",
-  "transformers<4.54.0"
+  "torchcodec"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ examples = [
   "ultralytics",
   "open_clip_torch",
   "openai",
-  "torchcodec ; (sys_platform == 'linux' or sys_platform == 'darwin')"
+  "transformers<4.54.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,7 @@ examples = [
   "huggingface_hub[hf_transfer]",
   "ultralytics",
   "open_clip_torch",
-  "openai",
-  "transformers<4.54.0"
+  "openai"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ examples = [
   "datachain[tests]",
   "defusedxml",
   "accelerate",
-  "huggingface_hub[hf_transfer]",
+  "huggingface_hub[hf_transfer]<0.34",
   "ultralytics",
   "open_clip_torch",
   "openai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "Pillow>=10.0.0,<12",
   "msgpack>=1.0.4,<2",
   "psutil",
-  "huggingface_hub<0.34.0",
+  "huggingface_hub",
   "iterative-telemetry>=0.0.10",
   "platformdirs",
   "dvc-studio-client>=0.21,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,10 +131,11 @@ examples = [
   "datachain[tests]",
   "defusedxml",
   "accelerate",
-  "huggingface_hub[hf_transfer,hf_xet]",
+  "huggingface_hub[hf_transfer]",
   "ultralytics",
   "open_clip_torch",
-  "openai"
+  "openai",
+  "transformers<4.54.0"
 ]
 
 [project.urls]

--- a/src/datachain/model/ultralytics/bbox.py
+++ b/src/datachain/model/ultralytics/bbox.py
@@ -31,11 +31,11 @@ class YoloBBox(DataModel):
         if not summary:
             return YoloBBox(box=BBox())
         name = summary[0].get("name", "")
-        box = (
-            BBox.from_dict(summary[0]["box"], title=name)
-            if summary[0].get("box")
-            else BBox()
-        )
+        if summary[0].get("box"):
+            assert isinstance(summary[0]["box"], dict)
+            box = BBox.from_dict(summary[0]["box"], title=name)
+        else:
+            box = BBox()
         return YoloBBox(
             cls=summary[0]["class"],
             name=name,
@@ -70,7 +70,8 @@ class YoloBBoxes(DataModel):
                 names.append(name)
                 confidence.append(s["confidence"])
                 if s.get("box"):
-                    box.append(BBox.from_dict(s.get("box"), title=name))
+                    assert isinstance(s["box"], dict)
+                    box.append(BBox.from_dict(s["box"], title=name))
         return YoloBBoxes(
             cls=cls,
             name=names,
@@ -101,11 +102,11 @@ class YoloOBBox(DataModel):
         if not summary:
             return YoloOBBox(box=OBBox())
         name = summary[0].get("name", "")
-        box = (
-            OBBox.from_dict(summary[0]["box"], title=name)
-            if summary[0].get("box")
-            else OBBox()
-        )
+        if summary[0].get("box"):
+            assert isinstance(summary[0]["box"], dict)
+            box = OBBox.from_dict(summary[0]["box"], title=name)
+        else:
+            box = OBBox()
         return YoloOBBox(
             cls=summary[0]["class"],
             name=name,
@@ -140,7 +141,8 @@ class YoloOBBoxes(DataModel):
                 names.append(name)
                 confidence.append(s["confidence"])
                 if s.get("box"):
-                    box.append(OBBox.from_dict(s.get("box"), title=name))
+                    assert isinstance(s["box"], dict)
+                    box.append(OBBox.from_dict(s["box"], title=name))
         return YoloOBBoxes(
             cls=cls,
             name=names,

--- a/src/datachain/model/ultralytics/pose.py
+++ b/src/datachain/model/ultralytics/pose.py
@@ -56,16 +56,16 @@ class YoloPose(DataModel):
         if not summary:
             return YoloPose(box=BBox(), pose=Pose3D())
         name = summary[0].get("name", "")
-        box = (
-            BBox.from_dict(summary[0]["box"], title=name)
-            if summary[0].get("box")
-            else BBox()
-        )
-        pose = (
-            Pose3D.from_dict(summary[0]["keypoints"])
-            if summary[0].get("keypoints")
-            else Pose3D()
-        )
+        if summary[0].get("box"):
+            assert isinstance(summary[0]["box"], dict)
+            box = BBox.from_dict(summary[0]["box"], title=name)
+        else:
+            box = BBox()
+        if summary[0].get("keypoints"):
+            assert isinstance(summary[0]["keypoints"], dict)
+            pose = Pose3D.from_dict(summary[0]["keypoints"])
+        else:
+            pose = Pose3D()
         return YoloPose(
             cls=summary[0]["class"],
             name=name,
@@ -103,9 +103,11 @@ class YoloPoses(DataModel):
                 names.append(name)
                 confidence.append(s["confidence"])
                 if s.get("box"):
-                    box.append(BBox.from_dict(s.get("box"), title=name))
+                    assert isinstance(s["box"], dict)
+                    box.append(BBox.from_dict(s["box"], title=name))
                 if s.get("keypoints"):
-                    pose.append(Pose3D.from_dict(s.get("keypoints")))
+                    assert isinstance(s["keypoints"], dict)
+                    pose.append(Pose3D.from_dict(s["keypoints"]))
         return YoloPoses(
             cls=cls,
             name=names,

--- a/src/datachain/model/ultralytics/segment.py
+++ b/src/datachain/model/ultralytics/segment.py
@@ -34,16 +34,16 @@ class YoloSegment(DataModel):
         if not summary:
             return YoloSegment(box=BBox(), segment=Segment())
         name = summary[0].get("name", "")
-        box = (
-            BBox.from_dict(summary[0]["box"], title=name)
-            if summary[0].get("box")
-            else BBox()
-        )
-        segment = (
-            Segment.from_dict(summary[0]["segments"], title=name)
-            if summary[0].get("segments")
-            else Segment()
-        )
+        if summary[0].get("box"):
+            assert isinstance(summary[0]["box"], dict)
+            box = BBox.from_dict(summary[0]["box"], title=name)
+        else:
+            box = BBox()
+        if summary[0].get("segments"):
+            assert isinstance(summary[0]["segments"], dict)
+            segment = Segment.from_dict(summary[0]["segments"], title=name)
+        else:
+            segment = Segment()
         return YoloSegment(
             cls=summary[0]["class"],
             name=summary[0]["name"],
@@ -81,9 +81,11 @@ class YoloSegments(DataModel):
                 names.append(name)
                 confidence.append(s["confidence"])
                 if s.get("box"):
-                    box.append(BBox.from_dict(s.get("box"), title=name))
+                    assert isinstance(s["box"], dict)
+                    box.append(BBox.from_dict(s["box"], title=name))
                 if s.get("segments"):
-                    segment.append(Segment.from_dict(s.get("segments"), title=name))
+                    assert isinstance(s["segments"], dict)
+                    segment.append(Segment.from_dict(s["segments"], title=name))
         return YoloSegments(
             cls=cls,
             name=names,


### PR DESCRIPTION
This removes the restriction and changes to fix and revert the changes made in #1265

## Summary by Sourcery

Remove the version restriction on huggingface_hub dependency and restore SQLAlchemy documentation indexing in the MkDocs configuration.

Enhancements:
- Remove the `<0.34.0` version cap on the huggingface_hub dependency
- Uncomment the SQLAlchemy objects.inv entry to re-enable its documentation in MkDocs