### PR TITLE
Add option to pass credentials name when creating a job

### DIFF
--- a/docs/commands/job/run.md
+++ b/docs/commands/job/run.md
@@ -32,6 +32,7 @@ This command runs a job in Studio using the specified query file. You can config
 * `--env-file ENV_FILE` - File with environment variables for the job
 * `--env ENV` - Environment variables in KEY=VALUE format
 * `--cluster CLUSTER` - Compute cluster to run the job on
+* `--credentials-name CREDENTIALS_NAME` - Name of the credentials to use for the job
 * `--workers WORKERS` - Number of workers for the job
 * `--files FILES` - Additional files to include in the job
 * `--python-version PYTHON_VERSION` - Python version for the job (e.g., 3.9, 3.10, 3.11)
@@ -97,7 +98,12 @@ datachain job clusters
 datachain job run --cluster 1 query.py
 ```
 
-9. Schedule a job to run once at a specific time
+9. Run a job with specific credentials
+```bash
+datachain job run --credentials-name my-aws-credentials query.py
+```
+
+10. Schedule a job to run once at a specific time
 ```bash
 # Run job tomorrow at 3pm
 datachain job run --start-time "tomorrow 3pm" query.py
@@ -112,7 +118,7 @@ datachain job run --start-time "monday 9am" query.py
 datachain job run --start-time "2024-01-15 14:30:00" query.py
 ```
 
-10. Schedule a recurring job using cron expression
+11. Schedule a recurring job using cron expression
 ```bash
 # Run job daily at midnight
 datachain job run --cron "0 0 * * *" query.py
@@ -127,13 +133,13 @@ datachain job run --cron "0 * * * *" query.py
 datachain job run --cron "@monthly" query.py
 ```
 
-11. Schedule a recurring job with a start time
+12. Schedule a recurring job with a start time
 ```bash
 # Start the cron job after tomorrow 3pm
 datachain job run --start-time "tomorrow 3pm" --cron "0 0 * * *" query.py
 ```
 
-12. Start the job and do not wait for the job to complete
+13. Start the job and do not wait for the job to complete
 ```bash
 # Do not follow or tail the logs from Studio.
 datachain job run query.py --no-wait

--- a/src/datachain/cli/parser/job.py
+++ b/src/datachain/cli/parser/job.py
@@ -64,6 +64,13 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
     )
 
     studio_run_parser.add_argument(
+        "-c",
+        "--credentials-name",
+        action="store",
+        help="Name of the credentials to use for the job",
+    )
+
+    studio_run_parser.add_argument(
         "--workers",
         type=int,
         help="Number of workers for the job",

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -431,6 +431,7 @@ class StudioClient:
         cluster: Optional[str] = None,
         start_time: Optional[str] = None,
         cron: Optional[str] = None,
+        credentials_name: Optional[str] = None,
     ) -> Response[JobData]:
         data = {
             "query": query,
@@ -446,6 +447,7 @@ class StudioClient:
             "compute_cluster_name": cluster,
             "start_after": start_time,
             "cron_expression": cron,
+            "credentials_name": credentials_name,
         }
         return self._send_request("datachain/job", data)
 

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -50,6 +50,7 @@ def process_jobs_args(args: "Namespace"):
             args.start_time,
             args.cron,
             args.no_wait,
+            args.credentials_name,
         )
 
     if args.cmd == "cancel":
@@ -356,6 +357,7 @@ def create_job(
     start_time: Optional[str] = None,
     cron: Optional[str] = None,
     no_wait: Optional[bool] = False,
+    credentials_name: Optional[str] = None,
 ):
     query_type = "PYTHON" if query_file.endswith(".py") else "SHELL"
     with open(query_file) as f:
@@ -393,6 +395,7 @@ def create_job(
         cluster=cluster,
         start_time=parsed_start_time,
         cron=cron,
+        credentials_name=credentials_name,
     )
     if not response.ok:
         raise DataChainError(response.message)

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -401,6 +401,8 @@ def test_studio_run(capsys, mocker, tmp_dir):
                     "https://github.com/iterative/datachain",
                     "--cluster",
                     "default",
+                    "--credentials-name",
+                    "my-credentials",
                 ]
             )
             == 0
@@ -442,6 +444,7 @@ def test_studio_run(capsys, mocker, tmp_dir):
         "compute_cluster_name": "default",
         "start_after": None,
         "cron_expression": None,
+        "credentials_name": "my-credentials",
     }
 
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for specifying credentials by name when creating Studio jobs

New Features:
- Add --credentials-name CLI flag for datachain job run
- Pass credentials_name through process_jobs_args and include it in create_job API calls

Documentation:
- Document the --credentials-name option and update examples in job run guide

Tests:
- Add unit tests to verify credentials_name is parsed and sent in job creation