### PR TITLE
Filtering all `sys__` columns from UDF table

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -665,7 +665,7 @@ class UDFSignal(UDFStep):
         original_cols = [c for c in subq.c if c.name not in partition_col_names]
 
         # new signal columns that are added to udf_table
-        signal_cols = [c for c in udf_table.c if c.name != "sys__id"]
+        signal_cols = [c for c in udf_table.c if not c.name.startswith("sys__")]
         signal_name_cols = {c.name: c for c in signal_cols}
         cols = signal_cols
 


### PR DESCRIPTION
Companion PR of https://github.com/iterative/studio/pull/12014

We needed to filter any `sys__` columns from UDF table so that new column needed for concurrent writes in Studio `sys__batch_id` doesn't end up in resulting table.

## Summary by Sourcery

Enhancements:
- Broaden filtering to exclude any columns starting with "sys__" instead of only "sys__id"