### PR TITLE
cleanup func docs, make sure string func are visible

### DIFF
--- a/docs/references/func.md
+++ b/docs/references/func.md
@@ -1,5 +1,38 @@
 # Functions
 
-Use built-in functions for data manipulation and analysis to operate on the underlying database storing the chain data. These functions are useful for operations like [`DataChain.filter`](datachain.md#datachain.lib.dc.DataChain.filter) and [`DataChain.mutate`](datachain.md#datachain.lib.dc.DataChain.mutate). Import these functions from `datachain.func`.
+Use built-in functions for data manipulation and analysis to operate on the underlying database storing the chain data. These functions are useful for operations like [`DataChain.filter`](datachain.md#datachain.lib.dc.DataChain.filter) and [`DataChain.mutate`](datachain.md#datachain.lib.dc.DataChain.mutate).
 
-::: datachain.func
+Functions are organized by category and accessed through their respective modules. For example, string functions are accessed via `func.string.length()`, array functions via `func.array.contains()`, etc.
+
+!!! note "Global Function Access"
+    Only a subset of functions are available directly from `datachain.func` (e.g., `func.length`). Most functions should be accessed through their specific module namespace (e.g., `func.string.length`) to avoid naming conflicts.
+
+## Function Categories
+
+DataChain provides several categories of functions for different types of operations:
+
+- **[Aggregate Functions](functions/aggregate.md)** - Functions for aggregating data like `sum`, `count`, `avg`, etc.
+- **[Array Functions](functions/array.md)** - Functions for working with arrays and lists
+- **[Conditional Functions](functions/conditional.md)** - Functions for conditional logic like `ifelse`, `case`, etc.
+- **[Numeric Functions](functions/numeric.md)** - Functions for numeric operations and computations
+- **[Path Functions](functions/path.md)** - Functions for working with file paths
+- **[Random Functions](functions/random.md)** - Functions for generating random values
+- **[String Functions](functions/string.md)** - Functions for string manipulation and processing
+- **[Window Functions](functions/window.md)** - Functions for window operations
+
+## Usage
+
+```python
+from datachain.func import aggregate, array, conditional, numeric, path, random, string, window
+
+# Access functions through their module namespaces
+dc.mutate(
+    text_length=string.length("text_column"),
+    contains_item=array.contains("array_column", "value"),
+    file_extension=path.file_ext("file_path")
+)
+
+# Some commonly used functions are also available directly
+from datachain.func import sum, count, length, ifelse
+dc.mutate(total=sum("amount"))
+```

--- a/docs/references/functions/aggregate.md
+++ b/docs/references/functions/aggregate.md
@@ -1,0 +1,5 @@
+# Aggregate Functions
+
+Aggregate functions perform calculations on sets of values and return a single result.
+
+::: datachain.func.aggregate

--- a/docs/references/functions/array.md
+++ b/docs/references/functions/array.md
@@ -1,0 +1,5 @@
+# Array Functions
+
+Functions for working with arrays and lists, including operations like distance calculations and array manipulation.
+
+::: datachain.func.array

--- a/docs/references/functions/conditional.md
+++ b/docs/references/functions/conditional.md
@@ -1,0 +1,5 @@
+# Conditional Functions
+
+Functions for conditional logic and control flow in data processing.
+
+::: datachain.func.conditional

--- a/docs/references/functions/numeric.md
+++ b/docs/references/functions/numeric.md
@@ -1,0 +1,5 @@
+# Numeric Functions
+
+Functions for numeric operations, bit manipulation, and mathematical computations.
+
+::: datachain.func.numeric

--- a/docs/references/functions/path.md
+++ b/docs/references/functions/path.md
@@ -1,0 +1,5 @@
+# Path Functions
+
+Functions for working with file paths and extracting path components.
+
+::: datachain.func.path

--- a/docs/references/functions/random.md
+++ b/docs/references/functions/random.md
@@ -1,0 +1,5 @@
+# Random Functions
+
+Functions for generating random values and sampling.
+
+::: datachain.func.random

--- a/docs/references/functions/string.md
+++ b/docs/references/functions/string.md
@@ -1,0 +1,22 @@
+# String Functions
+
+Functions for string manipulation, text processing, and string analysis.
+
+## Usage
+
+String functions are available under the `func.string` namespace to avoid name collisions with other functions:
+
+```python
+from datachain.func import string
+
+# Use string functions with the string namespace
+dc.mutate(
+    str_len=string.length("text_column"),
+    parts=string.split("text_column", ","),
+    cleaned=string.replace("text_column", "old", "new"),
+    regex_cleaned=string.regexp_replace("text_column", r"\d+", "X"),
+    distance=string.byte_hamming_distance("col1", "col2")
+)
+```
+
+::: datachain.func.string

--- a/docs/references/functions/window.md
+++ b/docs/references/functions/window.md
@@ -1,0 +1,5 @@
+# Window Functions
+
+Functions for window operations and analytical processing.
+
+::: datachain.func.window

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,16 @@ nav:
               - Segment: references/data-types/segment.md
           - UDF: references/udf.md
           - Torch: references/torch.md
-          - Functions: references/func.md
+          - Functions:
+              - Overview: references/func.md
+              - Aggregate: references/functions/aggregate.md
+              - Array: references/functions/array.md
+              - Conditional: references/functions/conditional.md
+              - Numeric: references/functions/numeric.md
+              - Path: references/functions/path.md
+              - Random: references/functions/random.md
+              - String: references/functions/string.md
+              - Window: references/functions/window.md
           - Toolkit: references/toolkit.md
       - 📖 CLI Reference:
           - Overview: commands/index.md

--- a/src/datachain/func/string.py
+++ b/src/datachain/func/string.py
@@ -6,6 +6,14 @@ from datachain.sql.functions import string
 
 from .func import ColT, Func
 
+__all__ = [
+    "byte_hamming_distance",
+    "length",
+    "regexp_replace",
+    "replace",
+    "split",
+]
+
 
 def length(col: ColT) -> Func:
     """


### PR DESCRIPTION
String functions were not visible. All functions in one place make it really hard to navigate. Basics step to improve this.

## Summary by Sourcery

Organize function documentation into dedicated category pages, improve visibility and usage examples (including string functions), update site navigation, and streamline SQLMutate.apply_sql_clause argument handling

Enhancements:
- Refactor functions documentation into category-specific pages (aggregate, array, conditional, numeric, path, random, string, window)
- Update mkdocs navigation to include categorized function references
- Enhance main functions overview with usage examples and highlight string functions namespace
- Simplify SQLMutate.apply_sql_clause by using the raw args list instead of parsing columns