### PR TITLE
fix(mutate): simplify and drop mutated columns

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1258,8 +1258,10 @@ class DataChain:
                 # adding new signal
                 mutated[name] = value
 
+        new_schema = schema.mutate(kwargs)
         return self._evolve(
-            query=self._query.mutate(**mutated), signal_schema=schema.mutate(kwargs)
+            query=self._query.mutate(new_schema=new_schema, **mutated),
+            signal_schema=new_schema,
         )
 
     @property

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -10,7 +10,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from copy import copy
 from functools import wraps
-from secrets import token_hex
 from types import GeneratorType
 from typing import (
     TYPE_CHECKING,
@@ -29,7 +28,7 @@ from attrs import frozen
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback, TqdmCallback
 from sqlalchemy import Column
 from sqlalchemy.sql import func as f
-from sqlalchemy.sql.elements import ColumnClause, ColumnElement
+from sqlalchemy.sql.elements import ColumnClause, ColumnElement, Label
 from sqlalchemy.sql.expression import label
 from sqlalchemy.sql.schema import TableClause
 from sqlalchemy.sql.selectable import Select
@@ -795,28 +794,36 @@ class SQLSelectExcept(SQLClause):
 
 @frozen
 class SQLMutate(SQLClause):
-    args: tuple[Union[Function, ColumnElement], ...]
+    args: tuple[Label, ...]
 
     def apply_sql_clause(self, query: Select) -> Select:
         original_subquery = query.subquery()
-        args = [
-            original_subquery.c[str(c)] if isinstance(c, (str, C)) else c
-            for c in self.parse_cols(self.args)
-        ]
-        to_mutate = {c.name for c in args}
+        to_mutate = {c.name for c in self.args}
 
-        prefix = f"mutate{token_hex(8)}_"
-        cols = [
-            c.label(prefix + c.name) if c.name in to_mutate else c
+        # Collect columns that are being referenced by simple column renames
+        # e.g., mutate(new_col=C('old_col')) should exclude 'old_col' from base_cols
+        columns_to_exclude = set()
+        for label_expr in self.args:
+            if isinstance(label_expr.element, ColumnClause):
+                columns_to_exclude.add(label_expr.element.name)
+
+        # Drop the original versions to avoid name collisions and exclude renamed
+        # columns
+        base_cols = [
+            c
             for c in original_subquery.c
+            if c.name not in to_mutate and c.name not in columns_to_exclude
         ]
-        # this is needed for new column to be used in clauses
-        # like ORDER BY, otherwise new column is not recognized
-        subquery = (
-            sqlalchemy.select(*cols, *args).select_from(original_subquery).subquery()
-        )
 
-        return sqlalchemy.select(*subquery.c).select_from(subquery)
+        # Create intermediate subquery to properly handle window functions
+        intermediate_query = sqlalchemy.select(*base_cols, *self.args).select_from(
+            original_subquery
+        )
+        intermediate_subquery = intermediate_query.subquery()
+
+        return sqlalchemy.select(*intermediate_subquery.c).select_from(
+            intermediate_subquery
+        )
 
 
 @frozen

--- a/src/datachain/query/schema.py
+++ b/src/datachain/query/schema.py
@@ -36,6 +36,10 @@ class ColumnMeta(type):
     def __getattr__(cls, name: str):
         return cls(ColumnMeta.to_db_name(name))
 
+    @staticmethod
+    def is_nested(name: str) -> bool:
+        return DEFAULT_DELIMITER in name
+
 
 class Column(sa.ColumnClause, metaclass=ColumnMeta):
     inherit_cache: Optional[bool] = True

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -17,7 +17,7 @@ from datachain.sql.types import (
 from tests.utils import (
     DEFAULT_TREE,
     TARRED_TREE,
-    create_tar_dataset_with_legacy_columns,
+    create_tar_dataset,
 )
 
 COMPLEX_TREE: dict[str, Any] = {
@@ -39,7 +39,7 @@ def test_dir_expansion(cloud_test_catalog, version_aware, cloud_type):
         # we don't want to index things in parent directory
         src_uri += "/"
 
-    chain = create_tar_dataset_with_legacy_columns(session, ctc.src_uri, "dc")
+    chain = create_tar_dataset(session, ctc.src_uri, "dc")
     dataset = catalog.get_dataset(chain.name)
     with catalog.warehouse.clone() as warehouse:
         dr = warehouse.dataset_rows(dataset, column="file")

--- a/tests/func/test_mutate.py
+++ b/tests/func/test_mutate.py
@@ -264,8 +264,9 @@ def test_mutate_nested_column_complex_mutation(test_session):
     )
 
     schema = ds.signals_schema.values
+    assert "file" in schema
     assert "file__path" not in schema
-    assert "tmp" in schema
+    assert "tmp" not in schema
 
     results = ds.order_by("file.path").to_list()
     assert len(results) == 3

--- a/tests/func/test_mutate.py
+++ b/tests/func/test_mutate.py
@@ -1,0 +1,213 @@
+import datachain as dc
+from datachain import Column, func
+from datachain.func import path as pathfunc
+from datachain.lib.data_model import DataModel
+from datachain.lib.file import File
+
+
+def _create_test_files(names_and_sizes):
+    """Helper function to create test files with given names and sizes."""
+    return [File(path=name, size=size) for name, size in names_and_sizes]
+
+
+def test_mutate_overwrite_twice(test_session):
+    files = _create_test_files(
+        [("file1.txt", 100), ("file2.txt", 200), ("file3.txt", 300)]
+    )
+    ds = dc.read_values(file=files, session=test_session)
+
+    orig_sizes = ds.order_by("file.path").to_values("file.size")
+    mutated_ds = ds.mutate(file__size=Column("file.size") + 1).mutate(
+        file__size=Column("file.size") + 1
+    )
+
+    result_sizes = mutated_ds.order_by("file.path").to_values("file.size")
+    expected = [s + 2 for s in orig_sizes]
+    assert result_sizes == expected
+
+
+def test_mutate_overwrite_then_order_by(test_session):
+    files = _create_test_files(
+        [("small.txt", 50), ("medium.txt", 100), ("large.txt", 200), ("huge.txt", 500)]
+    )
+    ds = dc.read_values(file=files, session=test_session)
+    mutated_ds = ds.mutate(file__size=0 - Column("file.size"))
+    rows = mutated_ds.order_by("file.size").to_list()
+
+    sizes = [row[0].size for row in rows]
+    assert sizes == sorted(sizes)
+    assert len(rows) == 4
+
+    expected_paths = ["huge.txt", "large.txt", "medium.txt", "small.txt"]
+    actual_paths = [row[0].path for row in rows]
+    assert actual_paths == expected_paths
+
+
+def test_mutate_multiple_columns(test_session):
+    files = _create_test_files([("dir/file1.txt", 100), ("dir/file2.txt", 200)])
+    ds = dc.read_values(file=files, session=test_session)
+    result = ds.mutate(
+        size_doubled=Column("file.size") * 2,
+        filename=pathfunc.name(Column("file.path")),
+        is_large=True,
+    )
+
+    rows = result.order_by("file.path").to_list()
+    assert rows[0][1] == 200
+    assert rows[0][2] == "file1.txt"
+    assert rows[0][3]
+
+    assert rows[1][1] == 400
+    assert rows[1][2] == "file2.txt"
+    assert rows[1][3]
+
+
+def test_mutate_chaining_with_different_operations(test_session):
+    files = _create_test_files(
+        [("test1.txt", 10), ("test2.txt", 20), ("test3.txt", 30)]
+    )
+    ds = dc.read_values(file=files, session=test_session)
+    result = (
+        ds.mutate(doubled=Column("file.size") * 2)
+        .mutate(added=Column("doubled") + 5)
+        .mutate(final=Column("added") * 10)
+    )
+
+    expected_values = [250, 450, 650]  # (size*2+5)*10
+
+    actual_values = result.order_by("file.path").to_values("final")
+    assert actual_values == expected_values
+
+
+def test_mutate_existing_column(test_session):
+    ds = dc.read_values(ids=[1, 2, 3], session=test_session)
+    ds = ds.mutate(ids=Column("ids") + 1)
+    assert ds.order_by("ids").to_list() == [(2,), (3,), (4,)]
+
+
+def test_mutate_with_primitives_save_load(test_session):
+    original_data = [1, 2, 3]
+    ds = dc.read_values(data=original_data, session=test_session).mutate(
+        str_col="test_string",
+        int_col=42,
+        float_col=3.14,
+        bool_col=True,
+    )
+
+    schema = ds.signals_schema.values
+    assert schema.get("str_col") is str
+    assert schema.get("int_col") is int
+    assert schema.get("float_col") is float
+    assert schema.get("bool_col") is bool
+
+    ds.save("test_mutate_primitives")
+    loaded_ds = dc.read_dataset("test_mutate_primitives", session=test_session)
+
+    loaded_schema = loaded_ds.signals_schema.values
+    assert loaded_schema.get("str_col") is str
+    assert loaded_schema.get("int_col") is int
+    assert loaded_schema.get("float_col") is float
+    assert loaded_schema.get("bool_col") is bool
+
+    results = set(loaded_ds.to_list())
+    expected_results = {
+        (1, "test_string", 42, 3.14, True),
+        (2, "test_string", 42, 3.14, True),
+        (3, "test_string", 42, 3.14, True),
+    }
+    assert len(results) == 3
+    assert results == expected_results
+
+
+def test_persist_after_mutate(test_session):
+    chain = (
+        dc.read_values(fib=[1, 1, 2, 3, 5, 8, 13, 21], session=test_session)
+        .map(mod3=lambda fib: fib % 3, output=int)
+        .group_by(cnt=dc.func.count(), partition_by="mod3")
+        .mutate(x=1)
+        .persist()
+    )
+
+    assert chain.count() == 3
+    assert set(chain.to_values("mod3")) == {0, 1, 2}
+
+
+def test_mutate_rename_column_no_db_leakage(test_session):
+    files = _create_test_files(
+        [("file1.txt", 100), ("file2.txt", 200), ("file3.txt", 300)]
+    )
+    ds = dc.read_values(file=files, session=test_session)
+    renamed_ds = ds.mutate(new_file=Column("file"))
+    renamed_ds.save("test_rename_column")
+
+    loaded_ds = dc.read_dataset("test_rename_column", session=test_session)
+
+    # Check actual database records using DatasetQuery
+    from datachain.query.dataset import DatasetQuery
+
+    query = DatasetQuery("test_rename_column", catalog=test_session.catalog)
+    db_records = query.limit(5).to_db_records()
+    db_columns = set(db_records[0].keys())
+    file_columns = {col for col in db_columns if col.startswith("file__")}
+
+    assert len(file_columns) == 0, f"Found leaked old file__ columns: {file_columns}"
+
+    assert len(loaded_ds.to_list()) == 3
+
+    paths = loaded_ds.order_by("new_file.path").to_values("new_file.path")
+    assert paths == ["file1.txt", "file2.txt", "file3.txt"]
+
+
+def test_mutate_with_window_functions(test_session):
+    """Test mutate with window functions"""
+
+    files = _create_test_files(
+        [
+            ("cats/cat1", 4),
+            ("cats/cat2", 4),
+            ("dogs/dog1", 4),
+            ("dogs/dog2", 3),
+            ("dogs/dog3", 4),
+            ("dogs/others/dog4", 4),
+            ("description", 13),
+        ]
+    )
+
+    class FileInfo(DataModel):
+        path: str = ""
+        name: str = ""
+
+    def file_info(file: File) -> FileInfo:
+        path_parts = file.path.split("/", 1)
+        return FileInfo(
+            path=path_parts[0] if len(path_parts) > 1 else "",
+            name=path_parts[1] if len(path_parts) > 1 else path_parts[0],
+        )
+
+    window = func.window(
+        partition_by="file_info.path", order_by="file_info.name", desc=True
+    )
+
+    ds = (
+        dc.read_values(file=files, session=test_session)
+        .settings(prefetch=False)
+        .map(file_info, params=["file"], output={"file_info": FileInfo})
+        .mutate(row_number=func.row_number().over(window))
+        .filter(dc.C("row_number") < 3)
+        .select_except("row_number")
+        .save("test-window-mutate")
+    )
+
+    results = {}
+    for r in ds.to_records():
+        results.setdefault(r["file_info__path"], []).append(r["file_info__name"])
+
+    assert results[""] == ["description"]  # Only one file in root
+    assert sorted(results["cats"]) == sorted(["cat1", "cat2"])  # Both cats files
+
+    assert len(results["dogs"]) == 2
+    all_dogs = ["dog1", "dog2", "dog3", "others/dog4"]
+    for dog in results["dogs"]:
+        assert dog in all_dogs
+        all_dogs.remove(dog)
+    assert len(all_dogs) == 2

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1147,8 +1147,10 @@ def test_mutate_rename_leaf(nested_file_schema):
 
 def test_mutate_new_signal():
     schema = SignalSchema({"name": str})
-    schema = schema.mutate({"age": Column("age", Float)})
-    assert schema.values == {"name": str, "age": float}
+    with pytest.raises(
+        SignalResolvingError, match="cannot resolve signal name 'age': is not found"
+    ):
+        schema.mutate({"age": Column("age", Float)})
 
 
 def test_mutate_change_type():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,27 +100,15 @@ def write_tar(tree, archive, curr_dir=""):
 TARRED_TREE: dict[str, Any] = {"animals.tar": make_tar(DEFAULT_TREE)}
 
 
-def create_tar_dataset_with_legacy_columns(
-    session, uri: str, ds_name: str
-) -> dc.DataChain:
+def create_tar_dataset(session, uri: str, ds_name: str) -> dc.DataChain:
     """
     Create a dataset from a storage location containing tar archives and other files.
-
     The resulting dataset contains both the original files (as regular objects)
     and the tar members (as v-objects).
     """
     chain = dc.read_storage(uri, session=session)
     tar_entries = chain.filter(C("file.path").glob("*.tar")).gen(file=process_tar)
-    return (
-        chain.union(tar_entries)
-        .mutate(
-            path=C("file.path"),
-            source=C("file.source"),
-            location=C("file.location"),
-            version=C("file.version"),
-        )
-        .save(ds_name)
-    )
+    return chain.union(tar_entries).save(ds_name)
 
 
 skip_if_not_sqlite = pytest.mark.skipif(


### PR DESCRIPTION
Fixes https://github.com/iterative/studio/issues/11989
Fixes https://github.com/iterative/studio/issues/12041

+ Simplifies code (removed redundant code in mutate)
+ Adds more tests and consolidates existing tests
+ Fixes a few other edge cases (e.g. dealing with nested columns)

## Summary by Sourcery

Simplify and correct the mutate clause implementation and reorganize its tests

Bug Fixes:
- Fix mutate to drop original columns and prevent old column names from leaking into the database

Enhancements:
- Simplify SQLMutate.apply_sql_clause by using an intermediate subquery and excluding mutated columns to avoid name collisions
- Rename create_tar_dataset_with_legacy_columns to create_tar_dataset and remove its legacy mutate step

Tests:
- Consolidate and expand mutate tests into a new test_mutate.py covering overwrites, ordering, multiple columns, chaining, persistence, renaming, and window functions
- Remove outdated mutate tests from test_datachain.py