### PR TITLE
Fixing parallel

### DIFF
--- a/src/datachain/query/dispatch.py
+++ b/src/datachain/query/dispatch.py
@@ -1,4 +1,5 @@
 import contextlib
+import multiprocessing as mp
 from collections.abc import Iterable, Sequence
 from itertools import chain
 from multiprocessing import cpu_count
@@ -8,7 +9,6 @@ from typing import TYPE_CHECKING, Literal, Optional
 import multiprocess
 from cloudpickle import load, loads
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
-from multiprocess import get_context
 
 from datachain.catalog import Catalog
 from datachain.catalog.catalog import clone_catalog_with_cache
@@ -116,7 +116,7 @@ class UDFDispatcher:
         self.buffer_size = buffer_size
         self.task_queue = None
         self.done_queue = None
-        self.ctx = get_context("spawn")
+        self.ctx = mp.get_context("spawn")
 
     @property
     def catalog(self) -> "Catalog":

--- a/src/datachain/query/queue.py
+++ b/src/datachain/query/queue.py
@@ -1,6 +1,7 @@
 import datetime
 from collections.abc import Iterable, Iterator
-from queue import Empty, Full, Queue
+from multiprocessing.queue import Queue
+from queue import Empty, Full
 from struct import pack, unpack
 from time import sleep
 from typing import Any


### PR DESCRIPTION
Companion PR of https://github.com/iterative/studio/pull/12038

We mixed multiprocess and multiprocessing modules when calling `get_context("spawn")`

## Summary by Sourcery

Bug Fixes:
- Replace get_context("spawn") with mp.get_context("spawn") to ensure the correct multiprocessing context is used