### PR TITLE
Fix for delta with retry when multiple error rows with same `id`

### DIFF
--- a/src/datachain/delta.py
+++ b/src/datachain/delta.py
@@ -124,7 +124,13 @@ def _get_retry_chain(
     # Subtract also diff chain since some items might be picked
     # up by `delta=True` itself (e.g. records got modified AND are missing in the
     # result dataset atm)
-    return retry_chain.subtract(diff_chain, on=on) if retry_chain else None
+    return (
+        retry_chain.diff(
+            diff_chain, on="id", added=True, same=True, modified=False, deleted=False
+        )
+        if retry_chain
+        else None
+    )
 
 
 def _get_source_info(

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2231,6 +2231,13 @@ def test_subtract(test_session):
     assert set(chain4.subtract(chain5, on="d", right_on="a").to_list()) == {(3, "z")}
 
 
+def test_subtract_duplicated_rows(test_session):
+    chain1 = dc.read_values(id=[1, 1], name=["1", "1"], session=test_session)
+    chain2 = dc.read_values(id=[2], name=["2"], session=test_session)
+    sub = chain1.subtract(chain2, on="id")
+    assert set(sub.to_list()) == {(1, "1"), (1, "1")}
+
+
 def test_subtract_error(test_session):
     chain1 = dc.read_values(a=[1, 1, 2], b=["x", "y", "z"], session=test_session)
     chain2 = dc.read_values(a=[1, 2], b=["x", "y"], session=test_session)


### PR DESCRIPTION
Currently, if there are multiple error rows generated with same `id` (name of the column for matching) then, for some unexplained reason, subtract filters out "duplicates" and leaves out only one error row in result. I've also added test for subtract that should've fail as well but for some, yet unknown, reason test passes which means that subtract behaves differently in test and in retry delta code.
Instead of `.subtract()`, `.diff()` was used which works as expected. Note that `.subtract()` was working fine with Clickhouse DB (also not explainable right now).