### PR TITLE
fix(parallel): rebuild models after pickle

### DIFF
--- a/examples/get_started/nested_datamodel.py
+++ b/examples/get_started/nested_datamodel.py
@@ -1,0 +1,70 @@
+"""Example: Nested DataModels with parallel execution.
+
+Demonstrates mapping a function that returns a nested DataModel (a DataModel
+containing other DataModels).
+
+The example keeps things minimal: we persist a tiny dataset, run a parallel map
+that returns a nested DataModel, and display the result.
+"""
+
+from typing import Optional
+
+from pydantic import Field
+
+import datachain as dc
+
+
+class Metric(dc.DataModel):
+    """Represents a single computed metric with quality metadata."""
+
+    value: Optional[float] = Field(default=None, description="Computed metric value")
+    confidence: Optional[float] = Field(
+        default=None, description="Confidence / quality score"
+    )
+    status: Optional[str] = Field(default=None, description="Processing status label")
+    metric_error: Optional[str] = Field(
+        default=None, description="Error message if metric computation failed"
+    )
+
+
+class SampleMetrics(dc.DataModel):
+    """Container for two illustrative nested metrics.
+
+    Each sub-field is its own DataModel instance to demonstrate nested schemas
+    """
+
+    metric_primary: Metric = Field(
+        default_factory=lambda: Metric(), description="Primary metric"
+    )
+    metric_secondary: Metric = Field(
+        default_factory=lambda: Metric(), description="Secondary metric"
+    )
+
+
+def generate_sample_metrics() -> SampleMetrics:
+    """Synthesize a pair of metrics.
+
+    In real scenarios you'd compute these values; here we just return constants
+    to keep the example deterministic.
+    """
+
+    return SampleMetrics(
+        metric_primary=Metric(value=50.0, confidence=0.95, status="ok"),
+    )
+
+
+def main():
+    (
+        dc.read_values(record_id=[1, 2])
+        .settings(parallel=2)  # Keep it parallel to test serialization
+        .map(metrics=generate_sample_metrics)
+        .save("nested_datamodel")
+    )
+
+    dc.read_dataset("nested_datamodel").show()
+
+    print(dc.read_dataset("nested_datamodel").to_values("metrics"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datachain/lib/model_store.py
+++ b/src/datachain/lib/model_store.py
@@ -89,3 +89,15 @@ class ModelStore:
             and ModelStore.is_pydantic(parent_type)
             and "@" in ModelStore.get_name(parent_type)
         )
+
+    @classmethod
+    def rebuild_all(cls) -> None:
+        """Ensure pydantic schemas are (re)built for all registered models.
+
+        Uses ``force=True`` to avoid subtle cases where a deserialized class
+        (e.g. from by-value cloudpickle in workers) reports built state but
+        nested model field schemas aren't fully resolved yet.
+        """
+        for versions in cls.store.values():
+            for model in versions.values():
+                model.model_rebuild(force=True)

--- a/src/datachain/query/dispatch.py
+++ b/src/datachain/query/dispatch.py
@@ -13,6 +13,7 @@ from multiprocess import get_context
 from datachain.catalog import Catalog
 from datachain.catalog.catalog import clone_catalog_with_cache
 from datachain.catalog.loader import DISTRIBUTED_IMPORT_PATH, get_udf_distributor_class
+from datachain.lib.model_store import ModelStore
 from datachain.lib.udf import _get_cache
 from datachain.query.dataset import (
     get_download_callback,
@@ -130,6 +131,8 @@ class UDFDispatcher:
 
     def _create_worker(self) -> "UDFWorker":
         udf: UDFAdapter = loads(self.udf_data)
+        # Ensure all registered DataModels have rebuilt schemas in worker processes.
+        ModelStore.rebuild_all()
         return UDFWorker(
             self.catalog,
             udf,
@@ -196,6 +199,8 @@ class UDFDispatcher:
         generated_cb: Callback = DEFAULT_CALLBACK,
     ) -> None:
         udf: UDFAdapter = loads(self.udf_data)
+        # Rebuild schemas in single process too for consistency (cheap, idempotent).
+        ModelStore.rebuild_all()
 
         if ids_only and not self.is_batching:
             input_rows = flatten(input_rows)

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -417,7 +417,7 @@ class JSONSerialize(json.JSONEncoder):
 
 def inside_colab() -> bool:
     try:
-        from google import colab  # noqa: F401
+        from google import colab  # type: ignore[attr-defined]  # noqa: F401
     except ImportError:
         return False
     return True


### PR DESCRIPTION
Fixes issue with nested models in parallel and distributed modes. We had failure to initialize UDF outputs for such models. Seems this was happening due to lazy nature of Pydantic models initialization. Rebuild helps in this case. 

* AI was used to experiment and come up with an option. So I'm not sure it this is the only / or the best option.

It is hard to add unit / functional tests since it requires parallel mode + some tricky serialization, so we are using regular python script here. Also because users were asking about some nested models examples.

## Summary by Sourcery

Ensure Pydantic schemas for nested DataModels are rebuilt in both parallel worker and single-process modes to fix initialization failures in parallel and distributed UDF execution.

Bug Fixes:
- Fix lazy initialization of nested Pydantic models that caused UDF output failures in parallel and distributed modes

Enhancements:
- Add ModelStore.rebuild_all method to force schema rebuild for all registered DataModels
- Invoke ModelStore.rebuild_all before UDF execution in both worker creation and single-run paths

Documentation:
- Introduce an example script demonstrating nested DataModels with parallel execution