### PR TITLE
Fix 'mock_is_studio'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -547,11 +547,9 @@ def is_studio():
 
 @pytest.fixture(autouse=True)
 def mock_is_studio(monkeypatch, is_studio):
-    if not is_studio:
-        yield
-    else:
+    if is_studio:
         monkeypatch.setenv("DATACHAIN_IS_STUDIO", "True")
-        yield
+    yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,7 +550,7 @@ def mock_is_studio(monkeypatch, is_studio):
     if not is_studio:
         yield
     else:
-        monkeypatch.setenv("DATACHAIN_IS_STUDIO", True)
+        monkeypatch.setenv("DATACHAIN_IS_STUDIO", "True")
         yield
 
 


### PR DESCRIPTION
```
  /home/runner/work/datachain/datachain/tests/conftest.py:553: PytestWarning: Value of environment variable DATACHAIN_IS_STUDIO type should be str, but got True (type: bool); converted to str implicitly
    monkeypatch.setenv("DATACHAIN_IS_STUDIO", True)
```

## Summary by Sourcery

Bug Fixes:
- Fix mock_is_studio fixture to set DATACHAIN_IS_STUDIO to the string "True" to avoid pytest environment variable type warnings