### PR TITLE
Update the changes to job API

### DIFF
--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -240,7 +240,6 @@ class StudioClient:
 
         return Response(data, ok, message, response.status_code)
 
-    @retry_with_backoff(retries=3, errors=(HTTPError, Timeout))
     def _send_multipart_request(
         self, route: str, files: dict[str, Any], params: Optional[dict[str, Any]] = None
     ) -> Response[Any]:
@@ -263,12 +262,6 @@ class StudioClient:
             },
             timeout=self.timeout,
         )
-        try:
-            response.raise_for_status()
-        except HTTPError:
-            if _is_server_error(response.status_code):
-                # going to retry
-                raise
 
         ok = response.ok
         try:

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import logging
 import os
@@ -7,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from struct import unpack
 from typing import (
     Any,
+    BinaryIO,
     Generic,
     Optional,
     TypeVar,
@@ -30,8 +30,9 @@ DatasetExportStatus = Optional[dict[str, Any]]
 DatasetExportSignedUrls = Optional[list[str]]
 FileUploadData = Optional[dict[str, Any]]
 JobData = Optional[dict[str, Any]]
-JobListData = dict[str, Any]
-ClusterListData = dict[str, Any]
+JobListData = list[dict[str, Any]]
+ClusterListData = list[dict[str, Any]]
+
 logger = logging.getLogger("datachain")
 
 DATASET_ROWS_CHUNK_SIZE = 8192
@@ -239,6 +240,52 @@ class StudioClient:
 
         return Response(data, ok, message, response.status_code)
 
+    @retry_with_backoff(retries=3, errors=(HTTPError, Timeout))
+    def _send_multipart_request(
+        self, route: str, files: dict[str, Any], params: Optional[dict[str, Any]] = None
+    ) -> Response[Any]:
+        """
+        Function that communicates with Studio API using multipart/form-data.
+        It will raise an exception, and try to retry, if 5xx status code is
+        returned, or if Timeout exceptions is thrown from the requests lib
+        """
+        import requests
+
+        # Add team_name to params
+        request_params = {**(params or {}), "team_name": self.team}
+
+        response = requests.post(
+            url=f"{self.url}/{route}",
+            files=files,
+            params=request_params,
+            headers={
+                "Authorization": f"token {self.token}",
+            },
+            timeout=self.timeout,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            if _is_server_error(response.status_code):
+                # going to retry
+                raise
+
+        ok = response.ok
+        try:
+            data = json.loads(response.content.decode("utf-8"))
+        except json.decoder.JSONDecodeError:
+            data = {}
+
+        if not ok:
+            if response.status_code == 403:
+                message = f"Not authorized for the team {self.team}"
+            else:
+                message = data.get("message", "")
+        else:
+            message = ""
+
+        return Response(data, ok, message, response.status_code)
+
     @staticmethod
     def _unpacker_hook(code, data):
         import msgpack
@@ -409,12 +456,13 @@ class StudioClient:
             method="GET",
         )
 
-    def upload_file(self, content: bytes, file_name: str) -> Response[FileUploadData]:
-        data = {
-            "file_content": base64.b64encode(content).decode("utf-8"),
-            "file_name": file_name,
-        }
-        return self._send_request("datachain/upload-file", data)
+    def upload_file(
+        self, file_obj: BinaryIO, file_name: str
+    ) -> Response[FileUploadData]:
+        # Prepare multipart form data
+        files = {"file": (file_name, file_obj, "application/octet-stream")}
+
+        return self._send_multipart_request("datachain/jobs/files", files)
 
     def create_job(
         self,
@@ -449,25 +497,27 @@ class StudioClient:
             "cron_expression": cron,
             "credentials_name": credentials_name,
         }
-        return self._send_request("datachain/job", data)
+        return self._send_request("datachain/jobs/", data)
 
     def get_jobs(
         self,
         status: Optional[str] = None,
         limit: int = 20,
+        job_id: Optional[str] = None,
     ) -> Response[JobListData]:
-        return self._send_request(
-            "datachain/jobs",
-            {"status": status, "limit": limit} if status else {"limit": limit},
-            method="GET",
-        )
+        params: dict[str, Any] = {"limit": limit}
+        if status is not None:
+            params["status"] = status
+        if job_id is not None:
+            params["job_id"] = job_id
+        return self._send_request("datachain/jobs/", params, method="GET")
 
     def cancel_job(
         self,
         job_id: str,
     ) -> Response[JobData]:
-        url = f"datachain/job/{job_id}/cancel"
+        url = f"datachain/jobs/{job_id}/cancel"
         return self._send_request(url, data={}, method="POST")
 
     def get_clusters(self) -> Response[ClusterListData]:
-        return self._send_request("datachain/clusters", {}, method="GET")
+        return self._send_request("datachain/clusters/", {}, method="GET")

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -491,7 +491,7 @@ def list_clusters(team_name: Optional[str]):
     if not response.ok:
         raise DataChainError(response.message)
 
-    clusters = response.data if response.data else []
+    clusters = response.data or []
     if not clusters:
         print("No clusters found")
         return

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -455,7 +455,7 @@ def list_jobs(status: Optional[str], team_name: Optional[str], limit: int):
     if not response.ok:
         raise DataChainError(response.message)
 
-    jobs = response.data if response.data else []
+    jobs = response.data or []
     if not jobs:
         print("No jobs found")
         return

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -428,8 +428,7 @@ def upload_files(client: StudioClient, files: list[str]) -> list[str]:
         if not response.data:
             raise DataChainError(f"Failed to upload file {file_name}")
 
-        file_id = response.data.get("id")
-        if file_id:
+        if file_id := response.data.get("id"):
             file_ids.append(str(file_id))
     return file_ids
 


### PR DESCRIPTION
This uses the changes made to the job related apis https://github.com/iterative/studio/pull/12067 in an effort to make apis
public and uniform.

## Summary by Sourcery

Update Studio client and CLI to align with uniform job and cluster APIs by pluralizing endpoints, switching file uploads to multipart with retry, and adapting to new response structures

Enhancements:
- Add multipart/form-data upload support with retry logic in Studio client
- Change upload_file to use multipart upload at /datachain/jobs/files
- Standardize job and cluster routes to use pluralized endpoints
- Update JobListData and ClusterListData aliases to list of dicts
- Extend get_jobs to accept an optional job_id filter
- Adapt CLI to extract top-level id and url fields and show the new 'Is Default' cluster property

Tests:
- Update CLI tests to mock new pluralized endpoints and verify multipart/form-data uploads and query parameters