### PR TITLE
Added `QueryStep`

### DIFF
--- a/src/datachain/data_storage/__init__.py
+++ b/src/datachain/data_storage/__init__.py
@@ -1,4 +1,5 @@
 from .job import JobQueryType, JobStatus
+from .job_query_step import JobQueryStepStatus
 from .metastore import AbstractDBMetastore, AbstractMetastore
 from .warehouse import AbstractWarehouse
 
@@ -6,6 +7,7 @@ __all__ = [
     "AbstractDBMetastore",
     "AbstractMetastore",
     "AbstractWarehouse",
+    "JobQueryStepStatus",
     "JobQueryType",
     "JobStatus",
 ]

--- a/src/datachain/data_storage/job_query_step.py
+++ b/src/datachain/data_storage/job_query_step.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class JobQueryStepStatus(int, Enum):
+    RUNNING = 10
+    FINISHED = 20
+    ERROR = 30

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -458,6 +458,8 @@ class SQLiteMetastore(AbstractDBMetastore):
         self.default_table_names.append(self._datasets_dependencies.name)
         self.db.create_table(self._jobs, if_not_exists=True)
         self.default_table_names.append(self._jobs.name)
+        self.db.create_table(self._jobs_query_steps, if_not_exists=True)
+        self.default_table_names.append(self._jobs_query_steps.name)
 
     def _init_namespaces_projects(self) -> None:
         """
@@ -541,6 +543,12 @@ class SQLiteMetastore(AbstractDBMetastore):
 
     def _jobs_insert(self) -> "Insert":
         return sqlite.insert(self._jobs)
+
+    #
+    # Jobs query steps
+    #
+    def _jobs_query_steps_insert(self) -> "Insert":
+        return sqlite.insert(self._jobs_query_steps)
 
     #
     # Namespaces

--- a/src/datachain/job.py
+++ b/src/datachain/job.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, Optional, TypeVar, Union
 
 J = TypeVar("J", bound="Job")
+JQS = TypeVar("JQS", bound="JobQueryStep")
 
 
 @dataclass
@@ -52,6 +53,44 @@ class Job:
             json.loads(metrics),
             finished_at,
             python_version,
+            error_message,
+            error_stack,
+        )
+
+
+@dataclass
+class JobQueryStep:
+    """
+    Class that represents one chain that results in a saved dataset inside a job
+    query script. One job can have multiple chains and produced datasets so it can
+    have multiple query steps as well.
+    """
+
+    id: str
+    job_id: str
+    status: int
+    started_at: datetime
+    finished_at: Optional[datetime] = None
+    error_message: str = ""
+    error_stack: str = ""
+
+    @classmethod
+    def parse(
+        cls,
+        id: Union[str, uuid.UUID],
+        job_id: str,
+        status: int,
+        error_message: str,
+        error_stack: str,
+        started_at: datetime,
+        finished_at: Optional[datetime],
+    ) -> "JobQueryStep":
+        return cls(
+            str(id),
+            job_id,
+            status,
+            started_at,
+            finished_at,
             error_message,
             error_stack,
         )


### PR DESCRIPTION
`QueryStep` is new model that tracks each specific chain in job query script. We track when chain has began to process and when it ended. This will be needed later on with checkpoints, as we need to track chains somehow and skip those that have successfully ended on job  re-run.

## Summary by Sourcery

Introduce JobQueryStep tracking to record each query step’s lifecycle (start, finish, error) in the metastore and integrate it into the Datachain save workflow

New Features:
- Add JobQueryStep dataclass and JobQueryStepStatus enum
- Extend AbstractMetastore API and SQLite schema with CRUD operations for job query steps
- Instrument Datachain.save to create and update query steps on job start, completion, and failure

Tests:
- Add functional tests for success and error scenarios of job query step tracking