### PR TITLE
fix(ds query): isolate temp table names

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1438,6 +1438,7 @@ class DatasetQuery:
         # This is needed to always use a new connection with all metastore and warehouse
         # implementations, as errors may close or render unusable the existing
         # connections.
+        assert len(self.temp_table_names) == len(set(self.temp_table_names))
         with self.catalog.metastore.clone(use_new_connection=True) as metastore:
             metastore.cleanup_tables(self.temp_table_names)
         with self.catalog.warehouse.clone(use_new_connection=True) as warehouse:
@@ -1531,6 +1532,7 @@ class DatasetQuery:
         obj.steps = obj.steps.copy()
         if new_table:
             obj.table = self.get_table()
+        obj.temp_table_names = []
         return obj
 
     @detach
@@ -1870,11 +1872,11 @@ class DatasetQuery:
 
     def exec(self) -> "Self":
         """Execute the query."""
+        query = self.clone()
         try:
-            query = self.clone()
             query.apply_steps()
         finally:
-            self.cleanup()
+            query.cleanup()
         return query
 
     def save(


### PR DESCRIPTION
Updated: might also fix https://github.com/iterative/datachain/issues/722

When we run multiple joins, within the same chain, due to a recursive line:

```python
temp_tables.extend(dq.temp_table_names)
```

in `SQLJoin` ([link](https://github.com/iterative/datachain/blob/91617c050a981d096b06e4d5185ccc12fa30458a/src/datachain/query/dataset.py#L933-L944))

we might end up with a list of 8K+ items, with a lot a lot of duplicates. 

It means query can run very long at the end.

Script to reproduce this. Mind we run show and save at the end, essentially also means we are doubling the list.

```python
from dotenv import load_dotenv

import datachain as dc
from datachain import C, func


load_dotenv("local/.env.test")

all_files = dc.read_storage("gs://datachain-demo", anon=False).mutate(s3_path=dc.C("file.path")).persist()

laion_files = all_files.filter(dc.C("file.path").glob("50k-laion-files/*")).mutate(laion_file=dc.C("file"))
aspset510_files = all_files.filter(dc.C("file.path").glob("aspset510/*")).mutate(aspset510_file=dc.C("file"))
coco2017_files = all_files.filter(dc.C("file.path").glob("coco2017/*")).mutate(coco2017_file=dc.C("file"))
datacomp_small_files = all_files.filter(dc.C("file.path").glob("datacomp-small/*")).mutate(datacomp_small_file=dc.C("file"))
open_images_v6_files = all_files.filter(dc.C("file.path").glob("open-images-v6/*")).mutate(open_images_v6_file=dc.C("file"))
nlp_cnn_stories_files = all_files.filter(dc.C("file.path").glob("nlp-cnn-stories/*")).mutate(nlp_cnn_stories_file=dc.C("file"))

raw_data = (
    laion_files
    .merge(aspset510_files, on="s3_path", inner=True)
    .merge(coco2017_files, on="s3_path", inner=True)
    .merge(datacomp_small_files, on="s3_path", inner=True)
    .merge(open_images_v6_files, on="s3_path", inner=True)
    .merge(nlp_cnn_stories_files, on="s3_path", inner=False)
    .select(
        "s3_path",
        "laion_file",
        "aspset510_file",
        "coco2017_file",
        "datacomp_small_file",
        "open_images_v6_file",
        "nlp_cnn_stories_file",
    )
)

raw_data.save("datachain-demo-merge")
raw_data.show(1000)
```


## TODO:

- [x] Run all tests
- [x] Add description
- [x] Add proper tests
- [x] Confirm semantics one more time

## Summary by Sourcery

Isolate temporary table names per dataset clone and enforce no duplicates to prevent runaway temp table list growth, and fix cleanup to target the cloned query instance.

Bug Fixes:
- Add assertion to ensure temp_table_names has no duplicates before cleanup
- Reset temp_table_names on dataset.clone to avoid carrying over names from previous queries
- Modify exec to clean up temp tables on the cloned query instance rather than the original