### PR TITLE
fix(delta): read qualified dataset name on no changes in delta

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -657,7 +657,9 @@ class DataChain:
                 # current latest version instead.
                 from .datasets import read_dataset
 
-                return read_dataset(name, **kwargs)
+                return read_dataset(
+                    name, namespace=namespace_name, project=project_name, **kwargs
+                )
 
         return self._evolve(
             query=self._query.save(


### PR DESCRIPTION
Fixes the scenario in delta case:

* No changes / second run
* Output dataset name exists in the default namespace (as well as in the target namespace)
* Delta silently reading the dataset from de the default namespace instead of the proper one (in the target namespace)

Quite serious issue since it can lead to usage of some wrong data

## Summary by Sourcery

Ensure delta save with no changes returns the correct dataset version from the intended namespace and project instead of defaulting to the default namespace

Bug Fixes:
- Pass namespace and project parameters to read_dataset when handling no-change delta saves to avoid reading from the default namespace

Enhancements:
- Update dependency retrieval to include project and namespace context and generate properly qualified dataset names

Tests:
- Introduce helper _get_short_ds_name and update existing tests to use fully qualified names
- Add test to verify no-change delta behavior across multiple namespace and project combinations