### PR TITLE
Added `delete_namespace` docs

### DIFF
--- a/docs/guide/namespaces.md
+++ b/docs/guide/namespaces.md
@@ -163,7 +163,7 @@ ds.show()
 
 ## Removing Namespaces and Projects
 
-Use `delete_namespace` to remove an empty namespace or an empty project within a namespace.
+Use `delete_namespace` to remove an empty namespace or an empty project within a namespace. Delete will fail if the target is not empty.
 
 ### Signature
 
@@ -171,10 +171,8 @@ Use `delete_namespace` to remove an empty namespace or an empty project within a
 def delete_namespace(name: str, session: Optional[Session]) -> None:
 ```
 
-- **`<namespace>`** — deletes the namespace (must contain no projects or datasets)
-- **`<namespace>.<project>`** — deletes the project (must contain no datasets)
-- Call fails if target is not empty
-- Deletion is permanent
+- **`<namespace>`** — deletes the namespace (must contain no projects or datasets).
+- **`<namespace>.<project>`** — deletes the project (must contain no datasets).
 
 ### Examples
 

--- a/docs/guide/namespaces.md
+++ b/docs/guide/namespaces.md
@@ -159,3 +159,28 @@ dc.read_values(scores=[0.8, 1.5, 2.1]).save("metrics")
 
 ds = dc.read_dataset("local.local.metrics")
 ds.show()
+```
+
+## Removing Namespaces and Projects
+
+Use `delete_namespace` to remove an empty namespace or an empty project within a namespace.
+
+### Signature
+
+```python
+def delete_namespace(name: str, session: Optional[Session]) -> None:
+```
+
+- **`<namespace>`** — deletes the namespace (must contain no projects or datasets)
+- **`<namespace>.<project>`** — deletes the project (must contain no datasets)
+- Call fails if target is not empty
+- Deletion is permanent
+
+### Examples
+
+```python
+import datachain as dc
+
+dc.delete_namespace("dev.my-project")  # delete project
+dc.delete_namespace("dev")             # delete namespace
+```

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -19,6 +19,8 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.datasets.move_dataset
 
+::: datachain.lib.namespaces.delete
+
 ::: datachain.lib.dc.hf.read_hf
 
 ::: datachain.lib.dc.json.read_json

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -19,7 +19,7 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.datasets.move_dataset
 
-::: datachain.lib.namespaces.delete
+::: datachain.lib.namespaces.delete_namespace
 
 ::: datachain.lib.dc.hf.read_hf
 

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -37,7 +37,7 @@ from datachain.lib.file import (
     VideoFrame,
 )
 from datachain.lib.model_store import ModelStore
-from datachain.lib.namespaces import delete as delete_namespace
+from datachain.lib.namespaces import delete_namespace
 from datachain.lib.projects import create as create_project
 from datachain.lib.udf import Aggregator, Generator, Mapper
 from datachain.lib.utils import AbstractUDF, DataChainError

--- a/src/datachain/lib/namespaces.py
+++ b/src/datachain/lib/namespaces.py
@@ -88,8 +88,8 @@ def delete_namespace(name: str, session: Optional[Session]) -> None:
             as these cannot be removed.
 
     Parameters:
-        name : The name of the namespace.
-        session : Session to use for getting project.
+        name: The name of the namespace.
+        session: Session to use for getting project.
 
     Example:
         ```py

--- a/src/datachain/lib/namespaces.py
+++ b/src/datachain/lib/namespaces.py
@@ -77,7 +77,7 @@ def ls(session: Optional[Session] = None) -> list[Namespace]:
     return Session.get(session).catalog.metastore.list_namespaces()
 
 
-def delete(name: str, session: Optional[Session]) -> None:
+def delete_namespace(name: str, session: Optional[Session]) -> None:
     """
     Removes a namespace by name.
 
@@ -94,8 +94,7 @@ def delete(name: str, session: Optional[Session]) -> None:
     Example:
         ```py
         import datachain as dc
-        from datachain.lib.namespace import delete as delete_namespace
-        delete_namespace("dev")
+        dc.delete_namespace("dev")
         ```
     """
     session = Session.get(session)

--- a/tests/unit/lib/test_namespace.py
+++ b/tests/unit/lib/test_namespace.py
@@ -7,7 +7,7 @@ from datachain.error import (
     NamespaceNotFoundError,
 )
 from datachain.lib.namespaces import create as create_namespace
-from datachain.lib.namespaces import delete as delete_namespace
+from datachain.lib.namespaces import delete_namespace
 from datachain.lib.namespaces import get as get_namespace
 from datachain.lib.namespaces import ls as ls_namespaces
 from datachain.lib.projects import create as create_project

--- a/tests/unit/lib/test_project.py
+++ b/tests/unit/lib/test_project.py
@@ -8,7 +8,7 @@ from datachain.error import (
     ProjectNotFoundError,
 )
 from datachain.lib.namespaces import create as create_namespace
-from datachain.lib.namespaces import delete as delete_namespace
+from datachain.lib.namespaces import delete_namespace
 from datachain.lib.namespaces import get as get_namespace
 from datachain.lib.projects import get as get_project
 from datachain.lib.projects import ls as ls_projects


### PR DESCRIPTION
Added docs for `delete_namespace` and fix current docs formatting.

## Summary by Sourcery

Add documentation for the `delete_namespace` function in the namespaces guide, including its signature, behavior, and usage examples, and correct existing formatting issues.

Enhancements:
- Fix formatting inconsistencies in the namespaces guide

Documentation:
- Document the `delete_namespace` function with details on removing empty namespaces or projects
- Include the function signature, parameter descriptions, and behavior constraints
- Add usage examples demonstrating namespace and project deletion