### PR TITLE
Fixing delete namespace

### DIFF
--- a/src/datachain/lib/namespaces.py
+++ b/src/datachain/lib/namespaces.py
@@ -77,7 +77,7 @@ def ls(session: Optional[Session] = None) -> list[Namespace]:
     return Session.get(session).catalog.metastore.list_namespaces()
 
 
-def delete_namespace(name: str, session: Optional[Session]) -> None:
+def delete_namespace(name: str, session: Optional[Session] = None) -> None:
     """
     Removes a namespace by name.
 

--- a/tests/unit/lib/test_namespace.py
+++ b/tests/unit/lib/test_namespace.py
@@ -88,6 +88,13 @@ def test_delete_namespace(test_session, dev_namespace):
         get_namespace(dev_namespace.name, session=test_session)
 
 
+def test_delete_namespace_no_session():
+    create_namespace("dev", "Dev namespace")
+    delete_namespace("dev")
+    with pytest.raises(NamespaceNotFoundError):
+        get_namespace("dev")
+
+
 def test_delete_namespace_not_found(test_session, dev_namespace):
     with pytest.raises(NamespaceNotFoundError):
         delete_namespace("missing", session=test_session)


### PR DESCRIPTION
Small fix for session arg

## Summary by Sourcery

Bug Fixes:
- Add default None to the session argument in delete_namespace to match other APIs