### PR TITLE
use pydantic instead of pickle for object configs

### DIFF
--- a/src/datachain/catalog/loader.py
+++ b/src/datachain/catalog/loader.py
@@ -44,6 +44,7 @@ def get_metastore(in_memory: bool = False) -> "AbstractMetastore":
                     APIMetastoreConfig,
                     PostgreSQLMetastoreConfig,
                 )
+
                 cfg_map = {
                     "api_metastore": APIMetastoreConfig,
                     "postgresql_metastore": PostgreSQLMetastoreConfig,
@@ -107,6 +108,7 @@ def get_warehouse(in_memory: bool = False) -> "AbstractWarehouse":
                 from datachain_server.config import (
                     ClickHouseWarehouseConfig,
                 )
+
                 cfg_map = {"clickhouse_warehouse": ClickHouseWarehouseConfig}
                 cfg_cls = cfg_map[kind]
                 return cfg_cls.model_validate(data).build()

--- a/src/datachain/data_storage/config.py
+++ b/src/datachain/data_storage/config.py
@@ -1,0 +1,57 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+from datachain.dataset import StorageURI
+
+from .sqlite import (
+    SQLiteDatabaseEngine,
+    SQLiteMetastore,
+    SQLiteWarehouse,
+    get_db_file_in_memory,
+)
+
+
+class SQLiteDatabaseEngineConfig(BaseModel):
+    kind: Literal["sqlite_db_engine"] = "sqlite_db_engine"
+    db_file: Optional[str] = None
+    in_memory: bool = False
+
+    def build(self) -> SQLiteDatabaseEngine:
+        return SQLiteDatabaseEngine.from_db_file(
+            get_db_file_in_memory(self.db_file, self.in_memory)
+        )
+
+    @classmethod
+    def from_instance(cls, db: SQLiteDatabaseEngine) -> "SQLiteDatabaseEngineConfig":
+        # Ensure Path-like values are serialized as strings for JSON/env usage
+        db_file = db.db_file
+        return cls(
+            db_file=str(db_file) if db_file is not None else None,
+            in_memory=(db_file == ":memory:"),
+        )
+
+
+class SQLiteMetastoreConfig(BaseModel):
+    kind: Literal["sqlite_metastore"] = "sqlite_metastore"
+    uri: str = ""
+    db: SQLiteDatabaseEngineConfig
+
+    def build(self) -> SQLiteMetastore:
+        return SQLiteMetastore(uri=StorageURI(self.uri), db=self.db.build())
+
+    @classmethod
+    def from_instance(cls, ms: SQLiteMetastore) -> "SQLiteMetastoreConfig":
+        return cls(uri=str(ms.uri), db=SQLiteDatabaseEngineConfig.from_instance(ms.db))
+
+
+class SQLiteWarehouseConfig(BaseModel):
+    kind: Literal["sqlite_warehouse"] = "sqlite_warehouse"
+    db: SQLiteDatabaseEngineConfig
+
+    def build(self) -> SQLiteWarehouse:
+        return SQLiteWarehouse(db=self.db.build())
+
+    @classmethod
+    def from_instance(cls, wh: SQLiteWarehouse) -> "SQLiteWarehouseConfig":
+        return cls(db=SQLiteDatabaseEngineConfig.from_instance(wh.db))

--- a/src/datachain/data_storage/serializer.py
+++ b/src/datachain/data_storage/serializer.py
@@ -1,8 +1,7 @@
 import base64
 import pickle
 from abc import abstractmethod
-from collections.abc import Callable
-from typing import Any
+from typing import Any, Callable
 
 
 class Serializable:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,7 @@ def clean_environment(
     working_dir = str(tmp_path_factory.mktemp("default_working_dir"))
     monkeypatch_session.chdir(working_dir)
     monkeypatch_session.delenv(DataChainDir.ENV_VAR, raising=False)
+    monkeypatch_session.delenv(DataChainDir.ENV_VAR_DATACHAIN_ROOT, raising=False)
 
 
 @pytest.fixture

--- a/tests/test_atomicity.py
+++ b/tests/test_atomicity.py
@@ -38,14 +38,23 @@ def test_atomicity_feature_file(tmp_dir, catalog_tmpfile):
         create_rows=True,
     )
 
+    from datachain.data_storage.config import (
+        SQLiteMetastoreConfig,
+        SQLiteWarehouseConfig,
+    )
+
     process = subprocess.Popen(  # noqa: S603
         command,
         shell=False,
         encoding="utf-8",
         env={
             **os.environ,
-            "DATACHAIN__METASTORE": catalog_tmpfile.metastore.serialize(),
-            "DATACHAIN__WAREHOUSE": catalog_tmpfile.warehouse.serialize(),
+            "DATACHAIN__METASTORE": SQLiteMetastoreConfig.from_instance(
+                catalog_tmpfile.metastore
+            ).model_dump_json(),
+            "DATACHAIN__WAREHOUSE": SQLiteWarehouseConfig.from_instance(
+                catalog_tmpfile.warehouse
+            ).model_dump_json(),
         },
         **popen_args,
     )

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -214,6 +214,11 @@ def verify_files(files, base=""):
 
 def run_step(step, catalog):
     """Run an end-to-end test step with a command and expected output."""
+    from datachain.data_storage.config import (
+        SQLiteMetastoreConfig,
+        SQLiteWarehouseConfig,
+    )
+
     result = subprocess.run(  # noqa: S603
         step["command"],
         shell=False,
@@ -222,8 +227,12 @@ def run_step(step, catalog):
         encoding="utf-8",
         env={
             **os.environ,
-            "DATACHAIN__METASTORE": catalog.metastore.serialize(),
-            "DATACHAIN__WAREHOUSE": catalog.warehouse.serialize(),
+            "DATACHAIN__METASTORE": SQLiteMetastoreConfig.from_instance(
+                catalog.metastore
+            ).model_dump_json(),
+            "DATACHAIN__WAREHOUSE": SQLiteWarehouseConfig.from_instance(
+                catalog.warehouse
+            ).model_dump_json(),
         },
     )
 

--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -174,6 +174,11 @@ def run_step(step, catalog):  # noqa: PLR0912
         # additional code duplication, as a file is only opened if needed.
         stdin_file = open(step["stdin_file"])  # noqa: SIM115
     try:
+        from datachain.data_storage.config import (
+            SQLiteMetastoreConfig,
+            SQLiteWarehouseConfig,
+        )
+
         process = subprocess.Popen(  # noqa: S603
             command,
             shell=False,
@@ -183,8 +188,12 @@ def run_step(step, catalog):  # noqa: PLR0912
             encoding="utf-8",
             env={
                 **os.environ,
-                "DATACHAIN__METASTORE": catalog.metastore.serialize(),
-                "DATACHAIN__WAREHOUSE": catalog.warehouse.serialize(),
+                "DATACHAIN__METASTORE": SQLiteMetastoreConfig.from_instance(
+                    catalog.metastore
+                ).model_dump_json(),
+                "DATACHAIN__WAREHOUSE": SQLiteWarehouseConfig.from_instance(
+                    catalog.warehouse
+                ).model_dump_json(),
             },
             **popen_args,
         )


### PR DESCRIPTION
To enforce security we need to migrate from pickle to more structured approach on how we pass metastore, warehouse and other params from one process to another.

The current implementation raises flags across different systems.

## Summary by Sourcery

Migrate metastore and warehouse configuration from pickle-based payloads to structured Pydantic-powered JSON schemas with backward compatibility for legacy serialized data.

New Features:
- Add Pydantic config models (SQLiteDatabaseEngineConfig, SQLiteMetastoreConfig, SQLiteWarehouseConfig) for JSON-based serialization and instance construction.

Enhancements:
- Update get_metastore and get_warehouse to parse JSON config payloads, fallback to legacy base64 pickle, and build instances via new config models.

Tests:
- Refactor unit and end-to-end tests to use JSON serialization through config.from_instance(), adjust deserialization assertions, and clean up DATACHAIN__ROOT environment variable.