### PR TITLE
Skip processing chain if checkpoint exists

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -399,6 +399,7 @@ class AbstractMetastore(ABC, Serializable):
         workers: int = 1,
         python_version: Optional[str] = None,
         params: Optional[dict[str, str]] = None,
+        parent_job_id: Optional[str] = None,
     ) -> str:
         """
         Creates a new job.
@@ -1596,6 +1597,7 @@ class AbstractDBMetastore(AbstractMetastore):
         workers: int = 1,
         python_version: Optional[str] = None,
         params: Optional[dict[str, str]] = None,
+        parent_job_id: Optional[str] = None,
         conn: Optional[Any] = None,
     ) -> str:
         """
@@ -1617,6 +1619,7 @@ class AbstractDBMetastore(AbstractMetastore):
                 error_stack="",
                 params=json.dumps(params or {}),
                 metrics=json.dumps({}),
+                parent_job_id=parent_job_id,
             ),
             conn=conn,
         )

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    desc,
     select,
 )
 from sqlalchemy.sql import func as f
@@ -443,6 +444,10 @@ class AbstractMetastore(ABC, Serializable):
     @abstractmethod
     def list_checkpoints(self, job_id: str, conn=None) -> Iterator["Checkpoint"]:
         """Returns all checkpoints related to some job"""
+
+    @abstractmethod
+    def get_last_checkpoint(self, job_id: str, conn=None) -> Optional[Checkpoint]:
+        """Get last created checkpoint for some job."""
 
     @abstractmethod
     def get_checkpoint_by_id(self, checkpoint_id: str, conn=None) -> Checkpoint:
@@ -1774,7 +1779,7 @@ class AbstractDBMetastore(AbstractMetastore):
         )
         return self.get_checkpoint_by_id(checkpoint_id)
 
-    def list_checkpoints(self, job_id: str, conn=None) -> Iterator["Checkpoint"]:
+    def list_checkpoints(self, job_id: str, conn=None) -> Iterator[Checkpoint]:
         """List checkpoints by job id."""
         query = self._checkpoints_query().where(self._checkpoints.c.job_id == job_id)
         rows = list(self.db.execute(query, conn=conn))
@@ -1799,6 +1804,18 @@ class AbstractDBMetastore(AbstractMetastore):
         ch = self._checkpoints
         query = self._checkpoints_select(ch).where(
             ch.c.job_id == job_id, ch.c.hash == _hash, ch.c.partial == partial
+        )
+        rows = list(self.db.execute(query, conn=conn))
+        if not rows:
+            return None
+        return self.checkpoint_class.parse(*rows[0])
+
+    def get_last_checkpoint(self, job_id: str, conn=None) -> Optional[Checkpoint]:
+        query = (
+            self._checkpoints_query()
+            .where(self._checkpoints.c.job_id == job_id)
+            .order_by(desc(self._checkpoints.c.created_at))
+            .limit(1)
         )
         rows = list(self.db.execute(query, conn=conn))
         if not rows:

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1603,6 +1603,14 @@ class AbstractDBMetastore(AbstractMetastore):
         Returns the job id.
         """
         job_id = str(uuid4())
+        print("---------------------------------------------------------------")
+        print("---------------------------------------------------------------")
+        print(f"Creating new job with id {job_id}")
+        print(f"Creating new job with id {job_id}")
+        print(f"Creating new job with id {job_id}")
+        print(f"Creating new job with id {job_id}")
+        print("---------------------------------------------------------------")
+        print("---------------------------------------------------------------")
         self.db.execute(
             self._jobs_insert().values(
                 id=job_id,
@@ -1625,6 +1633,10 @@ class AbstractDBMetastore(AbstractMetastore):
     def get_job(self, job_id: str, conn=None) -> Optional[Job]:
         """Returns the job with the given ID."""
         query = self._jobs_select(self._jobs).where(self._jobs.c.id == job_id)
+        print("Job query is")
+        print("Job query is")
+        print("Job query is")
+        print(query)
         results = list(self.db.execute(query, conn=conn))
         if not results:
             return None

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1603,14 +1603,6 @@ class AbstractDBMetastore(AbstractMetastore):
         Returns the job id.
         """
         job_id = str(uuid4())
-        print("---------------------------------------------------------------")
-        print("---------------------------------------------------------------")
-        print(f"Creating new job with id {job_id}")
-        print(f"Creating new job with id {job_id}")
-        print(f"Creating new job with id {job_id}")
-        print(f"Creating new job with id {job_id}")
-        print("---------------------------------------------------------------")
-        print("---------------------------------------------------------------")
         self.db.execute(
             self._jobs_insert().values(
                 id=job_id,
@@ -1633,10 +1625,6 @@ class AbstractDBMetastore(AbstractMetastore):
     def get_job(self, job_id: str, conn=None) -> Optional[Job]:
         """Returns the job with the given ID."""
         query = self._jobs_select(self._jobs).where(self._jobs.c.id == job_id)
-        print("Job query is")
-        print("Job query is")
-        print("Job query is")
-        print(query)
         results = list(self.db.execute(query, conn=conn))
         if not results:
             return None

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1548,6 +1548,7 @@ class AbstractDBMetastore(AbstractMetastore):
             Column("error_stack", Text, nullable=False, default=""),
             Column("params", JSON, nullable=False),
             Column("metrics", JSON, nullable=False),
+            Column("parent_job_id", Text, nullable=True),
         ]
 
     @cached_property

--- a/src/datachain/error.py
+++ b/src/datachain/error.py
@@ -101,3 +101,7 @@ class OutdatedDatabaseSchemaError(DataChainError):
 
 class CheckpointNotFoundError(NotFoundError):
     pass
+
+
+class JobNotFoundError(NotFoundError):
+    pass

--- a/src/datachain/job.py
+++ b/src/datachain/job.py
@@ -22,6 +22,7 @@ class Job:
     python_version: Optional[str] = None
     error_message: str = ""
     error_stack: str = ""
+    parent_job_id: Optional[str] = None
 
     @classmethod
     def parse(
@@ -39,6 +40,7 @@ class Job:
         error_stack: str,
         params: str,
         metrics: str,
+        parent_job_id: Optional[str],
     ) -> "Job":
         return cls(
             str(id),
@@ -54,4 +56,5 @@ class Job:
             python_version,
             error_message,
             error_stack,
+            parent_job_id,
         )

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -587,11 +587,7 @@ class DataChain:
         Hash is calculated using previous job checkpoint hash (if exists) and
         adding hash of this chain to produce new hash.
         """
-        last_checkpoint = max(
-            self.session.catalog.metastore.list_checkpoints(job_id),
-            key=lambda obj: obj.created_at,
-            default=None,
-        )
+        last_checkpoint = self.session.catalog.metastore.get_last_checkpoint(job_id)
 
         return hashlib.sha256(
             (bytes.fromhex(last_checkpoint.hash) if last_checkpoint else b"")

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -700,7 +700,7 @@ class DataChain:
         metastore = self.session.catalog.metastore
 
         job_id = os.getenv("DATACHAIN_JOB_ID")
-        checkpoints_reset = env2bool("DATACHAIN_CHECKPOINTS_RESET")
+        checkpoints_reset = env2bool("DATACHAIN_CHECKPOINTS_RESET", undefined=True)
 
         if not job_id:
             return None, None, None

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -37,6 +37,7 @@ from datachain.error import (
 from datachain.func import literal
 from datachain.func.base import Function
 from datachain.func.func import Func
+from datachain.job import Job
 from datachain.lib.convert.python_to_sql import python_to_sql
 from datachain.lib.data_model import (
     DataModel,
@@ -53,6 +54,7 @@ from datachain.lib.signal_schema import SignalResolvingError, SignalSchema
 from datachain.lib.udf import Aggregator, BatchMapper, Generator, Mapper, UDFBase
 from datachain.lib.udf_signature import UdfSignature
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
+from datachain.project import Project
 from datachain.query import Session
 from datachain.query.dataset import DatasetQuery, PartitionByType
 from datachain.query.schema import DEFAULT_DELIMITER, Column
@@ -618,126 +620,171 @@ class DataChain:
             update_version: which part of the dataset version to automatically increase.
                 Available values: `major`, `minor` or `patch`. Default is `patch`.
         """
-        from .datasets import read_dataset
 
         catalog = self.session.catalog
-        metastore = catalog.metastore
 
-        job = None
-        _hash = None
-        job_id = os.getenv("DATACHAIN_JOB_ID")
-        checkpoints_reset = env2bool("DATACHAIN_CHECKPOINTS_RESET")
+        result = None  # result chain that will be returned at the end
 
-        if version is not None:
-            semver.validate(version)
-
-        if update_version is not None and update_version not in [
-            "patch",
-            "major",
-            "minor",
-        ]:
-            raise ValueError(
-                "update_version can have one of the following values: major, minor or"
-                " patch"
-            )
+        # Version validation
+        self._validate_version(version)
+        self._validate_update_version(update_version)
 
         namespace_name, project_name, name = catalog.get_full_dataset_name(
             name,
             namespace_name=self._settings.namespace,
             project_name=self._settings.project,
         )
+        project = self._get_or_create_project(namespace_name, project_name)
 
-        try:
-            project = self.session.catalog.metastore.get_project(
-                project_name,
-                namespace_name,
-                create=is_studio(),
-            )
-        except ProjectNotFoundError as e:
-            # not being able to create it as creation is not allowed
-            raise ProjectCreateNotAllowedError("Creating project is not allowed") from e
+        # Checkpoint handling
+        job, _hash, result = self._resolve_checkpoint(name, project, kwargs)
 
-        # checking checkpoints and skip re-calculation of the chain if checkpoint exist
-        if job_id:
-            job = metastore.get_job(job_id)
-            if not job:
-                raise JobNotFoundError(f"Job with id {job_id} not found")
-            _hash = self._calculate_job_hash(job.id)
-
-            if (
-                job.parent_job_id
-                and not checkpoints_reset
-                and metastore.find_checkpoint(job.parent_job_id, _hash)
-            ):
-                # if we find checkpoint with correct hash in previous job, we can
-                # skip chain calculation and in addition we are copying found
-                # checkpoint to the current job to avoid job tree traversal for
-                # finding checkpoints in the future.
-                catalog.metastore.create_checkpoint(job.id, _hash)
-                return read_dataset(
-                    name, namespace=namespace_name, project=project_name, **kwargs
-                )
-
+        # Schema preparation
         schema = self.signals_schema.clone_without_sys_signals().serialize()
 
         # Handle retry and delta functionality
-        if self.delta and name:
-            from datachain.delta import delta_retry_update
+        if not result:
+            result = self._handle_delta(name, version, project, schema, kwargs)
 
-            # Delta chains must have delta_on defined (ensured by _as_delta method)
-            assert self._delta_on is not None, "Delta chain must have delta_on defined"
-
-            result_ds, dependencies, has_changes = delta_retry_update(
-                self,
-                namespace_name,
-                project_name,
-                name,
-                on=self._delta_on,
-                right_on=self._delta_result_on,
-                compare=self._delta_compare,
-                delta_retry=self._delta_retry,
-            )
-
-            if result_ds:
-                return self._evolve(
-                    query=result_ds._query.save(
-                        name=name,
-                        version=version,
-                        project=project,
-                        feature_schema=schema,
-                        dependencies=dependencies,
-                        **kwargs,
-                    )
+        if not result:
+            # calculate chain if we already don't have result from checkpoint or delta
+            result = self._evolve(
+                query=self._query.save(
+                    name=name,
+                    version=version,
+                    project=project,
+                    description=description,
+                    attrs=attrs,
+                    feature_schema=schema,
+                    update_version=update_version,
+                    **kwargs,
                 )
-
-            if not has_changes:
-                # sources have not been changed so new version of resulting dataset
-                # would be the same as previous one. To avoid duplicating exact
-                # datasets, we won't create new version of it and we will return
-                # current latest version instead.
-                if job:
-                    catalog.metastore.create_checkpoint(job.id, _hash)  # type: ignore[arg-type]
-                return read_dataset(
-                    name, namespace=namespace_name, project=project_name, **kwargs
-                )
-
-        result = self._evolve(
-            query=self._query.save(
-                name=name,
-                version=version,
-                project=project,
-                description=description,
-                attrs=attrs,
-                feature_schema=schema,
-                update_version=update_version,
-                **kwargs,
             )
-        )
 
         if job:
             catalog.metastore.create_checkpoint(job.id, _hash)  # type: ignore[arg-type]
 
         return result
+
+    def _validate_version(self, version: Optional[str]) -> None:
+        """Validate dataset version if provided."""
+        if version is not None:
+            semver.validate(version)
+
+    def _validate_update_version(self, update_version: Optional[str]) -> None:
+        """Ensure update_version is one of: major, minor, patch."""
+        allowed = ["major", "minor", "patch"]
+        if update_version not in allowed:
+            raise ValueError(f"update_version must be one of {allowed}")
+
+    def _get_or_create_project(self, namespace: str, project_name: str) -> Project:
+        """Get project or raise if creation not allowed."""
+        try:
+            return self.session.catalog.metastore.get_project(
+                project_name,
+                namespace,
+                create=is_studio(),
+            )
+        except ProjectNotFoundError as e:
+            raise ProjectCreateNotAllowedError("Creating project is not allowed") from e
+
+    def _resolve_checkpoint(
+        self,
+        name: str,
+        project: Project,
+        kwargs: dict,
+    ) -> tuple[Optional[Job], Optional[str], Optional["DataChain"]]:
+        """Check if checkpoint exists and return cached dataset if possible."""
+        from .datasets import read_dataset
+
+        metastore = self.session.catalog.metastore
+
+        job_id = os.getenv("DATACHAIN_JOB_ID")
+        checkpoints_reset = env2bool("DATACHAIN_CHECKPOINTS_RESET")
+
+        if not job_id:
+            return None, None, None
+
+        job = metastore.get_job(job_id)
+        if not job:
+            raise JobNotFoundError(f"Job with id {job_id} not found")
+
+        _hash = self._calculate_job_hash(job.id)
+
+        if (
+            job.parent_job_id
+            and not checkpoints_reset
+            and metastore.find_checkpoint(job.parent_job_id, _hash)
+        ):
+            # checkpoint found → reuse dataset
+            chain = read_dataset(
+                name, namespace=project.namespace.name, project=project.name, **kwargs
+            )
+            return job, _hash, chain
+
+        return job, _hash, None
+
+    def _handle_delta(
+        self,
+        name: str,
+        version: Optional[str],
+        project: Project,
+        schema: dict,
+        kwargs: dict,
+    ) -> Optional["DataChain"]:
+        """Try to save as a delta dataset.
+        Returns:
+            A DataChain if delta logic could handle it, otherwise None to fall back
+            to the regular save path (e.g., on first dataset creation).
+        """
+        from datachain.delta import delta_retry_update
+
+        from .datasets import read_dataset
+
+        if not self.delta or not name:
+            return None
+
+        assert self._delta_on is not None, "Delta chain must have delta_on defined"
+
+        result_ds, dependencies, has_changes = delta_retry_update(
+            self,
+            project.namespace.name,
+            project.name,
+            name,
+            on=self._delta_on,
+            right_on=self._delta_result_on,
+            compare=self._delta_compare,
+            delta_retry=self._delta_retry,
+        )
+
+        # Case 1: delta produced a new dataset
+        if result_ds:
+            return self._evolve(
+                query=result_ds._query.save(
+                    name=name,
+                    version=version,
+                    project=project,
+                    feature_schema=schema,
+                    dependencies=dependencies,
+                    **kwargs,
+                )
+            )
+
+        # Case 2: no changes → reuse last version
+        if not has_changes:
+            # sources have not been changed so new version of resulting dataset
+            # would be the same as previous one. To avoid duplicating exact
+            # datasets, we won't create new version of it and we will return
+            # current latest version instead.
+            return read_dataset(
+                name,
+                namespace=project.namespace.name,
+                project=project.name,
+                **kwargs,
+            )
+
+        # Case 3: first creation of dataset
+        return None
 
     def apply(self, func, *args, **kwargs):
         """Apply any function to the chain.

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -618,6 +618,8 @@ class DataChain:
             update_version: which part of the dataset version to automatically increase.
                 Available values: `major`, `minor` or `patch`. Default is `patch`.
         """
+        from .datasets import read_dataset
+
         catalog = self.session.catalog
         metastore = catalog.metastore
 
@@ -669,8 +671,6 @@ class DataChain:
             ):
                 # if we find checkpoint with correct hash, we can skip chain calculation
                 catalog.metastore.create_checkpoint(job.id, _hash)
-                from .datasets import read_dataset
-
                 return read_dataset(
                     name, namespace=namespace_name, project=project_name, **kwargs
                 )
@@ -712,8 +712,6 @@ class DataChain:
                 # would be the same as previous one. To avoid duplicating exact
                 # datasets, we won't create new version of it and we will return
                 # current latest version instead.
-                from .datasets import read_dataset
-
                 if job:
                     catalog.metastore.create_checkpoint(job.id, _hash)  # type: ignore[arg-type]
                 return read_dataset(

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -657,7 +657,7 @@ class DataChain:
 
         # checking checkpoints and skip re-calculation of the chain if checkpoint exist
         if job_id:
-            job = metastore.get_job(job_id)  # type: ignore[arg-type]
+            job = metastore.get_job(job_id)
             if not job:
                 raise JobNotFoundError(f"Job with id {job_id} not found")
             _hash = self._calculate_job_hash(job.id)

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -669,7 +669,10 @@ class DataChain:
                 and not checkpoints_reset
                 and metastore.find_checkpoint(job.parent_job_id, _hash)
             ):
-                # if we find checkpoint with correct hash, we can skip chain calculation
+                # if we find checkpoint with correct hash in previous job, we can
+                # skip chain calculation and in addition we are copying found
+                # checkpoint to the current job to avoid job tree traversal for
+                # finding checkpoints in the future.
                 catalog.metastore.create_checkpoint(job.id, _hash)
                 return read_dataset(
                     name, namespace=namespace_name, project=project_name, **kwargs

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -594,9 +594,8 @@ class DataChain:
         )
 
         return hashlib.sha256(
-            bytes.fromhex(last_checkpoint.hash)
-            if last_checkpoint
-            else b"" + bytes.fromhex(self.hash())
+            (bytes.fromhex(last_checkpoint.hash) if last_checkpoint else b"")
+            + bytes.fromhex(self.hash())
         ).hexdigest()
 
     def save(  # type: ignore[override]

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1265,8 +1265,10 @@ class DatasetQuery:
         if version:
             self.version = version
 
-        namespace_name = namespace_name or self.catalog.metastore.default_namespace_name
-        project_name = project_name or self.catalog.metastore.default_project_name
+        self.namespace_name = (
+            namespace_name or self.catalog.metastore.default_namespace_name
+        )
+        self.project_name = project_name or self.catalog.metastore.default_project_name
 
         if is_listing_dataset(name) and not version:
             # not setting query step yet as listing dataset might not exist at
@@ -1276,8 +1278,8 @@ class DatasetQuery:
             self._set_starting_step(
                 self.catalog.get_dataset_with_remote_fallback(
                     name,
-                    namespace_name=namespace_name,
-                    project_name=project_name,
+                    namespace_name=self.namespace_name,
+                    project_name=self.project_name,
                     version=version,
                     pull_dataset=True,
                     update=update,

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1265,10 +1265,8 @@ class DatasetQuery:
         if version:
             self.version = version
 
-        self.namespace_name = (
-            namespace_name or self.catalog.metastore.default_namespace_name
-        )
-        self.project_name = project_name or self.catalog.metastore.default_project_name
+        namespace_name = namespace_name or self.catalog.metastore.default_namespace_name
+        project_name = project_name or self.catalog.metastore.default_project_name
 
         if is_listing_dataset(name) and not version:
             # not setting query step yet as listing dataset might not exist at
@@ -1278,8 +1276,8 @@ class DatasetQuery:
             self._set_starting_step(
                 self.catalog.get_dataset_with_remote_fallback(
                     name,
-                    namespace_name=self.namespace_name,
-                    project_name=self.project_name,
+                    namespace_name=namespace_name,
+                    project_name=project_name,
                     version=version,
                     pull_dataset=True,
                     update=update,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,8 +457,18 @@ def cloud_server(request, tmp_upath_factory, cloud_type, version_aware, tree):
 
 
 @pytest.fixture()
-def datachain_job_id(monkeypatch):
+def datachain_job_id_old(monkeypatch):
     job_id = str(uuid.uuid4())
+    monkeypatch.setenv("DATACHAIN_JOB_ID", job_id)
+    return job_id
+
+
+@pytest.fixture
+def datachain_job_id(test_session, monkeypatch):
+    job_id = test_session.catalog.metastore.create_job(
+        "my-job",
+        'import datachain as dc; dc.read_values(num=[1, 2, 3].save("nums")',
+    )
     monkeypatch.setenv("DATACHAIN_JOB_ID", job_id)
     return job_id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -456,13 +456,6 @@ def cloud_server(request, tmp_upath_factory, cloud_type, version_aware, tree):
     return make_cloud_server(src_path, cloud_type, tree)
 
 
-@pytest.fixture()
-def datachain_job_id_old(monkeypatch):
-    job_id = str(uuid.uuid4())
-    monkeypatch.setenv("DATACHAIN_JOB_ID", job_id)
-    return job_id
-
-
 @pytest.fixture
 def datachain_job_id(test_session, monkeypatch):
     job_id = test_session.catalog.metastore.create_job(

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -31,7 +31,6 @@ def test_checkpoints(test_session, monkeypatch, nums_dataset, reset_checkpoints)
             .map(new=mapper_fail)
             .save("nums3")
         )
-    # check we created first 2 datasets but third one failed
     catalog.get_dataset("nums1")
     catalog.get_dataset("nums2")
     with pytest.raises(DatasetNotFoundError):
@@ -46,7 +45,6 @@ def test_checkpoints(test_session, monkeypatch, nums_dataset, reset_checkpoints)
     dc.read_dataset("nums", session=test_session).save("nums2")
     dc.read_dataset("nums", session=test_session).save("nums3")
 
-    # check that we skipped creation of first 2 datasets (they have only 1 version)
     assert (
         len(catalog.get_dataset("nums1").versions) == 1 if not reset_checkpoints else 2
     )
@@ -55,7 +53,6 @@ def test_checkpoints(test_session, monkeypatch, nums_dataset, reset_checkpoints)
     )
     assert len(catalog.get_dataset("nums3").versions) == 1
 
-    # check checkpoints
     assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 2
     assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
 
@@ -85,14 +82,12 @@ def test_checkpoints_modified_chains(
     )  # added change from first run
     dc.read_dataset("nums", session=test_session).save("nums3")
 
-    # check that we skipped creation of first 2 datasets (they have only 1 version)
     assert (
         len(catalog.get_dataset("nums1").versions) == 1 if not reset_checkpoints else 2
     )
     assert len(catalog.get_dataset("nums2").versions) == 2
     assert len(catalog.get_dataset("nums3").versions) == 2
 
-    # check checkpoints
     assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 3
     assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
 
@@ -116,7 +111,6 @@ def test_checkpoints_multiple_runs(
             .map(new=mapper_fail)
             .save("nums3")
         )
-    # check we created first 2 datasets but third one failed
     catalog.get_dataset("nums1")
     catalog.get_dataset("nums2")
     with pytest.raises(DatasetNotFoundError):
@@ -137,9 +131,7 @@ def test_checkpoints_multiple_runs(
     )
     monkeypatch.setenv("DATACHAIN_JOB_ID", third_job_id)
     dc.read_dataset("nums", session=test_session).save("nums1")
-    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save(
-        "nums2"
-    )  # added change from first run
+    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save("nums2")
     with pytest.raises(DataChainError):
         (
             dc.read_dataset("nums", session=test_session)
@@ -153,9 +145,7 @@ def test_checkpoints_multiple_runs(
     )
     monkeypatch.setenv("DATACHAIN_JOB_ID", fourth_job_id)
     dc.read_dataset("nums", session=test_session).save("nums1")
-    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save(
-        "nums2"
-    )  # added change from first run
+    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save("nums2")
     dc.read_dataset("nums", session=test_session).save("nums3")
 
     num1_versions = len(catalog.get_dataset("nums1").versions)
@@ -172,7 +162,6 @@ def test_checkpoints_multiple_runs(
         assert num2_versions == 2
         assert num3_versions == 2
 
-    # check checkpoints
     assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 2
     assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
     assert len(list(catalog.metastore.list_checkpoints(third_job_id))) == 2

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -1,7 +1,7 @@
 import pytest
 
 import datachain as dc
-from datachain.error import DatasetNotFoundError
+from datachain.error import DatasetNotFoundError, JobNotFoundError
 from datachain.lib.utils import DataChainError
 
 
@@ -186,3 +186,9 @@ def test_checkpoints_check_valid_chain_is_returned(
     assert ds.dataset.name == "nums1"
     assert len(ds.dataset.versions) == 1
     assert ds.order_by("num").to_list("num") == [(1,), (2,), (3,)]
+
+
+def test_checkpoints_invalid_parent_job_id(test_session, monkeypatch, nums_dataset):
+    monkeypatch.setenv("DATACHAIN_JOB_ID", "wrong")
+    with pytest.raises(JobNotFoundError):
+        dc.read_dataset("nums", session=test_session).save("nums1")

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -1,0 +1,184 @@
+import pytest
+
+import datachain as dc
+from datachain.error import DatasetNotFoundError
+from datachain.lib.utils import DataChainError
+
+
+def mapper_fail(num) -> int:
+    raise Exception("Error")
+
+
+@pytest.fixture
+def nums_dataset(test_session):
+    return dc.read_values(num=[1, 2, 3], session=test_session).save("nums")
+
+
+@pytest.mark.parametrize("reset_checkpoints", [True, False])
+def test_checkpoints(test_session, monkeypatch, nums_dataset, reset_checkpoints):
+    catalog = test_session.catalog
+
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", reset_checkpoints)
+
+    # first run
+    first_job_id = test_session.catalog.metastore.create_job("my-job", "echo 1;")
+    monkeypatch.setenv("DATACHAIN_JOB_ID", first_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).save("nums2")
+    with pytest.raises(DataChainError):
+        (
+            dc.read_dataset("nums", session=test_session)
+            .map(new=mapper_fail)
+            .save("nums3")
+        )
+    # check we created first 2 datasets but third one failed
+    catalog.get_dataset("nums1")
+    catalog.get_dataset("nums2")
+    with pytest.raises(DatasetNotFoundError):
+        catalog.get_dataset("nums3")
+
+    # -------------- SECOND RUN -------------------
+
+    second_job_id = test_session.catalog.metastore.create_job(
+        "my-job", "echo 1;", parent_job_id=first_job_id
+    )
+    monkeypatch.setenv("DATACHAIN_JOB_ID", second_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).save("nums2")
+    dc.read_dataset("nums", session=test_session).save("nums3")
+
+    # check that we skipped creation of first 2 datasets (they have only 1 version)
+    assert (
+        len(catalog.get_dataset("nums1").versions) == 1 if not reset_checkpoints else 2
+    )
+    assert (
+        len(catalog.get_dataset("nums2").versions) == 1 if not reset_checkpoints else 2
+    )
+    assert len(catalog.get_dataset("nums3").versions) == 1
+
+    # check checkpoints
+    assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 2
+    assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
+
+
+@pytest.mark.parametrize("reset_checkpoints", [True, False])
+def test_checkpoints_modified_chains(
+    test_session, monkeypatch, nums_dataset, reset_checkpoints
+):
+    catalog = test_session.catalog
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", reset_checkpoints)
+
+    # first run
+    first_job_id = test_session.catalog.metastore.create_job("my-job", "echo 1;")
+    monkeypatch.setenv("DATACHAIN_JOB_ID", first_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).save("nums2")
+    dc.read_dataset("nums", session=test_session).save("nums3")
+
+    # -------------- SECOND RUN -------------------
+
+    second_job_id = test_session.catalog.metastore.create_job(
+        "my-job", "echo 1;", parent_job_id=first_job_id
+    )
+    monkeypatch.setenv("DATACHAIN_JOB_ID", second_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save(
+        "nums2"
+    )  # added change from first run
+    dc.read_dataset("nums", session=test_session).save("nums3")
+
+    # check that we skipped creation of first 2 datasets (they have only 1 version)
+    assert (
+        len(catalog.get_dataset("nums1").versions) == 1 if not reset_checkpoints else 2
+    )
+    assert len(catalog.get_dataset("nums2").versions) == 2
+    assert len(catalog.get_dataset("nums3").versions) == 2
+
+    # check checkpoints
+    assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 3
+    assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
+
+
+@pytest.mark.parametrize("reset_checkpoints", [True, False])
+def test_checkpoints_multiple_runs(
+    test_session, monkeypatch, nums_dataset, reset_checkpoints
+):
+    catalog = test_session.catalog
+
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", reset_checkpoints)
+
+    # first run
+    first_job_id = test_session.catalog.metastore.create_job("my-job", "echo 1;")
+    monkeypatch.setenv("DATACHAIN_JOB_ID", first_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).save("nums2")
+    with pytest.raises(DataChainError):
+        (
+            dc.read_dataset("nums", session=test_session)
+            .map(new=mapper_fail)
+            .save("nums3")
+        )
+    # check we created first 2 datasets but third one failed
+    catalog.get_dataset("nums1")
+    catalog.get_dataset("nums2")
+    with pytest.raises(DatasetNotFoundError):
+        catalog.get_dataset("nums3")
+
+    # -------------- SECOND RUN -------------------
+
+    second_job_id = test_session.catalog.metastore.create_job(
+        "my-job", "echo 1;", parent_job_id=first_job_id
+    )
+    monkeypatch.setenv("DATACHAIN_JOB_ID", second_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).save("nums2")
+    dc.read_dataset("nums", session=test_session).save("nums3")
+
+    # -------------- THIRD RUN -------------------
+
+    third_job_id = test_session.catalog.metastore.create_job(
+        "my-job", "echo 1;", parent_job_id=second_job_id
+    )
+    monkeypatch.setenv("DATACHAIN_JOB_ID", third_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save(
+        "nums2"
+    )  # added change from first run
+    with pytest.raises(DataChainError):
+        (
+            dc.read_dataset("nums", session=test_session)
+            .map(new=mapper_fail)
+            .save("nums3")
+        )
+
+    # -------------- FOURTH RUN -------------------
+
+    fourth_job_id = test_session.catalog.metastore.create_job(
+        "my-job", "echo 1;", parent_job_id=third_job_id
+    )
+    monkeypatch.setenv("DATACHAIN_JOB_ID", fourth_job_id)
+    dc.read_dataset("nums", session=test_session).save("nums1")
+    dc.read_dataset("nums", session=test_session).filter(dc.C("num") > 1).save(
+        "nums2"
+    )  # added change from first run
+    dc.read_dataset("nums", session=test_session).save("nums3")
+
+    num1_versions = len(catalog.get_dataset("nums1").versions)
+    num2_versions = len(catalog.get_dataset("nums2").versions)
+    num3_versions = len(catalog.get_dataset("nums3").versions)
+
+    if reset_checkpoints:
+        assert num1_versions == 4
+        assert num2_versions == 4
+        assert num3_versions == 2
+
+    else:
+        assert num1_versions == 1
+        assert num2_versions == 2
+        assert num3_versions == 2
+
+    # check checkpoints
+    assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 2
+    assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
+    assert len(list(catalog.metastore.list_checkpoints(third_job_id))) == 2
+    assert len(list(catalog.metastore.list_checkpoints(fourth_job_id))) == 3

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -45,12 +45,8 @@ def test_checkpoints(test_session, monkeypatch, nums_dataset, reset_checkpoints)
     dc.read_dataset("nums", session=test_session).save("nums2")
     dc.read_dataset("nums", session=test_session).save("nums3")
 
-    assert (
-        len(catalog.get_dataset("nums1").versions) == 1 if not reset_checkpoints else 2
-    )
-    assert (
-        len(catalog.get_dataset("nums2").versions) == 1 if not reset_checkpoints else 2
-    )
+    assert len(catalog.get_dataset("nums1").versions) == 2 if reset_checkpoints else 1
+    assert len(catalog.get_dataset("nums2").versions) == 2 if reset_checkpoints else 1
     assert len(catalog.get_dataset("nums3").versions) == 1
 
     assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 2
@@ -82,9 +78,7 @@ def test_checkpoints_modified_chains(
     )  # added change from first run
     dc.read_dataset("nums", session=test_session).save("nums3")
 
-    assert (
-        len(catalog.get_dataset("nums1").versions) == 1 if not reset_checkpoints else 2
-    )
+    assert len(catalog.get_dataset("nums1").versions) == 2 if reset_checkpoints else 1
     assert len(catalog.get_dataset("nums2").versions) == 2
     assert len(catalog.get_dataset("nums3").versions) == 2
 

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -171,6 +171,7 @@ def test_checkpoints_check_valid_chain_is_returned(
 ):
     catalog = test_session.catalog
 
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", False)
     chain = dc.read_dataset("nums", session=test_session)
 
     # -------------- FIRST RUN -------------------

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -194,6 +194,7 @@ def test_checkpoints_check_valid_chain_is_returned(
 
 
 def test_checkpoints_invalid_parent_job_id(test_session, monkeypatch, nums_dataset):
-    monkeypatch.setenv("DATACHAIN_JOB_ID", "wrong")
+    # setting wrong job id
+    monkeypatch.setenv("DATACHAIN_JOB_ID", "caee6c54-6328-4bcd-8ca6-2b31cb4fff94")
     with pytest.raises(JobNotFoundError):
         dc.read_dataset("nums", session=test_session).save("nums1")

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -4019,7 +4019,7 @@ def test_update_versions_wrong_value(test_session):
         chain.save(ds_name, update_version="wrong")
 
     assert str(excinfo.value) == (
-        "update_version can have one of the following values: major, minor or patch"
+        "update_version must be one of ['major', 'minor', 'patch']"
     )
 
 


### PR DESCRIPTION
This PR adds a logic in `DataChain.save()` to create checkpoints where needed and to skip processing chain steps if checkpoint for this chain already exists.

## Summary by Sourcery

Add job-level checkpointing to DataChain.save to reuse prior results and skip redundant processing, introduce parent_job_id tracking, and expand tests to cover checkpoint reset and chain modification scenarios

New Features:
- Skip chain processing in DataChain.save when a matching checkpoint exists for the current job
- Introduce checkpoint creation for each job and support resetting via DATACHAIN_CHECKPOINTS_RESET
- Track parent-child job relationships through a new parent_job_id field in the metastore

Bug Fixes:
- Raise JobNotFoundError when DATACHAIN_JOB_ID does not correspond to an existing job

Enhancements:
- Add _calculate_job_hash method to compute chain hashes by combining previous checkpoint hashes and current chain hash

Tests:
- Add comprehensive unit tests to validate checkpoint behavior across first, subsequent, and multiple runs with and without resets
- Update datachain_job_id fixture to initialize jobs via metastore.create_job