### PR TITLE
fix(show): preserve None in output

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1963,12 +1963,15 @@ class DataChain:
         self,
         flatten: bool = False,
         include_hidden: bool = True,
+        as_object: bool = False,
     ) -> "pd.DataFrame":
         """Return a pandas DataFrame from the chain.
 
         Parameters:
             flatten: Whether to use a multiindex or flatten column names.
             include_hidden: Whether to include hidden columns.
+            as_object: Whether to emit a dataframe backed by Python objects
+                rather than pandas-inferred dtypes.
 
         Returns:
             pd.DataFrame: A pandas DataFrame representation of the chain.
@@ -1984,6 +1987,9 @@ class DataChain:
             columns = pd.MultiIndex.from_tuples(map(tuple, headers))
 
         results = self.results(include_hidden=include_hidden)
+        if as_object:
+            df = pd.DataFrame(results, columns=columns, dtype=object)
+            return df.where(pd.notna(df), None)
         return pd.DataFrame.from_records(results, columns=columns)
 
     def show(
@@ -2006,7 +2012,11 @@ class DataChain:
         import pandas as pd
 
         dc = self.limit(limit) if limit > 0 else self  # type: ignore[misc]
-        df = dc.to_pandas(flatten, include_hidden=include_hidden)
+        df = dc.to_pandas(
+            flatten,
+            include_hidden=include_hidden,
+            as_object=True,
+        )
 
         if df.empty:
             print("Empty result")

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -35,6 +35,7 @@ from tests.utils import (
     TARRED_TREE,
     df_equal,
     images_equal,
+    skip_if_not_sqlite,
     sorted_dicts,
     text_embedding,
 )
@@ -557,6 +558,25 @@ def test_show(capsys, test_session):
     assert "first_name age city" in normalized_output
     for i in range(3):
         assert f"{i} {first_name[i]}" in normalized_output
+
+
+@skip_if_not_sqlite
+def test_show_preserves_none(capsys, test_session):
+    chain = dc.read_values(
+        score=[1, None],
+        ts=[
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            None,
+        ],
+        session=test_session,
+    )
+
+    chain.show()
+
+    captured = capsys.readouterr().out
+    assert "NaN" not in captured
+    assert "NaT" not in captured
+    assert captured.count("None") >= 2
 
 
 def test_show_without_temp_datasets(capsys, test_session):


### PR DESCRIPTION
Instead of this output for empty File objects (e.g. after full outer merge):

```
    id   file  file file    file  file      file                      file     file right_id  \
       source  path size version  etag is_latest             last_modified location            
0  NaN   None  None  NaN    None  None       NaN                       NaT     None      5.0   
1  NaN   None  None  NaN    None  None       NaN                       NaT     None      6.0   
2  NaN   None  None  NaN    None  None       NaN                       NaT     None      7.0   
3  1.0            1  0.0                     1.0 1970-01-01 00:00:00+00:00     None      NaN   
4  2.0            2  0.0                     1.0 1970-01-01 00:00:00+00:00     None      NaN   
5  3.0            3  0.0                     1.0 1970-01-01 00:00:00+00:00     None      NaN 
```

(mind NaT and NaN)

we are getting real values from the database after this change, and we'll see `None`.

## Summary by Sourcery

Preserve Python None values in DataFrame outputs by introducing an object-backed `to_pandas(as_object=True)` mode and updating `show()` to leverage it, ensuring CLI output displays None rather than NaN or NaT.

New Features:
- Add an `as_object` option to `to_pandas` to emit object-typed DataFrames with Python None values

Bug Fixes:
- Make `show()` use the object-backed DataFrame so that None values are displayed instead of NaN/NaT

Tests:
- Add unit tests for `to_pandas(as_object=True)` to verify None preservation
- Add a functional test for `show()` to assert None is shown instead of NaN/NaT