### PR TITLE
Fix for bool on predicates

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1009,7 +1009,9 @@ class SQLJoin(Step):
     rname: str
 
     def hash_inputs(self) -> str:
-        predicates = ensure_sequence(self.predicates or [])
+        predicates = (
+            ensure_sequence(self.predicates) if self.predicates is not None else []
+        )
 
         parts = [
             bytes.fromhex(self.query1.hash()),

--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -147,7 +147,7 @@ def test_all_possible_steps(test_session):
             right_on=["player.name"],
         )
         .hash()
-    ) == "44b231652aee9712444ee26d5ecc77e6b87f768d17e6b8333303764d3706413b"
+    ) == "00280c54b9250fc691839d41d67c574a065c1b4eaf45563092670228b7aff4c3"
 
 
 def test_diff(test_session):
@@ -170,4 +170,4 @@ def test_diff(test_session):
             status_col="diff",
         )
         .hash()
-    ) == "aef929f3bf247966703534aa3daffb76fa8802d64660293deb95155ffacd8b77"
+    ) == "313e842c46fa9f0f4f7b6aaec918472ab1fc313ee0ad6a36464f19c4f1880471"

--- a/tests/unit/test_query_steps_hash.py
+++ b/tests/unit/test_query_steps_hash.py
@@ -281,6 +281,13 @@ def test_union_hash(test_session, numbers_dataset):
             "{name}_r",
             "f637c82a2a197823ec5dc6614623c860d682110ceec60821759534a9e24ec6cf",
         ),
+        (
+            sa.column("id"),
+            True,
+            False,
+            "{name}_right",
+            "fc55d6192d0859f0df3bfa7981540a8ec0640de707b23c18bc2e0059560be8f8",
+        ),
     ],
 )
 def test_join_hash(


### PR DESCRIPTION
Fixing bool on `self.predicates` in `SQLJoin` query step. This was failing because predicates are sqlalchemy construct so we need to compare with `None` directly. Added a test to cover this as well.

## Summary by Sourcery

Fix the handling of predicates in SQLJoin.hash_inputs by explicitly checking for None and add a test case to cover join hashing with predicate and join direction flags.

Bug Fixes:
- Fix boolean check on self.predicates in SQLJoin.hash_inputs to handle SQLAlchemy constructs by comparing with None directly

Tests:
- Add a test case for join hash with a SQLAlchemy predicate and specific join direction flags