### PR TITLE
Fix parallel workers stuck

### DIFF
--- a/src/datachain/query/queue.py
+++ b/src/datachain/query/queue.py
@@ -52,6 +52,11 @@ def put_into_queue(queue: Queue, item: Any) -> None:
             queue.put_nowait(item)
             return
         except Full:
+            # If queue is full, avoid blocking on progress notifications
+            # that can be lossy without affecting correctness.
+            status = item.get("status") if isinstance(item, dict) else None
+            if status in (OK_STATUS, NOTIFY_STATUS):
+                return
             sleep(0.01)
 
 


### PR DESCRIPTION
Trying to fix issue with parallel workers stuck using AI.

Draft, experimenting, update and reasoning required.

## Summary by Sourcery

Improve fault handling and cleanup in parallel UDF execution to prevent workers from hanging and avoid queue blocking

Bug Fixes:
- Fail fast on first worker exception by stopping task scheduling and terminating remaining workers to prevent deadlocks

Enhancements:
- Use contextlib.suppress to safely close queues and terminate processes during cleanup without blocking
- Drop non-essential status updates when the task queue is full to avoid producer blocking in put_into_queue