### PR TITLE
Improve column element serialization

### DIFF
--- a/src/datachain/hash_utils.py
+++ b/src/datachain/hash_utils.py
@@ -5,99 +5,76 @@ import textwrap
 from collections.abc import Sequence
 from typing import TypeVar, Union
 
-from sqlalchemy.sql.elements import (
-    BinaryExpression,
-    BindParameter,
-    ColumnElement,
-    Label,
-    Over,
-    UnaryExpression,
-)
-from sqlalchemy.sql.functions import Function
+from sqlalchemy.sql.elements import ColumnElement
 
 T = TypeVar("T", bound=ColumnElement)
 ColumnLike = Union[str, T]
 
 
-def serialize_column_element(expr: Union[str, ColumnElement]) -> dict:  # noqa: PLR0911
+def _serialize_value(val):  # noqa: PLR0911
+    """Helper to serialize arbitrary values recursively."""
+    if val is None:
+        return None
+    if isinstance(val, (str, int, float, bool)):
+        return val
+    # Check ColumnElement BEFORE checking for list/tuple since some ColumnElements
+    # look like sequences but don't support iteration
+    if isinstance(val, ColumnElement):
+        return serialize_column_element(val)
+    if isinstance(val, dict):
+        # Sort dict keys for deterministic serialization
+        return {k: _serialize_value(v) for k, v in sorted(val.items())}
+    if isinstance(val, (list, tuple)):
+        return [_serialize_value(v) for v in val]
+    if callable(val):
+        return val.__name__ if hasattr(val, "__name__") else str(val)
+    # For type objects and other complex values
+    return str(val)
+
+
+def serialize_column_element(expr: Union[str, ColumnElement]) -> dict:
     """
     Recursively serialize a SQLAlchemy ColumnElement into a deterministic structure.
+    Uses SQLAlchemy's _traverse_internals to automatically handle all expression types.
     """
+    # Import here to avoid circular imports
+    from sqlalchemy.sql.elements import BindParameter
 
-    # Binary operations: col > 5, col1 + col2, etc.
-    if isinstance(expr, BinaryExpression):
-        op = (
-            expr.operator.__name__
-            if hasattr(expr.operator, "__name__")
-            else str(expr.operator)
-        )
-        return {
-            "type": "binary",
-            "op": op,
-            "left": serialize_column_element(expr.left),
-            "right": serialize_column_element(expr.right),
-        }
-
-    # Unary operations: -col, NOT col, etc.
-    if isinstance(expr, UnaryExpression):
-        op = (
-            expr.operator.__name__
-            if expr.operator is not None and hasattr(expr.operator, "__name__")
-            else str(expr.operator)
-        )
-
-        return {
-            "type": "unary",
-            "op": op,
-            "element": serialize_column_element(expr.element),  # type: ignore[arg-type]
-        }
-
-    # Function calls: func.lower(col), func.count(col), etc.
-    if isinstance(expr, Function):
-        return {
-            "type": "function",
-            "name": expr.name,
-            "clauses": [serialize_column_element(c) for c in expr.clauses],
-        }
-
-    # Window functions: func.row_number().over(partition_by=..., order_by=...)
-    if isinstance(expr, Over):
-        return {
-            "type": "window",
-            "function": serialize_column_element(expr.element),
-            "partition_by": [
-                serialize_column_element(p) for p in getattr(expr, "partition_by", [])
-            ],
-            "order_by": [
-                serialize_column_element(o) for o in getattr(expr, "order_by", [])
-            ],
-        }
-
-    # Labeled expressions: col.label("alias")
-    if isinstance(expr, Label):
-        return {
-            "type": "label",
-            "name": expr.name,
-            "element": serialize_column_element(expr.element),
-        }
-
-    # Bound values (constants)
+    # Special case: BindParameter has non-deterministic 'key' attribute, only use value
     if isinstance(expr, BindParameter):
         return {"type": "bind", "value": expr.value}
 
-    # Plain columns
-    if hasattr(expr, "name"):
-        return {"type": "column", "name": expr.name}
+    # Generic handling for all ColumnElement types using SQLAlchemy's internals
+    if isinstance(expr, ColumnElement):
+        # All standard SQLAlchemy types have _traverse_internals
+        if hasattr(expr, "_traverse_internals"):
+            result = {"type": expr.__class__.__name__}
+            for attr_name, _ in expr._traverse_internals:
+                # Skip 'table' attribute - table names can be auto-generated/random
+                # and are not semantically important for hashing
+                if attr_name == "table":
+                    continue
+                if hasattr(expr, attr_name):
+                    val = getattr(expr, attr_name)
+                    result[attr_name] = _serialize_value(val)
+            return result
+        # Rare case: custom user-defined ColumnElement without _traverse_internals
+        # We don't know its structure, so just stringify it
+        return {"type": expr.__class__.__name__, "repr": str(expr)}
 
-    # Fallback: stringify unknown nodes
+    # Absolute fallback: stringify completely unknown types
     return {"type": "other", "repr": str(expr)}
 
 
-def hash_column_elements(columns: Sequence[ColumnLike]) -> str:
+def hash_column_elements(columns: Union[ColumnLike, Sequence[ColumnLike]]) -> str:
     """
     Hash a list of ColumnElements deterministically, dialect agnostic.
     Only accepts ordered iterables (like list or tuple).
     """
+    # Handle case where a single ColumnElement is passed instead of a sequence
+    if isinstance(columns, ColumnElement):
+        columns = (columns,)
+
     serialized = [serialize_column_element(c) for c in columns]
     json_str = json.dumps(serialized, sort_keys=True)  # stable JSON
     return hashlib.sha256(json_str.encode("utf-8")).hexdigest()

--- a/src/datachain/hash_utils.py
+++ b/src/datachain/hash_utils.py
@@ -7,6 +7,8 @@ from typing import TypeVar, Union
 
 from sqlalchemy.sql.elements import ColumnElement
 
+from datachain.utils import ensure_sequence
+
 T = TypeVar("T", bound=ColumnElement)
 ColumnLike = Union[str, T]
 
@@ -71,10 +73,7 @@ def hash_column_elements(columns: Union[ColumnLike, Sequence[ColumnLike]]) -> st
     Hash a list of ColumnElements deterministically, dialect agnostic.
     Only accepts ordered iterables (like list or tuple).
     """
-    # Handle case where a single ColumnElement is passed instead of a sequence
-    if isinstance(columns, ColumnElement):
-        columns = (columns,)
-
+    columns = ensure_sequence(columns)
     serialized = [serialize_column_element(c) for c in columns]
     json_str = json.dumps(serialized, sort_keys=True)  # stable JSON
     return hashlib.sha256(json_str.encode("utf-8")).hexdigest()

--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -114,7 +114,7 @@ def test_read_parquet(test_session, tmp_dir):
 
 def test_read_storage(mock_get_listing):
     assert dc.read_storage("s3://bucket").hash() == (
-        "c38b6f4ebd7f0160d9f900016aad1e6781acd463f042588cfe793e9d189a8a0e"
+        "811e7089ead93a572d75d242220f6b94fd30f21def1bbcf37f095f083883bc41"
     )
 
 
@@ -128,11 +128,11 @@ def test_read_dataset(test_session):
 def test_order_of_steps(mock_get_listing):
     assert (
         dc.read_storage("s3://bucket").mutate(new=10).filter(C("age") > 20).hash()
-    ) == "08a6c5657feaea55c734bc8e2b3eb0733ea692d4eab5fa78fa26409e6c2af098"
+    ) == "b07f11244f1f84e4ecde87976fc380b4b8b656b0202294179e30be2112df7d3a"
 
     assert (
         dc.read_storage("s3://bucket").filter(C("age") > 20).mutate(new=10).hash()
-    ) == "e91b84094233a2bf4d08d6a95e55529a65d900399be3a05dc3e2ca0401f8f25b"
+    ) == "82780df484ce63e499ceed6ef3418920fdf68461a6b5f24234d3c0628c311c02"
 
 
 def test_all_possible_steps(test_session):
@@ -195,7 +195,7 @@ def test_all_possible_steps(test_session):
             right_on=["player.name"],
         )
         .hash()
-    ) == "00280c54b9250fc691839d41d67c574a065c1b4eaf45563092670228b7aff4c3"
+    ) == "94da340ab42bd407bdc009a549c1f60f5bbea09d9f845b7a516a27dc68be039a"
 
 
 def test_diff(test_session):
@@ -218,4 +218,4 @@ def test_diff(test_session):
             status_col="diff",
         )
         .hash()
-    ) == "313e842c46fa9f0f4f7b6aaec918472ab1fc313ee0ad6a36464f19c4f1880471"
+    ) == "dbaf2277a1af061e98df3090500d3c284280bcf7f44340a315a0e3f3be72eafd"

--- a/tests/unit/test_hash_utils.py
+++ b/tests/unit/test_hash_utils.py
@@ -1,5 +1,19 @@
 import pytest
-import sqlalchemy as sa
+from sqlalchemy import (
+    Float,
+    Integer,
+    String,
+    and_,
+    case,
+    cast,
+    distinct,
+    literal,
+    not_,
+    null,
+    or_,
+    tuple_,
+)
+from sqlalchemy import func as sa_func
 
 from datachain import C, func
 from datachain.hash_utils import hash_callable, hash_column_elements
@@ -25,41 +39,281 @@ lambda3 = lambda z: z - 1  # noqa: E731
 @pytest.mark.parametrize(
     "expr,result",
     [
+        # Basic column references
         (
             [C("name")],
-            "8e95b415d0950727bb698f1a9fcaf28a4e088afe19d8256ecaa581022cde9365",
+            "9ff0747010842981e8a973b68d09f65682e14cc850a1b8a4badc2056461b8f9e",
         ),
         (
             [C("name"), C("age")],
-            "c4f98a6350d621d16255490fe0d522b61749720a27f6a42b262090bad4100092",
+            "6cfcbd8bebaf6f635685ea33962a6f060188c5b37e86806cc559c1d8c8c97ab4",
         ),
+        # Functions
         (
             [func.avg("age")],
-            "ddc23abe88c722954e568f7db548ddcbd060eed1a1a815bfcaabd1dce8add3aa",
+            "1e4e256dbd18e42fdc6ca4889e01b23862122ffe6e47014a8cbc26de79afdfa3",
         ),
+        (
+            [func.count()],
+            "1e1e766d2292b1f57fc93c4730cd4a059aa5223626069c958f3c9d79a85cca7a",
+        ),
+        (
+            [func.sum(C("age"))],
+            "db55ee6b19ae21138fb066e51706e6ec6cc2c8aec75f22313ebf2c028fdb2200",
+        ),
+        (
+            [func.min(C("age")), func.max(C("age"))],
+            "28dacc69c5d72045f6341c06bc7c3361f9c14c445b1bd783900dae1effba0cc4",
+        ),
+        (
+            [sa_func.coalesce(C("name"), "unknown")],
+            "49288fcd7afd2eca76fb80cde99b9da79a9e4d007d73ba31ae7125a548fb219f",
+        ),
+        (
+            [sa_func.nullif(C("age"), 0)],
+            "74ab91fcbb6fc8fb15a99fce74d265d10530b94b9bf6e2f99b3245d6868153ab",
+        ),
+        # Window functions
         (
             [
                 func.row_number().over(
                     func.window(partition_by="file.name", order_by="file.name")
                 )
             ],
-            "9da0e1581399e92f628c00879422835fc05ada2584e9962c0edb20f87637e8bf",
+            "3088d3b926949f61df407ccf3057f6d298873f9e0f8f7497e1430db3048bd6db",
         ),
+        (
+            [sa_func.rank().over(order_by=C("age").desc())],
+            "33ef6c6c5b2291578f9c3d5851cd7859c165be7a9e3390f9e69bcb88305aabac",
+        ),
+        # Labels
         (
             [C("age").label("user_age")],
-            "8a0a3d4e99972dc5fdc462b9981b309bbc6b0cc86d73880d56108ef0553bd426",
+            "cc9bebfc972f7358a77768cd08f4ccae6f6cea8f6ab10ecc5cb74d4bf9348f76",
         ),
+        # Arithmetic operations
+        (
+            [C("age") + 10],
+            "a819bb33c57756cf28ce23311cf1d618a17ee0bde8cc9a2d20409727744877ca",
+        ),
+        (
+            [C("age") * 2],
+            "89bf2d64c0db60cf20f791ce4b31d37d368ef79802ebce2e40d807a03472deba",
+        ),
+        (
+            [C("age") % 10],
+            "17ade84e87a0fc88f90ac3f72bbd331a4d1c8c440f18c13c9ec439ccdf70a4c3",
+        ),
+        (
+            [-C("age")],
+            "660f4f7991c53f15709132d3095a616a5fffc45009ff3e0fd56f724afb0b7048",
+        ),
+        # Comparison operations
         (
             [C("age") > 20],
-            "6ba1c4384c710fe439e84749d7d08d675cb03d4c3683eb55bce11efd42372b67",
+            "2cbfcbf64022dfc87f828ad3971da29172ee4b48cb1c53c633b65105994422e5",
         ),
         (
-            [sa.and_(C("age") > 20, C("name") != "")],
-            "a27c392ad1c294783ab70175478bf7cf2110fe559bf68504026f773e5aa361ab",
+            [C("age") >= 21],
+            "db078ea46b20bfdb8490ae186aa81d1707b15d38cca7c70ddb9b9cd5896af1a6",
         ),
+        (
+            [C("age") == 25],
+            "7bf196beaeaefdfba89b3ae11e4741d7db1a385c1fc16f91d009992f67e02403",
+        ),
+        (
+            [C("name") != ""],
+            "fece00afaa11205b37a4835e783a941752df08af1d474afbbe363337b42cf782",
+        ),
+        # Logical operations
+        (
+            [and_(C("age") > 20, C("name") != "")],
+            "28927235e702ce883662a8b06c726aa7519bdb8305fc8345bcf7e6b198cde243",
+        ),
+        (
+            [or_(C("age") < 18, C("age") > 65)],
+            "2bdeca05439163390ba6c96e87c90f74bf5eb2521acb2833ef3132e6eeca42b1",
+        ),
+        (
+            [not_(C("active"))],
+            "c3b9e76d5dc067e35189d021e10ba51f516fc355cd3302905c2f0b530440b3ac",
+        ),
+        (
+            [and_(C("age") > 18, or_(C("city") == "NYC", C("city") == "LA"))],
+            "c667270f3bfa16be1e2d4024c1a5f8cd810d38fcdd6df00e0b69743d08cb93ef",
+        ),
+        # String operations
+        (
+            [C("name").like("John%")],
+            "e5bd392c9add2ddf1c02863320059a9912b45cebf029e16455e8a3a75c52b9ef",
+        ),
+        (
+            [C("name").startswith("A")],
+            "91179e5d93da3bb8955c8779e039c1b6b79eb07ecd18965309b38281aac84c8b",
+        ),
+        (
+            [C("name").contains("John")],
+            "a1cb94e08a4c1c9e17a50bc43da70f6710cfac035ffb4ad744c398284ca7bb2a",
+        ),
+        (
+            [sa_func.concat(C("first_name"), " ", C("last_name"))],
+            "3c85ac41e43dff536599bfc78e79b1bf4aaa0ff3110dbd1f13f83a1174d8ac95",
+        ),
+        (
+            [sa_func.lower(C("name"))],
+            "a53c5bd08f8dbe1a6e36443275285671d955f6cd382ce77cfe1988c5cf106b47",
+        ),
+        # NULL operations
+        (
+            [C("name").is_(None)],
+            "8dd013d2fb21adf266bde8572f148b637769bd751902011e16ac7769d8167d62",
+        ),
+        (
+            [C("name").isnot(None)],
+            "f21c92f266be45b66dc5a91e4918305be7b412c7327c077368bcc60982a5fbbb",
+        ),
+        # IN operations
+        (
+            [C("age").in_([18, 21, 65])],
+            "b96949143855d2f42de36398a1330c1d0eb76435f667505f3515319f95942772",
+        ),
+        (
+            [C("name").in_(["Alice", "Bob", "Charlie"])],
+            "c7812971ae30d3af4a6a9cc2809765482ba515855d981d91f084ad5786f90861",
+        ),
+        (
+            [C("age").notin_([0, 1])],
+            "d259260deaa33ce15926f070585efc2e8f5f5f06006877b85d2c945f2a1bb786",
+        ),
+        # BETWEEN
+        (
+            [C("age").between(18, 65)],
+            "752a3c594167f829cd70119cae8bb010c4d670eae12005526153f04bc39bc2b4",
+        ),
+        # Cast operations with different types
+        (
+            [cast(C("age"), Integer)],
+            "167e712a70f2100d1d9f8d28ee40170882900f7195463413a4403b0b8beff7c6",
+        ),
+        (
+            [cast(C("price"), Float)],
+            "c6962d8f2a74ded308b6aab5d00acee4deddfecce09e0533450cb5031f3eaa39",
+        ),
+        (
+            [cast(C("id"), String)],
+            "52cf27d8d6786e7e0d95a79dfcc1188d89e92f9d250fcf9baf76c91f2cb62a99",
+        ),
+        # CASE expressions
+        (
+            [case((C("age") > 20, "adult"), else_="child")],
+            "c0a28bf0a0b142b781ea687e81df60b66004fa0b8df6d8b0972a4586ba5ba77b",
+        ),
+        (
+            [
+                case(
+                    (C("age") < 13, "child"),
+                    (C("age") < 20, "teen"),
+                    (C("age") < 65, "adult"),
+                    else_="senior",
+                )
+            ],
+            "8235765854809fb8a394a87b69a988ba240f84e14c830287d2df083c941fe649",
+        ),
+        (
+            [case({1: "one", 2: "two", 3: "three"}, value=C("num"), else_="other")],
+            "4f3d2ea0f185e32e7a24d0ac61ff3de3b5e6a64c23684cd871c3be96da739b20",
+        ),
+        # Tuple operations
+        (
+            [tuple_(C("name"), C("age"))],
+            "83cac95650d48fc1267b045a009173de012fcd2cdcf62812b21df345fe41e3ec",
+        ),
+        # Grouping
+        (
+            [(C("age") + 10).self_group()],
+            "d2e8c32e9fd0d0906e9364ebfded13f0b4f539773c6174f3bbf99eaf98222c82",
+        ),
+        # DISTINCT
+        (
+            [distinct(C("name"))],
+            "2662643edb4f4251947d76d78584665d0499a652ea7a48a2831b91097a5f4730",
+        ),
+        # Literal values
+        (
+            [literal(42)],
+            "96812d801ca9b755942a0a9837c5c43e21a6f443a6e0d34d5318c2644c791d35",
+        ),
+        (
+            [literal("hello")],
+            "2e41270813206603bcdbf16916bb5c9140af6395ed83fd70ae125e0277c9ab74",
+        ),
+        (
+            [literal(True)],
+            "135ff6f6ae9586a85f39bab816405378f87cc1d6b38b3234020070bc991c7fb0",
+        ),
+        # NULL literal
+        (
+            [null()],
+            "a21b4f0c7c1b9a3a0348ee750e4b55a73cd2674f61a3c5ad2fc250ec74c90538",
+        ),
+        # Ordering
+        (
+            [C("age").desc()],
+            "14d06018ff87649a6c48b6e2cd5117817a422aa39ff1ccc78255e18496f78216",
+        ),
+        (
+            [C("name").asc()],
+            "82c23e5c3bb16da8652bcc39b94f1d366af3b8e274e2f1a29276bd5f1525c27e",
+        ),
+        # Complex nested expressions
+        (
+            [
+                case(
+                    (C("age") > 65, "senior"),
+                    else_=case((C("age") >= 18, "adult"), else_="minor"),
+                )
+            ],
+            "1b8b42c231b033da9da01b4267e370f2210513e66d90898cf045e41febcbb6ec",
+        ),
+        (
+            [((C("price") * C("quantity")) + C("tax")) - C("discount")],
+            "03ba855b075db046ae39a3227b403a3d09ea9de4aa9a4643a4c6e73a538c1d28",
+        ),
+        (
+            [
+                and_(
+                    C("active") == True,  # noqa: E712
+                    or_(C("age") >= 18, C("parent_consent") == True),  # noqa: E712
+                    C("verified").isnot(None),
+                )
+            ],
+            "8675b93419cb6f3de78ba1a82e93bdcf2fca80007945313366f54b477f7274f4",
+        ),
+        # Empty list
         (
             [],
             "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+        ),
+        # Edge cases
+        (
+            [C("empty_string") == ""],
+            "b816b424bcf870ae0b9dd34a5e7f670aa198b807e7cb779734bc4e5b2616471b",
+        ),
+        (
+            [C("zero") == 0],
+            "f9ba87e4ec00e1dc402a6926fd9a2e197793895ade204e3b2d28e3f8321ae3ad",
+        ),
+        (
+            [C("negative") < -1000],
+            "c0f87a3ca2ee750e8ebb5d431b12f54e6430488b60cb8437c3330214fe4bc1cd",
+        ),
+        (
+            [sa_func.abs(C("value"))],
+            "6c70579c1bf7cfec78b0b95d933e37ce91333db25c6c0fc3a882ca073d57d8cc",
+        ),
+        (
+            [sa_func.round(C("price"), 2)],
+            "b77ea29b5f5f664f3765860b260364f875c702e5326b7f289092cdaf7533ea17",
         ),
     ],
 )

--- a/tests/unit/test_query_steps_hash.py
+++ b/tests/unit/test_query_steps_hash.py
@@ -116,16 +116,16 @@ def numbers_dataset(test_session):
     [
         (
             (C("name"), C("age") * 10, func.avg("id"), C("country").label("country")),
-            "d03395827dcdddc2b2c3f0a3dafb71affa89c7f3b03b89e42734af2aea0e05ba",
+            "d53cd8431f00e29ae1b31df6ef39ca206d2918555fe26877a9c6bb058fb77097",
         ),
         ((), "3245ba76bc1e4b1b1d4d775b88448ff02df9473bd919929166c70e9e2b245345"),
         (
             (C("name"),),
-            "fe30656afd177ef32da191cc5ab3c68268282c382ef405d753e128b69767602f",
+            "5da26d0f27cba01ae3464da25d5ca0d66ff57deb71eaecc549ffdcf0dfe471a4",
         ),
         (
             (func.rand().label("random"),),
-            "f99e28cd2023ae5a7855c72ffd44fc99e36442818d3855f46b3aed576ffc1d30",
+            "f6706531fb15662eec9a28845e8a460f1c5a2d9898cac0adb68568f7a16764ba",
         ),
         (("name",), "46eeec88c5f842bd478d3ec87032c49b22adcdd46572463b0acde4b2bac0900a"),
     ],
@@ -139,12 +139,12 @@ def test_select_hash(inputs, _hash):
     [
         (
             (C("name"), C("age") * 10, func.avg("id"), C("country").label("country")),
-            "19894de08d545f3db85242be292dea0bb1ef47b0feaaf2c9359b159c7aa588c6",
+            "1c8d29ed3c4c0e0f3344257a655a6d82b8bb53f3c0fa322f89cca0b5fc13d498",
         ),
         ((), "0d27e4cfa3801628afc535190c64a426d9db66e5145c57129b9f5ca0935ef29e"),
         (
             (C("name"),),
-            "9515589e525bfa21cec0b68edf41c09e8df26e5c3023fd0775ba0ea02c9f6c8f",
+            "84a4280453505d3d7704b75a78a7a861b130c4d06dd6b351a821bf17b3647e33",
         ),
         (("name",), "e26923a0433e549e680a4bcbc5cb95bb9a523c4b47ae23b07b2a928a609fc498"),
     ],
@@ -158,16 +158,16 @@ def test_select_except_hash(inputs, _hash):
     [
         (
             (sa.and_(C("name") != "John", C("age") * 10 > 100)),
-            "ba98f1a292cc7e95402899a43e5392708bcf448332e060becb24956fb531bfd0",
+            "c23048c8b931078d0d2dfc81fbde32f663a81f96a9592e7e39d9e88866f6cf73",
         ),
         ((), "19e718af35ddc311aa892756fa4f95413ce17db7c8b27f68200d9c3ce0fc8dbf"),
         (
             (C("files.path").glob("*.jpg"),),
-            "c77898b24747f5106fd3793862d6c227e0423e096c6859ac95c27a9f7f7a824b",
+            "b85dfb62d62f7b1e142c13544919e2cf8d4d47fa1d9da90cc41197b1d03e3ac4",
         ),
         (
             sa.or_(C("age") > 50, C("country") == "US"),
-            "025880292c522fe7d3cf1163a11dc33b12c333e53d09efb12e40be08f31f95a2",
+            "69102e1955786abc8e985b3ca88047ea04b340d9e0b5cde17f84a0c91db91775",
         ),
     ],
 )
@@ -181,12 +181,12 @@ def test_filter_hash(inputs, _hash):
         (
             {"new_id": func.sum("id")},
             SignalSchema({"id": int}),
-            "d8e3af2fa2b5357643f80702455f0bbecb795b38bbb37eef24c644315e28617c",
+            "a0488b8cd29774cd304a67b2980f76a8c3736d1dacff34dcb8835e0ebf4e7531",
         ),
         (
             {"new_id": C("id") * 10, "old_id": C("id")},
             SignalSchema({"id": int}),
-            "beea21224d3e2fae077a6a38d663fbaea0549fd38508b48fac3454cd76eca0df",
+            "d124ce7453b399e15a65bec1887d734115f0c1af3987f26d1df782ec1a29e879",
         ),
         (
             {},
@@ -209,12 +209,12 @@ def test_mutate_hash(inputs, schema, _hash):
     [
         (
             (C("name"), C("age")),
-            "8368b3239fd66422c18d561d2b61dbbae9fd88f9c935f67719b0d12ada50ffb6",
+            "47646b4046685f7f988b93e40cf72c8ea43678bbb2b68cfbc017fdb574bc428f",
         ),
         (("name",), "b3562b4508052e5a57bc84ae862255939df294eb079e124c5af61fc21044343e"),
         (
             (sa.desc(C("name")),),
-            "fd91c8cfe480debf1cdcf2b3f91462393a75042d0752a813ecc65dfed1ac7a6c",
+            "8e64f7694349f0e7487f662d4e24edff2fc42007d9d19b0e08aa504160c1f689",
         ),
         ((), "c525013178ef24a807af6d4dd44d108c20a5224eb3ab88b84c55c635ec32ba04"),
     ],
@@ -276,7 +276,7 @@ def test_union_hash(test_session, numbers_dataset):
     chain2 = dc.read_dataset("dev.num.numbers").filter(C("num") < 50).limit(20)
 
     assert SQLUnion(chain1._query, chain2._query).hash() == (
-        "c13c83192846342814d693740085494d509247bb3512af5966e66e2ed10bc8ad"
+        "a8bf8e31e33af266201985ac5e75b3d5e05f1b3b058ed5f87c173f888e0f0154"
     )
 
 
@@ -288,21 +288,21 @@ def test_union_hash(test_session, numbers_dataset):
             True,
             False,
             "{name}_right",
-            "cd3504449c68fce0e6a687a7494b8a3ddb8e1b9b3452147c234c384fbbc201b2",
+            "8dd0ed4b89968a76e0f674f9ce00ae5a31192da828c7d1ecfdf1af55e2f215b0",
         ),
         (
             ("id", "name"),
             False,
             True,
             "{name}_r",
-            "f637c82a2a197823ec5dc6614623c860d682110ceec60821759534a9e24ec6cf",
+            "e0d5d0cd0ed8b45053edaf159390645baf44671b41bcb9662b19c9caed85b64e",
         ),
         (
             sa.column("id"),
             True,
             False,
             "{name}_right",
-            "fc55d6192d0859f0df3bfa7981540a8ec0640de707b23c18bc2e0059560be8f8",
+            "6c202f10e09a90ffd1edb2ae3a806cd7cd9aec391e00c7d3a0b970f7f7bba795",
         ),
     ],
 )
@@ -334,17 +334,17 @@ def test_join_hash(
             [
                 C("id"),
             ],
-            "0f28ac6aa6daee1892d5e79b559c9c1c2072cec2d53d4e0f12c3ae42db1a869f",
+            "66a27e12813ba1c7ae84bff668b47a38b87dd04314427a2c4f0d7d176afc80bb",
         ),
         (
             {"cnt": func.count(), "sum": func.sum("id")},
             [C("id"), C("name")],
-            "f8ef71fc6d3438cd6905e0a4d96f9b13a465c4a955127d929837e3f0ac3d31d6",
+            "b0ee67f98df0075db9c7a1e03a34ae48c58a1b98024da16709d3f4aa0845c700",
         ),
         (
             {"cnt": func.count()},
             [],
-            "fe833a3ce997c919bcf3a2c5de1e76f2481a0937320f9fa0c2a8b3c191cea480",
+            "65a176864e4abc6b9c7a262cb52e472ce9dd46f3559401f3df88a970b77dcbbc",
         ),
     ],
 )
@@ -360,15 +360,15 @@ def test_group_by_hash(columns, partition_by, _hash):
     [
         (
             [("id", "id")],
-            "4efcdbe669ea1c073bb12339f7bba79a78d61959988b12be975bffbf5dab0efd",
+            "5f90fc7c0a5287c8665c0fd912b0d91fb2a8baca416e68dd7bb38f75ad8926a1",
         ),
         (
             [("id", "id"), ("name", "name")],
-            "35553413a5a988fc8d3b73694881603f50143b1e1846a6d8748a6274519c64db",
+            "f595869a8990a259023ec5cefa9d27868750931ebaaf91c13e2296a0d5ded990",
         ),
         (
             [],
-            "9e9089070d5cfa3895ac03a53fd586149b84df49d0b2adbbe970fb6066e4b663",
+            "0f1100306f3029d8897dc826ef1ebb2c950673682b2479582bf19e38c12a3f5d",
         ),
     ],
 )
@@ -477,14 +477,14 @@ def test_udf_generator_hash(
             ["x"],
             {"double": int},
             [C("x")],
-            "27f07777802865d1f78bba78edce4233cc1b155dbce1b0af3d1e93b290fba04e",
+            "9f0ffa47038bfea164b8b6aa87a9f7ee245a8a39506596cd132d9c0ec65a50ec",
         ),
         (
             custom_feature_gen,
             ["t1"],
             {"x": CustomFeature},
             [C.t1.my_name],
-            "f3d2861f9c080529fe1ab33106c59f157e48ed6422dfb84c3e62e12b62db7fa7",
+            "2f782a9ec575cb3a9042c7683184ec5d9d2c9db56488f1a66922341048e9d688",
         ),
     ],
 )


### PR DESCRIPTION
Improving `ColumnElement` serialization for hashing. Now this implementation is generic and should work for any subclass of `ColumnElement`, not only the common ones.
New tests are added

TODO: add more tests for `test_query_steps_hash.py`