### PR TITLE
Add dependency tracking to `hash_callable()`

### DIFF
--- a/src/datachain/hash_utils.py
+++ b/src/datachain/hash_utils.py
@@ -112,15 +112,26 @@ def hash_column_elements(columns: Sequence[str | Function | T]) -> str:
     return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
 
 
-def hash_callable(func):
+def hash_callable(func, _visited=None):
     """
-    Calculate a hash from a callable.
+    Calculate a hash from a callable, including its dependencies.
     Rules:
     - Named functions (def) → use source code for stable, cross-version hashing
     - Lambdas → use bytecode (deterministic in same Python runtime)
+    - Recursively hashes helper functions from the same module
     """
     if not callable(func):
         raise TypeError("Expected a callable")
+
+    # Track visited functions to avoid infinite recursion
+    if _visited is None:
+        _visited = set()
+
+    # Use id(func) to track which functions we've visited
+    func_id = id(func)
+    if func_id in _visited:
+        return hashlib.sha256(f"recursive:{func.__name__}".encode()).hexdigest()
+    _visited.add(func_id)
 
     # Determine if it is a lambda
     is_lambda = func.__name__ == "<lambda>"
@@ -149,8 +160,41 @@ def hash_callable(func):
         "annotations": annotations,
     }
 
+    # Find helper functions that this function depends on
+    dependencies = {}
+    if hasattr(func, "__code__") and hasattr(func, "__globals__"):
+        # Get all names referenced in the function's code
+        referenced_names = func.__code__.co_names
+        func_module = inspect.getmodule(func)
+
+        for name in referenced_names:
+            # Look up the name in the function's global namespace
+            if name in func.__globals__:
+                obj = func.__globals__[name]
+
+                # Only hash user-defined functions from the same module
+                # Skip built-ins, imported functions from other modules, and classes
+                if (
+                    callable(obj)
+                    and hasattr(obj, "__module__")
+                    and func_module is not None
+                    and obj.__module__ == func_module.__name__
+                    and not inspect.isclass(obj)
+                    and not inspect.isbuiltin(obj)
+                ):
+                    # Recursively hash the dependency
+                    try:
+                        dependencies[name] = hash_callable(obj, _visited)
+                    except (TypeError, OSError):
+                        # If we can't hash it, skip it
+                        pass
+
     # Compute SHA256
     h = hashlib.sha256()
     h.update(str(payload).encode() if isinstance(payload, str) else payload)
     h.update(str(extras).encode())
+    # Include dependency hashes in sorted order for determinism
+    if dependencies:
+        deps_str = json.dumps(dependencies, sort_keys=True)
+        h.update(deps_str.encode())
     return h.hexdigest()

--- a/tests/unit/test_hash_utils.py
+++ b/tests/unit/test_hash_utils.py
@@ -107,3 +107,30 @@ def test_lambda_different_hashes():
 
     # Ensure hashes are all different
     assert len({h1, h2, h3}) == 3
+
+
+def test_hash_callable_with_dependencies():
+    """Test that hash_callable includes dependencies from the same module."""
+
+    # Define helper and function that uses it
+    def helper(x):
+        return x + 1
+
+    def func_with_helper(x):
+        return helper(x) * 2
+
+    hash1 = hash_callable(func_with_helper)
+    assert hash1 == "5b2dbae7cca8695acd62ea2ee2226277962c1c59a098ab948ff1b2e73b3d822c"
+
+    # Redefine helper with different implementation (same name, different code)
+    def helper(x):  # noqa: F811
+        return x + 10
+
+    def func_with_helper(x):
+        return helper(x) * 2
+
+    hash2 = hash_callable(func_with_helper)
+    assert hash2 == "099b86b464fb5a901393b28f073b7701f22a31775b5ce8402b4ea1116a50064e"
+
+    # Hashes should be different because helper changed
+    assert hash1 != hash2


### PR DESCRIPTION
Currently `hash_callable()` only hashed the function itself. Changes to helper functions in the same script didn't change the hash

Example:

  ```python
  def helper(x):
      return x + 1

  def my_udf(x):
      return helper(x) * 2

  hash1 = hash_callable(my_udf)

  # Change helper
  def helper(x):
      return x + 10

  hash2 = hash_callable(my_udf)  # hash1 == hash2 -> wrong!
```

  Solution

  Now recursively tracks and hashes user-defined helper functions from the same **module**:
  - Inspects `func.__code__.co_names` to find dependencies
  - Only includes functions from same file (ignores imports, built-ins, classes)
  - Handles circular dependencies

  Limitations

  1. Global variables/constants not tracked - e.g. changing THRESHOLD = 100 to 200 (assuming it's used in function) won't change hash
  2. Cross-module imports ignored - from utils import helper changes not tracked (by design)
  3. Closures not tracked - captured values in closures not reflected

## Summary by Sourcery

Add recursive dependency tracking to hash_callable so that changes in user-defined helper functions within the same module affect the hash, with cycle detection to prevent infinite recursion.

New Features:
- Recursively include user-defined helper functions from the same module in hash_callable
- Handle circular dependencies by tracking visited functions

Enhancements:
- Inspect function code names and globals to identify same-module dependencies and ignore imports, builtins, and classes
- Include sorted dependency hashes in the hash payload for determinism

Tests:
- Add unit test to verify that hash_callable changes when a helper function implementation is modified