### PR TITLE
Fix 'WDSLaion' model (broken after Pydantic 2.12.0)

### DIFF
--- a/src/datachain/lib/webdataset_laion.py
+++ b/src/datachain/lib/webdataset_laion.py
@@ -42,7 +42,7 @@ class Laion(WDSReadableSubclass):
 
 class WDSLaion(WDSBasic):
     txt: str | None = Field(default=None)
-    json: Laion  # type: ignore[assignment]
+    json: Laion = Field(default_factory=Laion)  # type: ignore[assignment]
 
 
 class LaionMeta(BaseModel):


### PR DESCRIPTION
CI is failing, example: https://github.com/iterative/datachain/actions/runs/18295119238/job/52205959596

Reason: `Pydantic` updates to `2.12.0`: https://docs.pydantic.dev/2.12/errors/validation_errors/#missing

## Summary by Sourcery

Bug Fixes:
- Provide default_factory on the json field in WDSLaion to satisfy Pydantic’s requirement for missing defaults