### PR TITLE
fix(file): set stream after resolve

### DIFF
--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -681,7 +681,7 @@ class File(DataModel):
             normalized_path = self.get_path_normalized()
             info = client.fs.info(client.get_full_path(normalized_path))
             converted_info = client.info_to_file(info, normalized_path)
-            return type(self)(
+            res = type(self)(
                 path=self.path,
                 source=self.source,
                 size=converted_info.size,
@@ -691,6 +691,8 @@ class File(DataModel):
                 last_modified=converted_info.last_modified,
                 location=self.location,
             )
+            res._set_stream(self._catalog)
+            return res
         except FileError as e:
             logger.warning(
                 "File error when resolving %s/%s: %s", self.source, self.path, str(e)
@@ -703,7 +705,7 @@ class File(DataModel):
                 str(e),
             )
 
-        return type(self)(
+        res = type(self)(
             path=self.path,
             source=self.source,
             size=0,
@@ -713,6 +715,8 @@ class File(DataModel):
             last_modified=TIME_ZERO,
             location=self.location,
         )
+        res._set_stream(self._catalog)
+        return res
 
     def rebase(
         self,

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -322,6 +322,23 @@ def test_file_resolve_no_catalog():
         file.resolve()
 
 
+def test_file_resolve_sets_catalog(tmp_path, catalog):
+    # https://github.com/iterative/datachain/pull/1393
+    file_name = "myfile"
+    file_path = tmp_path / file_name
+    file_path.write_text("this is a TexT data...")
+
+    file = File(path=file_name, source=f"file://{tmp_path}")
+    file._set_stream(catalog, True)
+
+    file_path.write_text("new data")
+    new_file = file.resolve()
+
+    assert new_file._catalog is catalog
+    new_file.ensure_cached()
+    assert new_file.read_text() == "new data"
+
+
 def test_resolve_function():
     mock_file = Mock(spec=File)
     mock_file.resolve.return_value = "resolved_file"


### PR DESCRIPTION
Fixes code like:

```python
def amend_file(old_file: dc.File) -> dc.File :
    file = old_file.resolve()    
    file.ensure_cached()
    return file
```

That fails with an error like:

```python
datachain_worker.tasks.udf_run.UdfTaskFailed: UDF task failed: Error in user code in class 'Mapper': cannot download file to cache because catalog is not setup
```

## Summary by Sourcery

Bug Fixes:
- Ensure resolve() calls _set_stream(self._catalog) on new File objects before returning to avoid caching errors when using ensure_cached()