### PR TITLE
Alternative to  #1387

### DIFF
--- a/src/datachain/catalog/dependency.py
+++ b/src/datachain/catalog/dependency.py
@@ -1,4 +1,67 @@
-from datachain.dataset import DatasetDependency, DatasetDependencyNode
+import builtins
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TypeVar
+
+from datachain.dataset import DatasetDependency
+
+DDN = TypeVar("DDN", bound="DatasetDependencyNode")
+
+
+@dataclass
+class DatasetDependencyNode:
+    namespace: str
+    project: str
+    id: int
+    dataset_id: int | None
+    dataset_version_id: int | None
+    dataset_name: str | None
+    dataset_version: str | None
+    created_at: datetime
+    source_dataset_id: int
+    source_dataset_version_id: int | None
+    depth: int
+
+    @classmethod
+    def parse(
+        cls: builtins.type[DDN],
+        namespace: str,
+        project: str,
+        id: int,
+        dataset_id: int | None,
+        dataset_version_id: int | None,
+        dataset_name: str | None,
+        dataset_version: str | None,
+        created_at: datetime,
+        source_dataset_id: int,
+        source_dataset_version_id: int | None,
+        depth: int,
+    ) -> "DatasetDependencyNode | None":
+        return cls(
+            namespace,
+            project,
+            id,
+            dataset_id,
+            dataset_version_id,
+            dataset_name,
+            dataset_version,
+            created_at,
+            source_dataset_id,
+            source_dataset_version_id,
+            depth,
+        )
+
+    def to_dependency(self) -> "DatasetDependency | None":
+        return DatasetDependency.parse(
+            namespace_name=self.namespace,
+            project_name=self.project,
+            id=self.id,
+            dataset_id=self.dataset_id,
+            dataset_version_id=self.dataset_version_id,
+            dataset_name=self.dataset_name,
+            dataset_version=self.dataset_version,
+            dataset_version_created_at=self.created_at,
+        )
 
 
 def build_dependency_hierarchy(

--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -20,7 +20,6 @@ LT = TypeVar("LT", bound="DatasetListRecord")
 V = TypeVar("V", bound="DatasetVersion")
 LV = TypeVar("LV", bound="DatasetListVersion")
 DD = TypeVar("DD", bound="DatasetDependency")
-DDN = TypeVar("DDN", bound="DatasetDependencyNode")
 
 DATASET_PREFIX = "ds://"
 QUERY_DATASET_PREFIX = "ds_query_"
@@ -93,62 +92,6 @@ def parse_dataset_name(name: str) -> tuple[str | None, str | None, str]:
 class DatasetDependencyType:
     DATASET = "dataset"
     STORAGE = "storage"
-
-
-@dataclass
-class DatasetDependencyNode:
-    namespace: str
-    project: str
-    id: int
-    dataset_id: int | None
-    dataset_version_id: int | None
-    dataset_name: str | None
-    dataset_version: str | None
-    created_at: datetime
-    source_dataset_id: int
-    source_dataset_version_id: int | None
-    depth: int
-
-    @classmethod
-    def parse(
-        cls: builtins.type[DDN],
-        namespace: str,
-        project: str,
-        id: int,
-        dataset_id: int | None,
-        dataset_version_id: int | None,
-        dataset_name: str | None,
-        dataset_version: str | None,
-        created_at: datetime,
-        source_dataset_id: int,
-        source_dataset_version_id: int | None,
-        depth: int,
-    ) -> "DatasetDependencyNode | None":
-        return cls(
-            namespace,
-            project,
-            id,
-            dataset_id,
-            dataset_version_id,
-            dataset_name,
-            dataset_version,
-            created_at,
-            source_dataset_id,
-            source_dataset_version_id,
-            depth,
-        )
-
-    def to_dependency(self) -> "DatasetDependency | None":
-        return DatasetDependency.parse(
-            namespace_name=self.namespace,
-            project_name=self.project,
-            id=self.id,
-            dataset_id=self.dataset_id,
-            dataset_version_id=self.dataset_version_id,
-            dataset_name=self.dataset_name,
-            dataset_version=self.dataset_version,
-            dataset_version_created_at=self.created_at,
-        )
 
 
 @dataclass


### PR DESCRIPTION
Alternative to  #1387
Summary:
------
This PR changes improvement in performances to dataset dependency
calculation as well as in storage where we now store the nested
dependency structure directly to optimize the retreival process.

Changes:
------
- Replaced recursive database queries with a single batch query that fetches all dependencies at once
- Reduced Database Round-trips: Dependency calculation now uses get_direct_dataset_dependencies_by_ids() to fetch all required dependencies in one query
- Optimized Memory Usage: New DatasetDependencyMinimal class stores only essential dependency information

Database change:
-------
- Added nested_dependencies Column: New JSON column in datasets_dependencies table to store pre-calculated dependency structures
- Backward Compatibility: Schema migration safely adds the new column to existing databases
- Efficient Storage: Nested dependency trees are stored as JSON, reducing storage overhead

## Summary by Sourcery

Improve dataset dependency retrieval by replacing recursive per-dependency queries with a single batch recursive CTE, storing nested dependency trees directly in the database, and providing utilities to assemble dependency hierarchies in memory.

New Features:
- Introduce DatasetDependencyNode dataclass to represent dependency entries with hierarchy depth
- Add metastore.get_dataset_dependency_node method leveraging a recursive CTE to fetch complete dependency trees
- Implement catalog.get_dataset_dependencies_by_ids method to retrieve and assemble nested dependencies in a single batch
- Provide build_dependency_hierarchy and populate_nested_dependencies utilities for constructing nested dependency trees

Enhancements:
- Replace recursive per-dependency database lookups with a single batched query to reduce round trips
- Add nested_dependencies JSON column to datasets_dependencies table with a migration for efficient storage of precomputed dependency structures