### PR TITLE
Fix checkpoints hash tests

### DIFF
--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -195,7 +195,7 @@ def test_all_possible_steps(test_session):
             right_on=["player.name"],
         )
         .hash()
-    ) == "1e2caf5d0bcda7ea75e33bb4db43cc7321191306b47a77ae541b61bbbfcea32b"
+    ) == "2c8d3fffade5574a418c45545f4c821cbe734f648cfcbfa55843673796bc35eb"
 
 
 def test_diff(test_session):

--- a/tests/unit/test_hash_utils.py
+++ b/tests/unit/test_hash_utils.py
@@ -67,11 +67,11 @@ lambda3 = lambda z: z - 1  # noqa: E731
         ),
         (
             [sa_func.coalesce(C("name"), "unknown")],
-            "54f932d64722aeb4cc167d68e12c149e10547b3737f4fce91c536d56cbf8c6bd",
+            "13532bc4a1a250e6ea24420bddda3cc1dc15b0ce710b1d2a73c815129152caad",
         ),
         (
             [sa_func.nullif(C("age"), 0)],
-            "ff437af7c0cf5586358b78ecd7bc6cdfdd714bb23d6a0732b940e671585a8d50",
+            "57c0d74f3881dd687a1d97717e662ecea668d89be62f75487ab6824d2e176761",
         ),
         # Window functions
         (
@@ -153,11 +153,11 @@ lambda3 = lambda z: z - 1  # noqa: E731
         ),
         (
             [sa_func.concat(C("first_name"), " ", C("last_name"))],
-            "6bb32f278bc048cb177941749d1e30e18d5eb747b1d74e274a118ea27e5044eb",
+            "b7b6b68d73eb0ea274e8d1d418541a52023cc978106bcf914d92a0bee810566a",
         ),
         (
             [sa_func.lower(C("name"))],
-            "fcc14e7bdef5ffd2400a81bf8dcc38a42186da7114fa10bd44734d8a85ad14a8",
+            "09ce2d422c40e4db6dd0c1a1dc8d34457786dc366c8dca23b87aca2a76af1542",
         ),
         # NULL operations
         (
@@ -318,11 +318,11 @@ lambda3 = lambda z: z - 1  # noqa: E731
         ),
         (
             [sa_func.abs(C("value"))],
-            "1b7730de86ee63596f01acb68a8b894b4fc1d3e0b166f6c285614b20e7535fc6",
+            "0f32eade11cd2591bf7c948760c8658c66f9c3986b15affc7488a5646e2f6e39",
         ),
         (
             [sa_func.round(C("price"), 2)],
-            "215bb8748e030d0dcab919f730d35bef28a40eace1d14c04f79f31783822592b",
+            "1c0223a26f3884bfceca93e69dc9e0adbcb0dbe00d96338c4343b4128330ef63",
         ),
     ],
 )

--- a/tests/unit/test_query_steps_hash.py
+++ b/tests/unit/test_query_steps_hash.py
@@ -181,7 +181,7 @@ def test_filter_hash(inputs, _hash):
         (
             {"new_id": func.sum("id")},
             SignalSchema({"id": int}),
-            "47f57e322e79be378d12cb8823273567f93e52b245c9c0736562826b54cd6f7e",
+            "60f3a9e31aa77dabb8045060659e75f050133278fd613f0a0075b309747eb80e",
         ),
         (
             {"new_id": C("id") * 10, "old_id": C("id")},
@@ -334,17 +334,17 @@ def test_join_hash(
             [
                 C("id"),
             ],
-            "27df6281d3e83a7012edcab01715b1a44225a128df9c9f59586178ecdba6b8e6",
+            "dad35b97c6a47beaa605df6ccc46225c7279180d93f01b43cf2918fccca0a7ed",
         ),
         (
             {"cnt": func.count(), "sum": func.sum("id")},
             [C("id"), C("name")],
-            "02ed6a8bee48bf53928cdd9d22d2f383749da48c376d6b9965b4beb89f194da3",
+            "5ebb814165256f4cd4717d8ec255d6d67bc4abb165bffaa95b09b49b0f90c6e5",
         ),
         (
             {"cnt": func.count()},
             [],
-            "021558fa58a0aef53df616927a8bc12dae0f86afdb8e6f1f8be593bac4708fc4",
+            "96512eb2367f9940e53e37d450d79f9a08d3de19b6c36d79a6939b55487d657c",
         ),
     ],
 )


### PR DESCRIPTION
After sqlalchemy update to `2.0.44`.

## Summary by Sourcery

Tests:
- Update expected hash digests in hash utility, query steps, and datachain tests to align with SQLAlchemy 2.0.44