### PR TITLE
fix(audio): migrate from deprecated torchaudio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ torch = [
   "transformers>=4.36.0"
 ]
 audio = [
-  "torchaudio",
   "soundfile"
 ]
 remote = [
@@ -88,7 +87,11 @@ hf = [
   "datasets[vision]>=4.0.0",
   # https://github.com/pytorch/torchcodec/issues/640
   "datasets[audio]>=4.0.0 ; (sys_platform == 'linux' or sys_platform == 'darwin')",
-  "fsspec>=2024.12.0"
+  "fsspec>=2024.12.0",
+  # Until datasets solve the issue, run test_hf_audio test to see if this can be removed
+  # https://github.com/meta-pytorch/torchcodec/issues/912
+  # https://github.com/huggingface/transformers/pull/41610
+  "torch<2.9.0"
 ]
 video = [
   "ffmpeg-python",
@@ -134,7 +137,9 @@ examples = [
   "huggingface_hub[hf_transfer]",
   "ultralytics",
   "open_clip_torch",
-  "openai"
+  "openai",
+  # Transformers still require it
+  "torchaudio<2.9.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
It is failing now with the 2.9.0 release. More information here https://github.com/pytorch/audio/issues/3902

## Summary by Sourcery

Migrate audio processing from the deprecated torchaudio library to the soundfile library and update related code, tests, and dependencies accordingly.

Enhancements:
- Replace torchaudio.info and torchaudio.load calls in audio_info and audio_to_np with soundfile.info and soundfile.read.
- Introduce a helper to map soundfile subtypes to bits per sample and simplify format detection based on info.format or file extension.
- Refactor audio_to_bytes to use the new audio_to_np implementation without redundant imports.

Build:
- Remove torchaudio dependency and add soundfile in pyproject.toml to restore compatibility after torchaudio 2.9.0 deprecation.

Tests:
- Update unit tests to mock soundfile.info and validate format and codec detection based on soundfile.format and subtype parameters.