### PR TITLE
Don't duplicate temp tables on reusing queries

### DIFF
--- a/tests/func/test_temp_table_tracking.py
+++ b/tests/func/test_temp_table_tracking.py
@@ -1,0 +1,68 @@
+import datachain as dc
+from datachain.query.dataset import DatasetQuery
+
+
+def _capture_temp_tables(mocker):
+    captured: list[list[str]] = []
+    original_cleanup = DatasetQuery.cleanup
+
+    def capture(self):
+        captured.append(list(self.temp_table_names))
+        return original_cleanup(self)
+
+    mocker.patch("datachain.query.dataset.DatasetQuery.cleanup", capture)
+    return captured
+
+
+def _assert_no_duplicate_temp_tables(captured: list[list[str]]):
+    for tables in captured:
+        assert len(tables) == len(set(tables))
+
+
+def test_nested_merge_has_no_duplicate_temp_tables(test_session, mocker):
+    captured = _capture_temp_tables(mocker)
+
+    base = dc.read_values(num=[1, 2], session=test_session)
+    generated = base.map(num_plus=lambda num: str(num + 10))
+    inner = generated.merge(base, on="num", inner=True)
+    chain = base.merge(inner, on="num", inner=True)
+
+    expected = chain.select("num").to_pandas()["num"].tolist()
+    assert expected == [1, 2]
+
+    rerun = chain.select("num").to_pandas()["num"].tolist()
+    assert rerun == expected
+
+    _assert_no_duplicate_temp_tables(captured)
+
+
+def test_union_has_no_duplicate_temp_tables(test_session, mocker):
+    captured = _capture_temp_tables(mocker)
+
+    left = dc.read_values(num=[1, 2], session=test_session)
+    right = dc.read_values(num=[3], session=test_session)
+    union_chain = left.union(right)
+
+    expected = sorted(union_chain.select("num").to_pandas()["num"].tolist())
+    assert expected == [1, 2, 3]
+
+    rerun = sorted(union_chain.select("num").to_pandas()["num"].tolist())
+    assert rerun == expected
+
+    _assert_no_duplicate_temp_tables(captured)
+
+
+def test_subtract_has_no_duplicate_temp_tables(test_session, mocker):
+    captured = _capture_temp_tables(mocker)
+
+    source = dc.read_values(num=[1, 2], session=test_session)
+    target = dc.read_values(num=[2], session=test_session)
+    subtract_chain = source.subtract(target, on="num")
+
+    expected = subtract_chain.select("num").to_pandas()["num"].tolist()
+    assert expected == [1]
+
+    rerun = subtract_chain.select("num").to_pandas()["num"].tolist()
+    assert rerun == expected
+
+    _assert_no_duplicate_temp_tables(captured)


### PR DESCRIPTION
We need a proper fix for the whole temp table tracking. I'll take a look hopefully. We should be using some kind of "run context" instead of reusing one global temp_tables from the initial chain. 

For now this makes the manipulations with temp tables more precise.

## Summary by Sourcery

Fix temporary table tracking by slicing appended names to avoid duplicates and add tests to validate correct behavior

Bug Fixes:
- Prevent duplicate temp table entries by appending only newly added names in various query methods
- Log an error if duplicate temp tables are detected during cleanup

Tests:
- Add functional tests to verify no duplicate temp tables in nested merge, union, and subtract operations