### PR TITLE
better fix for sys_id in delta, add tests

### DIFF
--- a/src/datachain/delta.py
+++ b/src/datachain/delta.py
@@ -1,16 +1,12 @@
-import hashlib
 from collections.abc import Sequence
 from copy import copy
 from functools import wraps
 from typing import TYPE_CHECKING, TypeVar
 
-from attrs import frozen
-
 import datachain
 from datachain.dataset import DatasetDependency, DatasetRecord
 from datachain.error import DatasetNotFoundError
 from datachain.project import Project
-from datachain.query.dataset import Step, step_result
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -18,9 +14,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import ParamSpec
 
-    from datachain.catalog import Catalog
     from datachain.lib.dc import DataChain
-    from datachain.query.dataset import QueryGenerator
 
     P = ParamSpec("P")
 
@@ -49,38 +43,11 @@ def delta_disabled(
     return _inner
 
 
-@frozen
-class _RegenerateSystemColumnsStep(Step):
-    catalog: "Catalog"
-
-    def hash_inputs(self) -> str:
-        return hashlib.sha256(b"regenerate_sys_columns").hexdigest()
-
-    def apply(self, query_generator: "QueryGenerator", temp_tables: list[str]):
-        selectable = query_generator.select()
-        regenerated = self.catalog.warehouse._regenerate_system_columns(
-            selectable,
-            keep_existing_columns=True,
-            regenerate_columns=None,
-        )
-
-        def q(*columns):
-            return regenerated.with_only_columns(*columns)
-
-        return step_result(q, regenerated.selected_columns)
-
-
 def _append_steps(dc: "DataChain", other: "DataChain"):
     """Returns cloned chain with appended steps from other chain.
     Steps are all those modification methods applied like filters, mappers etc.
     """
     dc = dc.clone()
-    dc._query.steps.append(
-        _RegenerateSystemColumnsStep(
-            catalog=dc.session.catalog,
-        )
-    )
-
     dc._query.steps += other._query.steps.copy()
     dc.signals_schema = other.signals_schema
     return dc

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -200,6 +200,10 @@ def read_dataset(
         signals_schema |= SignalSchema.deserialize(query.feature_schema)
     else:
         signals_schema |= SignalSchema.from_column_types(query.column_types or {})
+
+    if delta:
+        signals_schema = signals_schema.clone_without_sys_signals()
+
     chain = DataChain(query, _settings, signals_schema)
 
     if delta:

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -187,6 +187,12 @@ def read_storage(
             project=listing_project_name,
             session=session,
             settings=settings,
+            delta=delta,
+            delta_on=delta_on,
+            delta_result_on=delta_result_on,
+            delta_compare=delta_compare,
+            delta_retry=delta_retry,
+            delta_unsafe=delta_unsafe,
         )
         dc._query.update = update
         dc.signals_schema = dc.signals_schema.mutate({f"{column}": file_type})
@@ -251,14 +257,5 @@ def read_storage(
         storage_chain = storage_chain.union(file_chain) if storage_chain else file_chain
 
     assert storage_chain is not None
-
-    if delta:
-        storage_chain = storage_chain._as_delta(
-            on=delta_on,
-            right_on=delta_result_on,
-            compare=delta_compare,
-            delta_retry=delta_retry,
-            delta_unsafe=delta_unsafe,
-        )
 
     return storage_chain


### PR DESCRIPTION
Continuation of https://github.com/iterative/datachain/pull/1412/files

Since we use union in delta, we essentially properly set schema in read_dataset to not include sys columns


## Summary by Sourcery

Simplify and correct delta processing by filtering out system columns at read time, removing a redundant regeneration step, propagating delta parameters in storage reads, and adding tests to validate proper behavior

Bug Fixes:
- Exclude system columns from the schema during delta reads to prevent incorrect sys_id unions

Enhancements:
- Remove the manual _RegenerateSystemColumnsStep hack and streamline delta logic by passing delta parameters through read_storage
- Adjust read_dataset to drop system signals when delta is enabled

Tests:
- Add functional tests to verify that storage-based delta replays correctly regenerate system columns and include new records

## Summary by Sourcery

Improve delta handling by excluding system columns at read time, removing the hacky regeneration step, consolidating delta logic in storage reads, and expanding functional tests

Bug Fixes:
- Exclude system columns from the schema when reading datasets in delta mode to fix sys_id handling

Enhancements:
- Remove the _RegenerateSystemColumnsStep hack and redundant _as_delta invocation
- Propagate delta parameters directly in read_storage for unified delta logic

Tests:
- Update delta functional test to use the new save signature and add a storage delta replay test for system column regeneration