### PR TITLE
fix(delta): handle missing dependencies

### DIFF
--- a/src/datachain/delta.py
+++ b/src/datachain/delta.py
@@ -200,7 +200,9 @@ def _get_source_info(
         indirect=False,
     )
 
-    source_ds_dep = next((d for d in dependencies if d.name == source_ds.name), None)
+    source_ds_dep = next(
+        (d for d in dependencies if d and d.name == source_ds.name), None
+    )
     if not source_ds_dep:
         # Starting dataset was removed, back off to normal dataset creation
         return None, None, None, None, None


### PR DESCRIPTION
Account for some dependencies deleted when we do delta updates.

## Summary by Sourcery

Ensure delta updates revert to full dataset creation if the referenced source version is removed, avoiding errors from missing dependencies

Bug Fixes:
- Handle missing dependencies in delta updates by falling back to a full rebuild when the source version is deleted

Enhancements:
- Skip None entries when filtering dataset dependencies in delta logic

Tests:
- Add functional test to verify fallback behavior when a delta dependency is missing