### PR TITLE
fix(diff): edge case when there no columns except provided in on

### DIFF
--- a/src/datachain/diff/__init__.py
+++ b/src/datachain/diff/__init__.py
@@ -103,8 +103,10 @@ def _compare(  # noqa: C901
     left = left.mutate(**{ldiff_col: 1})
     right = right.mutate(**{rdiff_col: 1})
 
-    if not compare:
+    if compare is None:
         modified_cond = True
+    elif len(compare) == 0:
+        modified_cond = False
     else:
         modified_cond = or_(  # type: ignore[assignment]
             *[

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -35,7 +35,7 @@ def test_checkpoints(
     catalog = test_session.catalog
     metastore = catalog.metastore
 
-    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", reset_checkpoints)
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", str(reset_checkpoints))
 
     if with_delta:
         chain = dc.read_dataset(
@@ -75,8 +75,9 @@ def test_checkpoints(
     chain.save("nums3")
     second_job_id = test_session.get_or_create_job().id
 
-    assert len(catalog.get_dataset("nums1").versions) == 2 if reset_checkpoints else 1
-    assert len(catalog.get_dataset("nums2").versions) == 2 if reset_checkpoints else 1
+    expected_versions = 1 if with_delta or not reset_checkpoints else 2
+    assert len(catalog.get_dataset("nums1").versions) == expected_versions
+    assert len(catalog.get_dataset("nums2").versions) == expected_versions
     assert len(catalog.get_dataset("nums3").versions) == 1
 
     assert len(list(catalog.metastore.list_checkpoints(first_job_id))) == 2
@@ -88,7 +89,7 @@ def test_checkpoints_modified_chains(
     test_session, monkeypatch, nums_dataset, reset_checkpoints
 ):
     catalog = test_session.catalog
-    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", reset_checkpoints)
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", str(reset_checkpoints))
 
     chain = dc.read_dataset("nums", session=test_session)
 
@@ -120,7 +121,7 @@ def test_checkpoints_multiple_runs(
 ):
     catalog = test_session.catalog
 
-    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", reset_checkpoints)
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", str(reset_checkpoints))
 
     chain = dc.read_dataset("nums", session=test_session)
 
@@ -184,7 +185,7 @@ def test_checkpoints_check_valid_chain_is_returned(
     monkeypatch,
     nums_dataset,
 ):
-    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", False)
+    monkeypatch.setenv("DATACHAIN_CHECKPOINTS_RESET", str(False))
     chain = dc.read_dataset("nums", session=test_session)
 
     # -------------- FIRST RUN -------------------
@@ -197,6 +198,7 @@ def test_checkpoints_check_valid_chain_is_returned(
 
     # checking that we return expected DataChain even though we skipped chain creation
     # because of the checkpoints
+    assert ds.dataset is not None
     assert ds.dataset.name == "nums1"
     assert len(ds.dataset.versions) == 1
     assert ds.order_by("num").to_list("num") == [(1,), (2,), (3,)]

--- a/tests/unit/lib/test_diff.py
+++ b/tests/unit/lib/test_diff.py
@@ -256,6 +256,24 @@ def test_diff_on_equal_datasets(test_session, on_self):
     assert diff.order_by("id").to_list(*collect_fields) == expected
 
 
+def test_diff_only_on_columns_treated_as_same(test_session):
+    ds1 = dc.read_values(
+        id=[1, 2],
+        session=test_session,
+    )
+    ds2 = dc.read_values(
+        id=[1, 2],
+        session=test_session,
+    )
+
+    diff = ds1.diff(ds2, on=["id"], same=True, status_col="diff")
+
+    assert diff.order_by("id").to_list("diff", "id") == [
+        (CompareStatus.SAME, 1),
+        (CompareStatus.SAME, 2),
+    ]
+
+
 def test_diff_multiple_columns(test_session, str_default):
     ds1 = dc.read_values(
         id=[1, 2, 4],
@@ -382,7 +400,7 @@ def test_diff_missing_on(test_session):
     ds2 = dc.read_values(id=[1, 2, 4], session=test_session)
 
     with pytest.raises(ValueError) as exc_info:
-        ds1.diff(ds2, on=None)
+        ds1.diff(ds2, on=None)  # type: ignore[arg-type]
 
     assert str(exc_info.value) == "'on' must be specified"
 

--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -218,4 +218,4 @@ def test_diff(test_session):
             status_col="diff",
         )
         .hash()
-    ) == "4135f2deffa91702259de50b48076dd2f8cdf3be32c167332840209c137977f9"
+    ) == "8ffac19b12cf96e2916968914d357c4a9c1b81038c43ab5cf97ba1127fb86567"


### PR DESCRIPTION
Fixes an edge case in `diff` (see test). When only column(s) that dataset has are the ones provided in `on` we treated records as different. It fixes to treat those as same. (It affects delta among other things).

## Summary by Sourcery

Fix diff edge case where datasets with only 'on' columns were incorrectly marked as different by treating an empty compare list as no modifications and add a test for this scenario

Bug Fixes:
- Handle empty compare list in diff to avoid marking rows as modified when only 'on' columns are present

Tests:
- Add test to verify diff treats records as same when only 'on' columns exist