### PR TITLE
always drop sys id in merge

### DIFF
--- a/src/datachain/delta.py
+++ b/src/datachain/delta.py
@@ -150,7 +150,9 @@ def _get_retry_chain(
         error_records = result_dataset.filter(C(delta_retry) != "")
         error_source_records = source_dc.merge(
             error_records, on=on, right_on=right_on, inner=True
-        ).select(*list(source_dc.signals_schema.values))
+        ).select(
+            *list(source_dc.signals_schema.clone_without_sys_signals().values.keys())
+        )
         retry_chain = error_source_records
 
     # Handle missing records if delta_retry is True

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1697,13 +1697,12 @@ class DataChain:
         query.feature_schema = None
         ds = self._evolve(query=query)
 
+        # Note: merge drops sys signals from both sides, make sure to not include it
+        # in the resulting schema
         signals_schema = self.signals_schema.clone_without_sys_signals()
         right_signals_schema = right_ds.signals_schema.clone_without_sys_signals()
 
         ds.signals_schema = signals_schema.merge(right_signals_schema, rname)
-
-        if not full:
-            ds.signals_schema = SignalSchema({"sys": Sys}) | ds.signals_schema
 
         return ds
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1065,7 +1065,7 @@ class SQLJoin(Step):
         q1 = self.get_query(self.query1, temp_tables)
         q2 = self.get_query(self.query2, temp_tables)
 
-        q1_columns = _drop_system_columns(q1.c) if self.full else list(q1.c)
+        q1_columns = _drop_system_columns(q1.c)
         q1_column_names = {c.name for c in q1_columns}
 
         q2_columns = []


### PR DESCRIPTION
Continuation of my favorite thing - `sys__id` and `sys__rand` management.

It is not really safe to keep in merge / join in general since there could be duplicates after merge AFAIU.

It is better to drop it and don't advertise as part of the schema outside.

## Summary by Sourcery

Enforce dropping of system columns (sys signals) during merge and join operations to prevent duplicate or exposed internal schema fields and verify correct behavior through updated and new tests.

Enhancements:
- Always drop sys signals when merging or joining datasets in both client and query implementations.

Tests:
- Remove sys key assertions from existing merge tests and add a new test to confirm system columns are excluded after merge and correctly restored on save/load.