### PR TITLE
fix(gen): always prepare table for now to have sys columns

### DIFF
--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -1699,10 +1699,16 @@ def test_agg_offset_limit(catalog_tmpfile, parallel, offset, limit, files):
         value=list(range(100)),
         session=catalog_tmpfile.session,
     )
+    # Read values in general doesn't guarantee order, so we need to order first
+    ds = ds.order_by("filename")
     if offset is not None:
         ds = ds.offset(offset)
     if limit is not None:
         ds = ds.limit(limit)
+
+    limited_filenames = ds.to_values("filename")
+    assert set(limited_filenames) == set(files)
+
     ds = (
         ds.settings(parallel=parallel)
         .agg(


### PR DESCRIPTION
Probably we'll need this table anyways for checkpoints to work, so let's unify it with map for simplicity as a quick fix (and thus ensure presence of sys columns for gen as well). Then, let's review all these manipulations and if can optimize things (cc @ilongin )

## Summary by Sourcery

Always prepare a pre-UDF table to include system columns for generation and simplify checkpointing, unify process_input_query behavior, and add a functional test for parallel gen without duplicate IDs

Enhancements:
- Unify process_input_query to always materialize inputs into a pre-UDF table to ensure presence of system columns for gen and map operations

Tests:
- Add functional test for parallel generation to verify outputs contain unique values in concurrent gen scenarios