### PR TITLE
add sys signals back after persist

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -577,7 +577,8 @@ class DataChain:
             create=True,
         )
         return self._evolve(
-            query=self._query.save(project=project, feature_schema=schema)
+            query=self._query.save(project=project, feature_schema=schema),
+            signal_schema=self.signals_schema | SignalSchema({"sys": Sys}),
         )
 
     def _calculate_job_hash(self, job_id: str) -> str:

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1219,6 +1219,22 @@ def test_vector_of_vectors(test_session):
     assert np.allclose(actual[1], vector[1])
 
 
+def test_persist_restores_sys_signals_after_merge(test_session):
+    left = dc.read_values(ids=[1, 2], session=test_session)
+    right = dc.read_values(ids=[1, 2], extra=["x", "y"], session=test_session)
+
+    merged = left.merge(right, on="ids")
+
+    with pytest.raises(SignalResolvingError):
+        merged.signals_schema.resolve("sys.rand")
+
+    persisted = merged.persist()
+
+    sys_schema = persisted.signals_schema.resolve("sys.id", "sys.rand").values
+    assert sys_schema["sys.id"] is int
+    assert sys_schema["sys.rand"] is int
+
+
 def test_unsupported_output_type(test_session):
     vector = [3.14, 2.72, 1.62]
 


### PR DESCRIPTION
Make sure that persist keeps signal schema up to date explicitly (fixes our tutorials, and some potential customer issues)

## Summary by Sourcery

Ensure that the persist operation explicitly merges back the system signal schema so that sys signals remain resolvable after merging and saving.

Bug Fixes:
- Restore system signals schema in persist to prevent resolution errors after merging

Tests:
- Add unit test to verify that persist restores sys signals schema after merge