### PR TITLE
fix split / shuffle after union / merge

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -52,7 +52,11 @@ from datachain.lib.udf_signature import UdfSignature
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
 from datachain.project import Project
 from datachain.query import Session
-from datachain.query.dataset import DatasetQuery, PartitionByType
+from datachain.query.dataset import (
+    DatasetQuery,
+    PartitionByType,
+    RegenerateSystemColumns,
+)
 from datachain.query.schema import DEFAULT_DELIMITER, Column
 from datachain.sql.functions import path as pathfunc
 from datachain.utils import batched_it, env2bool, inside_notebook, row_to_nested_dict
@@ -2740,8 +2744,20 @@ class DataChain:
         )
 
     def shuffle(self) -> "Self":
-        """Shuffle the rows of the chain deterministically."""
-        return self.order_by("sys.rand")
+        """Shuffle rows with a best-effort deterministic ordering.
+
+        This produces repeatable shuffles. Merge and union operations can
+        lead to non-deterministic results. Use order by or save a dataset
+        afterward to guarantee the same result.
+        """
+        query = self._query.clone(new_table=False)
+        query.steps.append(RegenerateSystemColumns(self._query.catalog))
+
+        chain = self._evolve(
+            query=query,
+            signal_schema=SignalSchema({"sys": Sys}) | self.signals_schema,
+        )
+        return chain.order_by("sys.rand")
 
     def sample(self, n: int) -> "Self":
         """Return a random sample from the chain.

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1235,6 +1235,20 @@ def test_persist_restores_sys_signals_after_merge(test_session):
     assert sys_schema["sys.rand"] is int
 
 
+def test_shuffle_after_merge(test_session):
+    left = dc.read_values(ids=[1, 2], session=test_session)
+    right = dc.read_values(ids=[1, 2], extra=["x", "y"], session=test_session)
+
+    shuffled = left.merge(right, on="ids").shuffle()
+
+    sys_schema = shuffled.signals_schema.resolve("sys.id", "sys.rand").values
+    assert sys_schema["sys.id"] is int
+    assert sys_schema["sys.rand"] is int
+
+    rows = set(shuffled.to_list("ids", "extra"))
+    assert rows == {(1, "x"), (2, "y")}
+
+
 def test_unsupported_output_type(test_session):
     vector = [3.14, 2.72, 1.62]
 


### PR DESCRIPTION
After all recent changes it got broken (since we drop sys columns after unsafe operations like union and merge). This PR restores them in shuffle and split.

## Summary by Sourcery

Restore dropped system signal columns in shuffle and train_test_split by regenerating them when missing, refine deterministic split logic, and add tests to validate behavior after merge or union.

Bug Fixes:
- Preserve system columns `sys.id` and `sys.rand` in shuffle and train_test_split after merge or union operations

Enhancements:
- Regenerate system columns before ordering in DataChain.shuffle using a new RegenerateSystemColumns step
- Improve train_test_split by persisting missing `sys.rand` signals and computing explicit split boundaries
- Update docstrings to clarify determinism guarantees and reproducibility requirements for shuffle and split

Tests:
- Add tests to verify system columns are restored and results are consistent in split_after_merge and shuffle_after_merge scenarios
- Adjust variable naming in existing train_test_split tests for clarity