### PR TITLE
fix(models): support list, dicts of models

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -18,6 +18,7 @@ from datachain.data_storage.schema import convert_rows_custom_column_types
 from datachain.data_storage.serializer import Serializable
 from datachain.dataset import DatasetRecord, StorageURI
 from datachain.lib.file import File
+from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
 from datachain.node import DirType, DirTypeGroup, Node, NodeWithPath, get_path
 from datachain.query.batch import RowsOutput
@@ -76,6 +77,29 @@ class AbstractWarehouse(ABC, Serializable):
     def cleanup_for_tests(self):
         """Cleanup for tests."""
 
+    def _to_jsonable(self, obj: Any) -> Any:
+        """Recursively convert Python/Pydantic structures into JSON-serializable
+        objects.
+        """
+
+        if ModelStore.is_pydantic(type(obj)):
+            return obj.model_dump()
+
+        if isinstance(obj, dict):
+            out: dict[str, Any] = {}
+            for k, v in obj.items():
+                if not isinstance(k, str):
+                    key_str = json.dumps(self._to_jsonable(k), ensure_ascii=False)
+                else:
+                    key_str = k
+                out[key_str] = self._to_jsonable(v)
+            return out
+
+        if isinstance(obj, (list, tuple, set)):
+            return [self._to_jsonable(i) for i in obj]
+
+        return obj
+
     def convert_type(  # noqa: PLR0911
         self,
         val: Any,
@@ -122,11 +146,13 @@ class AbstractWarehouse(ABC, Serializable):
             if col_python_type is dict or col_type_name == "JSON":
                 if value_type is str:
                     return val
-                if value_type in (dict, list):
-                    return json.dumps(val, ensure_ascii=False)
-                raise ValueError(
-                    f"Cannot convert value {val!r} with type {value_type} to JSON"
-                )
+                try:
+                    json_ready = self._to_jsonable(val)
+                    return json.dumps(json_ready, ensure_ascii=False)
+                except Exception as e:
+                    raise ValueError(
+                        f"Cannot convert value {val!r} with type {value_type} to JSON"
+                    ) from e
 
             if isinstance(val, col_python_type):
                 return val

--- a/src/datachain/lib/convert/values_to_tuples.py
+++ b/src/datachain/lib/convert/values_to_tuples.py
@@ -13,40 +13,152 @@ class ValuesToTupleError(DataChainParamsError):
         super().__init__(f"Cannot convert signals for dataset{ds_name}: {msg}")
 
 
-def values_to_tuples(  # noqa: C901, PLR0912
+def _find_first_non_none(sequence: Sequence[Any]) -> Any | None:
+    """Find the first non-None element in a sequence."""
+    try:
+        return next(itertools.dropwhile(lambda i: i is None, sequence))
+    except StopIteration:
+        return None
+
+
+def _infer_list_item_type(lst: list) -> type:
+    """Infer the item type of a list, handling None values and nested lists."""
+    if len(lst) == 0:
+        # Default to str when list is empty to avoid generic list
+        return str
+
+    first_item = _find_first_non_none(lst)
+    if first_item is None:
+        # Default to str when all items are None
+        return str
+
+    item_type = type(first_item)
+
+    # Handle nested lists one level deep
+    if isinstance(first_item, list) and len(first_item) > 0:
+        nested_item = _find_first_non_none(first_item)
+        if nested_item is not None:
+            return list[type(nested_item)]  # type: ignore[misc, return-value]
+        # Default to str for nested lists with all None
+        return list[str]  # type: ignore[return-value]
+
+    return item_type
+
+
+def _infer_dict_value_type(dct: dict) -> type:
+    """Infer the value type of a dict, handling None values and list values."""
+    if len(dct) == 0:
+        # Default to str when dict is empty to avoid generic dict values
+        return str
+
+    # Find first non-None value
+    first_value = None
+    for val in dct.values():
+        if val is not None:
+            first_value = val
+            break
+
+    if first_value is None:
+        # Default to str when all values are None
+        return str
+
+    # Handle list values
+    if isinstance(first_value, list) and len(first_value) > 0:
+        list_item = _find_first_non_none(first_value)
+        if list_item is not None:
+            return list[type(list_item)]  # type: ignore[misc, return-value]
+        # Default to str for lists with all None
+        return list[str]  # type: ignore[return-value]
+
+    return type(first_value)
+
+
+def _infer_type_from_sequence(
+    sequence: Sequence[DataValue], signal_name: str, ds_name: str
+) -> type:
+    """
+    Infer the type from a sequence of values.
+
+    Returns str if all values are None, otherwise infers from the first non-None value.
+    Handles lists and dicts with proper type inference for nested structures.
+    """
+    first_element = _find_first_non_none(sequence)
+
+    if first_element is None:
+        # Default to str if column is empty or all values are None
+        return str
+
+    typ = type(first_element)
+
+    if not is_chain_type(typ):
+        raise ValuesToTupleError(
+            ds_name,
+            f"signal '{signal_name}' has unsupported type '{typ.__name__}'."
+            f" Please use DataModel types: {DataTypeNames}",
+        )
+
+    if isinstance(first_element, list):
+        item_type = _infer_list_item_type(first_element)
+        return list[item_type]  # type: ignore[valid-type, return-value]
+
+    if isinstance(first_element, dict):
+        # If the first dict is empty, use str as default key/value types
+        if len(first_element) == 0:
+            return dict[str, str]  # type: ignore[return-value]
+        first_key = next(iter(first_element.keys()))
+        value_type = _infer_dict_value_type(first_element)
+        return dict[type(first_key), value_type]  # type: ignore[misc, return-value]
+
+    return typ
+
+
+def _validate_and_normalize_output(
+    output: DataType | Sequence[str] | dict[str, DataType] | None,
+    fr_map: dict[str, Sequence[DataValue]],
+    ds_name: str,
+) -> dict[str, DataType] | None:
+    """Validate and normalize the output parameter to a dict format."""
+    if not output:
+        return None
+
+    if not isinstance(output, (Sequence, str, dict)):
+        if len(fr_map) != 1:
+            raise ValuesToTupleError(
+                ds_name,
+                f"only one output type was specified, {len(fr_map)} expected",
+            )
+        if not isinstance(output, type):
+            raise ValuesToTupleError(
+                ds_name,
+                f"output must specify a type while '{output}' was given",
+            )
+
+        key: str = next(iter(fr_map.keys()))
+        return {key: output}  # type: ignore[dict-item]
+
+    if not isinstance(output, dict):
+        raise ValuesToTupleError(
+            ds_name,
+            "output type must be dict[str, DataType] while "
+            f"'{type(output).__name__}' is given",
+        )
+
+    if len(output) != len(fr_map):
+        raise ValuesToTupleError(
+            ds_name,
+            f"number of outputs '{len(output)}' should match"
+            f" number of signals '{len(fr_map)}'",
+        )
+
+    return output  # type: ignore[return-value]
+
+
+def values_to_tuples(
     ds_name: str = "",
     output: DataType | Sequence[str] | dict[str, DataType] | None = None,
     **fr_map: Sequence[DataValue],
 ) -> tuple[Any, Any, Any]:
-    if output:
-        if not isinstance(output, (Sequence, str, dict)):
-            if len(fr_map) != 1:
-                raise ValuesToTupleError(
-                    ds_name,
-                    f"only one output type was specified, {len(fr_map)} expected",
-                )
-            if not isinstance(output, type):
-                raise ValuesToTupleError(
-                    ds_name,
-                    f"output must specify a type while '{output}' was given",
-                )
-
-            key: str = next(iter(fr_map.keys()))
-            output = {key: output}  # type: ignore[dict-item]
-
-        if not isinstance(output, dict):
-            raise ValuesToTupleError(
-                ds_name,
-                "output type must be dict[str, DataType] while "
-                f"'{type(output).__name__}' is given",
-            )
-
-        if len(output) != len(fr_map):
-            raise ValuesToTupleError(
-                ds_name,
-                f"number of outputs '{len(output)}' should match"
-                f" number of signals '{len(fr_map)}'",
-            )
+    output = _validate_and_normalize_output(output, fr_map, ds_name)
 
     types_map: dict[str, type] = {}
     length = -1
@@ -65,23 +177,7 @@ def values_to_tuples(  # noqa: C901, PLR0912
             # FIXME: Stops as soon as it finds the first non-None value.
             # If a non-None value appears early, it won't check the remaining items for
             # `None` values.
-            try:
-                first_not_none_element = next(
-                    itertools.dropwhile(lambda i: i is None, v)
-                )
-            except StopIteration:
-                # set default type to `str` if column is empty or all values are `None`
-                typ = str
-            else:
-                typ = type(first_not_none_element)  # type: ignore[assignment]
-                if not is_chain_type(typ):
-                    raise ValuesToTupleError(
-                        ds_name,
-                        f"signal '{k}' has unsupported type '{typ.__name__}'."
-                        f" Please use DataModel types: {DataTypeNames}",
-                    )
-                if isinstance(first_not_none_element, list):
-                    typ = list[type(first_not_none_element[0])]  # type: ignore[assignment, misc]
+            typ = _infer_type_from_sequence(v, k, ds_name)
             types_map[k] = typ
 
         if length < 0:

--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -64,6 +64,9 @@ def is_chain_type(t: type) -> bool:
     if orig is list and len(args) == 1:
         return is_chain_type(get_args(t)[0])
 
+    if orig is dict and len(args) == 2:
+        return is_chain_type(args[0]) and is_chain_type(args[1])
+
     if orig in (Union, types.UnionType) and len(args) == 2 and (type(None) in args):
         return is_chain_type(args[0] if args[1] is type(None) else args[1])
 

--- a/tests/func/test_retrieval.py
+++ b/tests/func/test_retrieval.py
@@ -1,0 +1,470 @@
+import math
+from typing import Any, cast
+
+import pytest
+
+import datachain as dc
+from datachain.lib.data_model import DataModel
+from datachain.lib.file import File
+
+
+class MyFr(DataModel):
+    nnn: str
+    count: int
+
+
+class MyNested(DataModel):
+    label: str
+    fr: MyFr
+
+
+class MyWithList(DataModel):
+    """Model containing a list of primitives."""
+
+    name: str
+    values: list[int]
+
+
+class MyWithModelList(DataModel):
+    """Model containing a list of DataModels."""
+
+    title: str
+    items: list[MyFr]
+
+
+class MyWithDict(DataModel):
+    """Model containing a dict with primitive values."""
+
+    name: str
+    metadata: dict[str, str]
+
+
+class MyWithModelDict(DataModel):
+    """Model containing a dict with DataModel values."""
+
+    title: str
+    mapping: dict[str, MyFr]
+
+
+def sort_files(files: list[File]) -> list[File]:
+    """Sort files by path then size."""
+    return sorted(files, key=lambda f: (f.path, f.size))
+
+
+# Test data
+features = [
+    MyFr(nnn="n1", count=1),
+    MyFr(nnn="n1", count=3),
+    MyFr(nnn="n2", count=5),
+]
+
+features_nested = [
+    MyNested(label="label_0", fr=MyFr(nnn="n1", count=1)),
+    MyNested(label="label_1", fr=MyFr(nnn="n1", count=3)),
+    MyNested(label="label_2", fr=MyFr(nnn="n2", count=5)),
+]
+
+
+def test_iterable_chain(test_session):
+    """Test iterating over DataChain using for loop (calls __iter__ internally)."""
+    chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
+
+    n = 0
+    for sample in chain.order_by("f1.nnn", "f1.count"):
+        assert len(sample) == 2
+        fr, num = sample
+
+        assert isinstance(fr, MyFr)
+        assert isinstance(num, int)
+        assert num == n
+        assert fr == features[n]
+
+        n += 1
+
+    assert n == len(features)
+
+
+def test_to_list_nested_feature(test_session):
+    """Test to_list() with nested DataModel features."""
+    chain = dc.read_values(sign1=features_nested, session=test_session)
+
+    for n, sample in enumerate(
+        chain.order_by("sign1.fr.nnn", "sign1.fr.count").to_list()
+    ):
+        assert len(sample) == 1
+        nested = sample[0]
+
+        assert isinstance(nested, MyNested)
+        assert nested == features_nested[n]
+
+
+def test_collect_deprecated(test_session):
+    """Test deprecated collect() method (should use to_iter instead)."""
+    chain = dc.read_values(fib=[1, 1, 2, 3, 5], session=test_session)
+
+    with pytest.warns(DeprecationWarning, match="Method `collect` is deprecated"):
+        vals = list(chain.collect("fib"))
+        assert set(vals) == {1, 2, 3, 5}
+
+
+def test_to_values_and_to_list(test_session):
+    """Test to_values() and to_list() with File objects and nested fields."""
+    names = ["f1.jpg", "f1.json", "f1.txt", "f2.jpg", "f2.json"]
+    sizes = [1, 2, 3, 4, 5]
+    files = sort_files(
+        [File(path=name, size=size) for name, size in zip(names, sizes, strict=False)]
+    )
+
+    scores = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+    chain = dc.read_values(file=files, score=scores, session=test_session)
+    chain = chain.order_by("file.path", "file.size")
+
+    # Test to_values() with File objects and nested fields
+    assert chain.to_values("file") == files
+    assert chain.to_values("file.path") == names
+    assert chain.to_values("file.size") == sizes
+    assert chain.to_values("file.source") == [""] * len(names)
+
+    # Test to_values() with floats
+    actual_scores = chain.to_values("score")
+    for actual, expected in zip(actual_scores, scores, strict=False):
+        assert math.isclose(actual, expected, rel_tol=1e-7)
+
+    # Test to_list() with multiple columns
+    for actual, expected in zip(
+        chain.to_list("file.size", "score"),
+        [[x, y] for x, y in zip(sizes, scores, strict=False)],
+        strict=False,
+    ):
+        assert len(actual) == 2
+        assert actual[0] == expected[0]
+        assert math.isclose(actual[1], expected[1], rel_tol=1e-7)
+
+
+def test_to_values_list_of_models(test_session):
+    """Retrieval: list[DataModel] should round-trip via to_values/to_list."""
+    rows = [
+        [{"nnn": "n1", "count": 1}],
+        [{"nnn": "n2", "count": 2}, {"nnn": "n3", "count": 3}],
+    ]
+
+    chain = dc.read_values(
+        items=rows, session=test_session, output={"items": list[MyFr]}
+    )
+
+    # Schema should reflect parameterized element type
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["items"].startswith("list[MyFr@v1]")
+
+    # Single-column retrieval as values
+    items_vals = cast("list[list[MyFr]]", chain.to_values("items"))
+    assert isinstance(items_vals, list)
+    # Row order may vary across backends, so check lengths flexibly
+    assert sorted([len(v) for v in items_vals]) == [1, 2]
+    # Find the row with 2 items
+    two_item_row = next(v for v in items_vals if len(v) == 2)
+    assert all(isinstance(two_item_row[i], MyFr) for i in range(2))
+    assert sorted([m.count for m in two_item_row]) == [2, 3]
+
+    # Full-row retrieval
+    rows_list = chain.to_list()
+    assert len(rows_list) == 2
+    assert len(rows_list[0]) == 1 and isinstance(rows_list[0][0], list)
+    assert isinstance(rows_list[0][0][0], MyFr)
+
+
+def test_to_values_dict_of_models_supported(test_session):
+    """dict[str, DataModel] as an output type is now supported."""
+    rows = [
+        {
+            "first": {"label": "a", "fr": {"nnn": "n1", "count": 1}},
+            "second": {"label": "b", "fr": {"nnn": "n2", "count": 2}},
+        }
+    ]
+
+    chain = dc.read_values(
+        items=rows,
+        session=test_session,
+        output={"items": dict[str, MyNested]},
+    )
+
+    # Schema should reflect dict[str, MyNested]
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["items"].startswith("dict[str, MyNested@v1]")
+
+    vals = cast("list[dict[str, MyNested]]", chain.to_values("items"))
+    assert len(vals) == 1
+    items_dict = vals[0]
+    assert isinstance(items_dict, dict)
+    assert set(items_dict.keys()) == {"first", "second"}
+    assert isinstance(items_dict["first"], MyNested)
+    assert items_dict["first"].label == "a"
+    assert items_dict["first"].fr.nnn == "n1"
+    assert items_dict["first"].fr.count == 1
+    assert isinstance(items_dict["second"], MyNested)
+    assert items_dict["second"].label == "b"
+
+
+def test_optional_collection_roundtrip(test_session):
+    """Retrieval: Optional[list[DataModel]] should handle None and non-None."""
+    rows = [None, [{"nnn": "test", "count": 5}]]
+
+    chain = dc.read_values(
+        items=rows,
+        session=test_session,
+        output=cast("Any", {"items": list[MyFr] | None}),
+    )
+
+    # Schema should reflect Optional[list[MyFr]]
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["items"].startswith("Optional[list[MyFr@v1]]")
+
+    vals = cast("list[list[MyFr] | None]", chain.to_values("items"))
+    # Row order may vary across backends
+    assert len(vals) == 2
+    # ClickHouse may convert top-level None to a default.
+    # Accept either None or an empty collection for the "None" case.
+    has_none_or_empty = any(v is None or v in ([], {}) for v in vals)
+    assert has_none_or_empty
+    # Find the non-empty list and validate its content
+    lists = [v for v in vals if isinstance(v, list)]
+    # There must be at least one list value
+    assert len(lists) >= 1
+    non_empty_list = next((lst for lst in lists if len(lst) > 0), [])
+    assert len(non_empty_list) == 1
+    assert isinstance(non_empty_list[0], MyFr)
+    assert (non_empty_list[0].nnn, non_empty_list[0].count) == ("test", 5)
+
+
+def test_read_values_list_of_models(test_session):
+    """Test that read_values works with lists of DataModel instances."""
+    model1 = MyFr(nnn="n1", count=1)
+    model2 = MyFr(nnn="n2", count=2)
+    model3 = MyFr(nnn="n3", count=3)
+
+    chain = dc.read_values(
+        items=[[model1, model2], [model3]],
+        session=test_session,
+    )
+
+    # Schema should reflect list[MyFr]
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["items"].startswith("list[MyFr@v1]")
+
+    vals = cast("list[list[MyFr]]", chain.to_values("items"))
+    assert len(vals) == 2
+    # Row order may vary, check both rows flexibly
+    assert sorted([len(v) for v in vals]) == [1, 2]
+    # Find row with 2 items to verify type
+    two_item_row = next(v for v in vals if len(v) == 2)
+    assert isinstance(two_item_row[0], MyFr)
+    # Check all items are present across both rows
+    all_counts = sorted([m.count for v in vals for m in v])
+    assert all_counts == [1, 2, 3]
+    all_nnns = sorted([m.nnn for v in vals for m in v])
+    assert all_nnns == ["n1", "n2", "n3"]
+
+
+def test_read_values_dict_of_models(test_session):
+    """Test that read_values works with dicts of DataModel instances."""
+    model1 = MyFr(nnn="alpha", count=10)
+    model2 = MyFr(nnn="beta", count=20)
+
+    chain = dc.read_values(
+        mapping=[{"a": model1, "b": model2}],
+        session=test_session,
+    )
+
+    # Schema should reflect dict[str, MyFr] (auto-detected)
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["mapping"].startswith("dict[str, MyFr@v1]")
+
+    vals = cast("list[dict[str, MyFr]]", chain.to_values("mapping"))
+    assert len(vals) == 1
+    mapping = vals[0]
+    assert isinstance(mapping, dict)
+    assert set(mapping.keys()) == {"a", "b"}
+    assert isinstance(mapping["a"], MyFr)
+    assert (mapping["a"].nnn, mapping["a"].count) == ("alpha", 10)
+    assert (mapping["b"].nnn, mapping["b"].count) == ("beta", 20)
+
+
+def test_read_values_dict_int_keys_of_models(test_session):
+    """Test that read_values works with dict[int, DataModel].
+
+    Note: JSON stores int keys as strings, but we convert them back to int
+    when reading based on the type annotation.
+    """
+    model1 = MyFr(nnn="first", count=100)
+    model2 = MyFr(nnn="second", count=200)
+
+    chain = dc.read_values(
+        mapping=[{1: model1, 2: model2}],
+        session=test_session,
+    )
+
+    # Schema should reflect dict[int, MyFr] (auto-detected)
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["mapping"].startswith("dict[int, MyFr@v1]")
+
+    # Keys should be converted back to int based on the type annotation
+    vals = cast("list[dict[int, MyFr]]", chain.to_values("mapping"))
+    assert len(vals) == 1
+    mapping = vals[0]
+    assert isinstance(mapping, dict)
+    # Keys should be int, not str
+    assert set(mapping.keys()) == {1, 2}
+    assert all(isinstance(k, int) for k in mapping)
+    assert isinstance(mapping[1], MyFr)
+    assert (mapping[1].nnn, mapping[1].count) == ("first", 100)
+    assert (mapping[2].nnn, mapping[2].count) == ("second", 200)
+
+
+def test_read_values_model_with_list(test_session):
+    """Test read_values with DataModel containing list[int]."""
+    model1 = MyWithList(name="first", values=[1, 2, 3])
+    model2 = MyWithList(name="second", values=[4, 5])
+
+    chain = dc.read_values(
+        items=[model1, model2],
+        session=test_session,
+    )
+
+    vals = cast("list[MyWithList]", chain.to_values("items"))
+    assert len(vals) == 2
+    # Row order may vary, check by finding each model by name
+    names_to_models = {v.name: v for v in vals}
+    assert set(names_to_models.keys()) == {"first", "second"}
+    assert isinstance(names_to_models["first"], MyWithList)
+    assert names_to_models["first"].values == [1, 2, 3]
+    assert names_to_models["second"].values == [4, 5]
+
+
+def test_read_values_model_with_model_list(test_session):
+    """Test read_values with DataModel containing list[DataModel]."""
+    fr1 = MyFr(nnn="a", count=1)
+    fr2 = MyFr(nnn="b", count=2)
+    fr3 = MyFr(nnn="c", count=3)
+
+    model1 = MyWithModelList(title="first", items=[fr1, fr2])
+    model2 = MyWithModelList(title="second", items=[fr3])
+
+    chain = dc.read_values(
+        data=[model1, model2],
+        session=test_session,
+    )
+
+    vals = cast("list[MyWithModelList]", chain.to_values("data"))
+    assert len(vals) == 2
+    # Row order may vary, check by finding each model by title
+    titles_to_models = {v.title: v for v in vals}
+    assert set(titles_to_models.keys()) == {"first", "second"}
+    first_model = titles_to_models["first"]
+    assert isinstance(first_model, MyWithModelList)
+    assert len(first_model.items) == 2
+    assert isinstance(first_model.items[0], MyFr)
+    assert sorted([item.nnn for item in first_model.items]) == ["a", "b"]
+    assert sorted([item.count for item in first_model.items]) == [1, 2]
+    second_model = titles_to_models["second"]
+    assert len(second_model.items) == 1
+    assert second_model.items[0].nnn == "c"
+
+
+def test_read_values_model_with_dict(test_session):
+    """Test read_values with DataModel containing dict[str, str]."""
+    model1 = MyWithDict(name="first", metadata={"key1": "val1", "key2": "val2"})
+    model2 = MyWithDict(name="second", metadata={"key3": "val3"})
+
+    chain = dc.read_values(
+        items=[model1, model2],
+        session=test_session,
+    )
+
+    vals = cast("list[MyWithDict]", chain.to_values("items"))
+    assert len(vals) == 2
+    # Row order may vary, check by finding each model by name
+    names_to_models = {v.name: v for v in vals}
+    assert set(names_to_models.keys()) == {"first", "second"}
+    assert isinstance(names_to_models["first"], MyWithDict)
+    assert names_to_models["first"].metadata == {"key1": "val1", "key2": "val2"}
+    assert names_to_models["second"].metadata == {"key3": "val3"}
+
+
+def test_read_values_model_with_model_dict(test_session):
+    """Test read_values with DataModel containing dict[str, DataModel]."""
+    fr1 = MyFr(nnn="alpha", count=10)
+    fr2 = MyFr(nnn="beta", count=20)
+    fr3 = MyFr(nnn="gamma", count=30)
+
+    model1 = MyWithModelDict(title="first", mapping={"a": fr1, "b": fr2})
+    model2 = MyWithModelDict(title="second", mapping={"c": fr3})
+
+    chain = dc.read_values(
+        data=[model1, model2],
+        session=test_session,
+    )
+
+    vals = cast("list[MyWithModelDict]", chain.to_values("data"))
+    assert len(vals) == 2
+    # Row order may vary, check by finding each model by title
+    titles_to_models = {v.title: v for v in vals}
+    assert set(titles_to_models.keys()) == {"first", "second"}
+    first_model = titles_to_models["first"]
+    assert isinstance(first_model, MyWithModelDict)
+    assert len(first_model.mapping) == 2
+    assert isinstance(first_model.mapping["a"], MyFr)
+    assert first_model.mapping["a"].nnn == "alpha"
+    assert first_model.mapping["b"].count == 20
+    second_model = titles_to_models["second"]
+    assert len(second_model.mapping) == 1
+    assert second_model.mapping["c"].nnn == "gamma"
+
+
+def test_read_values_dict_float_keys(test_session):
+    """Test that read_values works with dict[float, str].
+
+    Float keys are converted back from JSON strings based on type annotation.
+    """
+    chain = dc.read_values(
+        data=[{1.5: "one-half", 2.7: "two-seven", 3.0: "three"}],
+        session=test_session,
+    )
+
+    # Schema should reflect dict[float, str]
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["data"] == "dict[float, str]"
+
+    vals = cast("list[dict[float, str]]", chain.to_values("data"))
+    assert len(vals) == 1
+    result = vals[0]
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {1.5, 2.7, 3.0}
+    assert all(isinstance(k, float) for k in result)
+    assert result[1.5] == "one-half"
+    assert result[2.7] == "two-seven"
+    assert result[3.0] == "three"
+
+
+def test_read_values_dict_bool_keys(test_session):
+    """Test that read_values works with dict[bool, str].
+
+    Bool keys are converted back from JSON strings based on type annotation.
+    """
+    chain = dc.read_values(
+        data=[{True: "yes", False: "no"}],
+        session=test_session,
+    )
+
+    # Schema should reflect dict[bool, str]
+    schema_ser = chain.signals_schema.serialize()
+    assert schema_ser["data"] == "dict[bool, str]"
+
+    vals = cast("list[dict[bool, str]]", chain.to_values("data"))
+    assert len(vals) == 1
+    result = vals[0]
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {True, False}
+    assert all(isinstance(k, bool) for k in result)
+    assert result[True] == "yes"
+    assert result[False] == "no"

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -599,6 +599,11 @@ def test_from_features_more_simple_types(test_session):
         num=range(len(features)),
         bb=[True, True, False],
         dd=[{}, {"ee": 3}, {"ww": 1, "qq": 2}],
+        ll1=[[], [1, 2, 3], [3, 4, 5]],
+        ll=[[None, 1, 2], [3, 4], []],
+        dd2=[{"a": 1}, {"b": 2}, {"c": 3}],
+        nn=[None, None, None],
+        ss=["x", None, "y"],
         time=[
             datetime.datetime.now(),
             datetime.datetime.today(),
@@ -613,6 +618,11 @@ def test_from_features_more_simple_types(test_session):
         "num",
         "bb",
         "dd",
+        "ll1",
+        "ll",
+        "dd2",
+        "nn",
+        "ss",
         "time",
         "f",
     }
@@ -620,7 +630,11 @@ def test_from_features_more_simple_types(test_session):
         MyFr,
         int,
         bool,
-        dict,
+        dict[str, str],  # from dd (starts with empty dict)
+        dict[str, int],  # from dd2
+        list[str],  # from ll1 (starts with empty list)
+        list[int],  # from ll
+        str,  # from nn and ss
         datetime.datetime,
         float,
     }
@@ -954,45 +968,6 @@ def test_batch_map_tuple_result_iterator(test_session):
     assert chain.order_by("x").to_values("x") == [1, 2, 3]
 
 
-def test_iterable_chain(test_session):
-    chain = dc.read_values(f1=features, num=range(len(features)), session=test_session)
-
-    n = 0
-    for sample in chain.order_by("f1.nnn", "f1.count"):
-        assert len(sample) == 2
-        fr, num = sample
-
-        assert isinstance(fr, MyFr)
-        assert isinstance(num, int)
-        assert num == n
-        assert fr == features[n]
-
-        n += 1
-
-    assert n == len(features)
-
-
-def test_to_list_nested_feature(test_session):
-    chain = dc.read_values(sign1=features_nested, session=test_session)
-
-    for n, sample in enumerate(
-        chain.order_by("sign1.fr.nnn", "sign1.fr.count").to_list()
-    ):
-        assert len(sample) == 1
-        nested = sample[0]
-
-        assert isinstance(nested, MyNested)
-        assert nested == features_nested[n]
-
-
-def test_collect_deprecated(test_session):
-    chain = dc.read_values(fib=[1, 1, 2, 3, 5], session=test_session)
-
-    with pytest.warns(DeprecationWarning, match="Method `collect` is deprecated"):
-        vals = list(chain.collect("fib"))
-        assert set(vals) == {1, 2, 3, 5}
-
-
 def test_select_read_hf_without_sys_columns(test_session):
     from datachain import func
 
@@ -1257,34 +1232,6 @@ def test_unsupported_output_type(test_session):
 
     with pytest.raises(TypeError):
         dc.read_values(key=[123], session=test_session).map(emd=get_vector)
-
-
-def test_to_list_single_item(test_session):
-    names = ["f1.jpg", "f1.json", "f1.txt", "f2.jpg", "f2.json"]
-    sizes = [1, 2, 3, 4, 5]
-    files = sort_files(
-        [File(path=name, size=size) for name, size in zip(names, sizes, strict=False)]
-    )
-
-    scores = [0.1, 0.2, 0.3, 0.4, 0.5]
-
-    chain = dc.read_values(file=files, score=scores, session=test_session)
-    chain = chain.order_by("file.path", "file.size")
-
-    assert chain.to_values("file") == files
-    assert chain.to_values("file.path") == names
-    assert chain.to_values("file.size") == sizes
-    assert chain.to_values("file.source") == [""] * len(names)
-    assert np.allclose(chain.to_values("score"), scores)
-
-    for actual, expected in zip(
-        chain.to_list("file.size", "score"),
-        [[x, y] for x, y in zip(sizes, scores, strict=False)],
-        strict=False,
-    ):
-        assert len(actual) == 2
-        assert actual[0] == expected[0]
-        assert math.isclose(actual[1], expected[1], rel_tol=1e-7)
 
 
 def test_default_output_type(test_session):

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -806,6 +806,80 @@ def test_get_features_nested(test_session, nested_file_schema):
     assert actual_features[3].nested_file._catalog == test_session.catalog
 
 
+def test_row_to_features_list_of_models(test_session):
+    schema = SignalSchema({"items": list[MyType1]})
+    row = ([{"aa": 1, "bb": "x"}, {"aa": 2, "bb": "y"}],)
+
+    features = schema.row_to_features(row, test_session.catalog)
+
+    assert len(features) == 1
+    items = features[0]
+    assert isinstance(items, list)
+    assert [item.aa for item in items] == [1, 2]
+    assert all(isinstance(item, MyType1) for item in items)
+
+
+def test_row_to_features_dict_of_models(test_session):
+    schema = SignalSchema({"lookup": dict[str, MyType2]})
+    row = (
+        {
+            "first": {"name": "a", "deep": {"aa": 1, "bb": "x"}},
+            "second": {"name": "b", "deep": {"aa": 2, "bb": "y"}},
+        },
+    )
+
+    features = schema.row_to_features(row, test_session.catalog)
+
+    assert len(features) == 1
+    lookup = features[0]
+    assert isinstance(lookup, dict)
+    assert set(lookup) == {"first", "second"}
+    assert isinstance(lookup["first"], MyType2)
+    assert lookup["second"].deep.aa == 2
+
+
+def test_row_to_features_optional_collection(test_session):
+    schema = SignalSchema({"items": list[MyType1] | None})
+
+    features_none = schema.row_to_features((None,), test_session.catalog)
+    assert features_none == [None]
+
+    row = ([{"aa": 3, "bb": "z"}],)
+    features = schema.row_to_features(row, test_session.catalog)
+    assert len(features) == 1
+    items = features[0]
+    assert isinstance(items, list)
+    assert isinstance(items[0], MyType1)
+
+
+@pytest.mark.parametrize(
+    "union_type,union_name",
+    [
+        (Union[list[MyType1], None], "Union[list[MyType1], None]"),
+        (list[MyType1] | None, "list[MyType1] | None"),
+    ],
+    ids=["old-style-union", "new-style-union"],
+)
+def test_row_to_features_union_types(test_session, union_type, union_name):
+    """Test that both old-style Union[X, None] and new-style X | None work correctly."""
+    schema = SignalSchema({"items": union_type})
+
+    # Test None case
+    features_none = schema.row_to_features((None,), test_session.catalog)
+    assert features_none == [None], f"Failed for {union_name} with None value"
+
+    # Test non-None case
+    row = ([{"aa": 5, "bb": "test"}],)
+    features = schema.row_to_features(row, test_session.catalog)
+    assert len(features) == 1, f"Failed for {union_name}"
+    items = features[0]
+    assert isinstance(items, list), f"Expected list for {union_name}, got {type(items)}"
+    assert len(items) == 1, f"Expected 1 item for {union_name}"
+    assert isinstance(items[0], MyType1), f"Expected MyType1 instance for {union_name}"
+    assert items[0].aa == 5, f"Wrong value for {union_name}"
+    assert items[0].bb == "test", f"Wrong value for {union_name}"
+
+
 def test_get_signals_subclass(nested_file_schema):
     class NewFile(File):
         pass
@@ -852,16 +926,18 @@ def test_print_types():
         str | int | bool: "Union[str, int, bool]",
         List: "list",
         list: "list",
+        List[bool]: "list[bool]",
         list[bool]: "list[bool]",
-        list[bool]: "list[bool]",
+        List[bool | None]: "list[Optional[bool]]",
         list[bool | None]: "list[Optional[bool]]",
-        list[bool | None]: "list[Optional[bool]]",
-        list[bool | None]: "list[Optional[bool]]",
-        list[bool | None]: "list[Optional[bool]]",
+        List[int]: "list[int]",
+        list[int]: "list[int]",
         Dict: "dict",
         dict: "dict",
+        Dict[str, bool]: "dict[str, bool]",
         dict[str, bool]: "dict[str, bool]",
-        dict[str, bool]: "dict[str, bool]",
+        Dict[str, int]: "dict[str, int]",
+        dict[str, int]: "dict[str, int]",
         dict[str, MyType1 | None]: "dict[str, Optional[MyType1@v1]]",
         dict[str, MyType1 | None]: "dict[str, Optional[MyType1@v1]]",
         dict[str, MyType1 | None]: "dict[str, Optional[MyType1@v1]]",
@@ -944,6 +1020,32 @@ def test_resolve_types():
     for s, t in mapping_warnings.items():
         with pytest.warns(SignalSchemaWarning):
             assert SignalSchema._resolve_type(s, {}) == t
+
+
+def test_type_to_str_typing_module_vs_builtin_generics():
+    """Test that typing.List/Dict and list/dict behave identically with get_origin().
+
+    This ensures Python 3.10+ compatibility where both old-style (typing.List)
+    and new-style (list[]) generic annotations are normalized by get_origin()
+    to the same built-in types.
+    """
+    from typing import get_origin
+
+    # Verify get_origin() normalizes both forms to built-in types
+    assert get_origin(List[int]) is list
+    assert get_origin(list[int]) is list
+    assert get_origin(Dict[str, int]) is dict
+    assert get_origin(dict[str, int]) is dict
+
+    # Verify _type_to_str produces identical output for both forms
+    assert SignalSchema._type_to_str(List[int]) == SignalSchema._type_to_str(list[int])
+    assert SignalSchema._type_to_str(Dict[str, int]) == SignalSchema._type_to_str(
+        dict[str, int]
+    )
+    assert SignalSchema._type_to_str(List[str]) == "list[str]"
+    assert SignalSchema._type_to_str(list[str]) == "list[str]"
+    assert SignalSchema._type_to_str(Dict[str, bool]) == "dict[str, bool]"
+    assert SignalSchema._type_to_str(dict[str, bool]) == "dict[str, bool]"
 
 
 def test_resolve_types_errors():


### PR DESCRIPTION
Fixes https://github.com/iterative/datachain/issues/1437 and adds more support across different scenarios for lists / dicts / unions.

## Summary by Sourcery

Enable SignalSchema to handle list and dict annotations of Pydantic models (including optional and union types) during feature conversion, update downstream serialization in warehouse and values_to_tuples, and extend chain type detection to include dict types.

New Features:
- Support conversion of list[DataModel] and dict[key, DataModel] annotations in SignalSchema.row_to_features
- Allow optional and union types for collections when converting feature values

Enhancements:
- Introduce _convert_feature_value to recursively convert raw values into Pydantic models, lists, and dicts based on type hints
- Update warehouse.convert_type to serialize Pydantic models inside dicts and lists to JSON
- Enhance values_to_tuples to infer types for empty lists and dicts during tuple conversion
- Extend is_chain_type to recognize dict types as chain operations

Tests:
- Add unit tests for list/dict of models and optional/union collection scenarios in row_to_features
- Remove obsolete tests for iterable_chain, test_to_list_single_item, and test_collect_deprecated