### PR TITLE
improve error messages in func when complex column passed

### DIFF
--- a/tests/func/functions/test_aggregate.py
+++ b/tests/func/functions/test_aggregate.py
@@ -1,5 +1,8 @@
+import pytest
+
 import datachain as dc
 from datachain import func
+from datachain.lib.utils import DataChainParamsError
 
 
 def test_aggregate_avg(test_session):
@@ -169,3 +172,31 @@ def test_aggregate_any_value(test_session):
     assert all(isinstance(x[3], int) and x[3] in (20, 40, 60) for x in ds)
     assert all(isinstance(x[4], float) and x[4] in (2.0, 4.0, 6.0) for x in ds)
     assert all(isinstance(x[5], str) and x[5] in ("x", "y", "z") for x in ds)
+
+
+def test_funcs_disallow_complex_object_collect(test_session):
+    class Rec(dc.DataModel):
+        i: int
+
+    ds = dc.read_values(
+        id=(1, 2),
+        rec=(Rec(i=1), Rec(i=2)),
+        session=test_session,
+    )
+
+    with pytest.raises(DataChainParamsError, match="doesn't support complex object"):
+        ds.group_by(res=func.collect("rec"), partition_by="id")
+
+
+def test_funcs_disallow_complex_object_min(test_session):
+    class Rec(dc.DataModel):
+        i: int
+
+    ds = dc.read_values(
+        id=(1, 2),
+        rec=(Rec(i=1), Rec(i=2)),
+        session=test_session,
+    )
+
+    with pytest.raises(DataChainParamsError, match="doesn't support complex object"):
+        ds.group_by(res=func.min("rec"), partition_by="id")

--- a/tests/func/functions/test_conditional.py
+++ b/tests/func/functions/test_conditional.py
@@ -1,5 +1,8 @@
+import pytest
+
 import datachain as dc
 from datachain import func
+from datachain.lib.utils import DataChainParamsError
 from tests.utils import skip_if_not_sqlite
 
 
@@ -174,3 +177,13 @@ def test_conditional_greatest_least(test_session):
         (20, 2.0, 20, 2.0, 40, 4.0, 40, 3.5, 40, 1.5),
         (30, 3.0, 25, 2.5, 60, 6.0, 50, 3.5, 60, 1.5),
     ]
+
+
+def test_conditional_funcs_disallow_complex_object_greatest(test_session):
+    class Rec(dc.DataModel):
+        i: int
+
+    ds = dc.read_values(id=[1, 2], rec=[Rec(i=1), Rec(i=2)], session=test_session)
+
+    with pytest.raises(DataChainParamsError, match="doesn't support complex object"):
+        ds.mutate(t=func.greatest("rec", 1))

--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -187,7 +187,7 @@ def test_all_possible_steps(test_session):
         .sample(10)
         .offset(2)
         .limit(5)
-        .group_by(age_avg=func.avg("persons.age"), partition_by="persons.name")
+        .group_by(age_avg=func.avg("persons.ages"), partition_by="persons.name")
         .select("persons.name", "age_avg")
         .subtract(
             players_chain,
@@ -195,7 +195,7 @@ def test_all_possible_steps(test_session):
             right_on=["player.name"],
         )
         .hash()
-    ) == "2c8d3fffade5574a418c45545f4c821cbe734f648cfcbfa55843673796bc35eb"
+    ) == "ff0ab3df5e69f5e4f14ee7ddbeeddecfa1f237540b83ba5166ca3671625c6d4d"
 
 
 def test_diff(test_session):

--- a/tests/unit/test_func.py
+++ b/tests/unit/test_func.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy import Label
 
 import datachain as dc
+from datachain import func
 from datachain.func import (
     and_,
     bit_hamming_distance,
@@ -18,6 +19,7 @@ from datachain.func.array import contains
 from datachain.func.random import rand
 from datachain.func.string import length as strlen
 from datachain.lib.signal_schema import SignalSchema
+from datachain.lib.utils import DataChainParamsError
 from datachain.sql.sqlite.base import (
     sqlite_bit_hamming_distance,
     sqlite_byte_hamming_distance,
@@ -67,6 +69,19 @@ def test_get_column():
     col = rnd.get_column(SignalSchema({}))
     assert isinstance(col, Label)
     assert col.name == "rand"
+
+
+def test_get_column_disallow_complex_object_in_sql_funcs():
+    class Rec(dc.DataModel):
+        i: int
+
+    schema = SignalSchema({"rec": Rec})
+
+    with pytest.raises(DataChainParamsError, match="doesn't support complex object"):
+        func.min("rec").get_column(schema)
+
+    with pytest.raises(DataChainParamsError, match="doesn't support complex object"):
+        func.collect("rec").get_column(schema)
 
 
 def test_add():


### PR DESCRIPTION
Makes it a bit easier to understand what is going on in certain user scenarios.

## Summary by Sourcery

Disallow complex object columns in SQL functions by raising descriptive errors and add fallback resolution for complex column types.

Enhancements:
- Guard against passing Pydantic model columns to SQL functions (min, collect, greatest) by raising a DataChainParamsError with guidance on using leaf fields or UDFs
- Add fallback logic in get_db_col_type to resolve complex object column types via subtree lookup when initial name resolution fails

Tests:
- Add functional tests in aggregate and conditional modules to assert DataChainParamsError is raised for collect, min, and greatest with complex object columns
- Add unit tests for func.get_column to verify errors on complex object columns