### PR TITLE
add new kind parameter to create table

### DIFF
--- a/src/datachain/data_storage/db_engine.py
+++ b/src/datachain/data_storage/db_engine.py
@@ -112,7 +112,13 @@ class DatabaseEngine(ABC, Serializable):
         return sa.inspect(self.engine).has_table(name)
 
     @abstractmethod
-    def create_table(self, table: "Table", if_not_exists: bool = True) -> None: ...
+    def create_table(
+        self,
+        table: "Table",
+        if_not_exists: bool = True,
+        *,
+        kind: str | None = None,
+    ) -> None: ...
 
     @abstractmethod
     def drop_table(self, table: "Table", if_exists: bool = False) -> None: ...

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -327,7 +327,13 @@ class SQLiteDatabaseEngine(DatabaseEngine):
         query = "SELECT name FROM sqlite_master WHERE type='table';"
         return [r[0] for r in self.execute_str(query).fetchall()]
 
-    def create_table(self, table: "Table", if_not_exists: bool = True) -> None:
+    def create_table(
+        self,
+        table: "Table",
+        if_not_exists: bool = True,
+        *,
+        kind: str | None = None,
+    ) -> None:
         self.execute(CreateTable(table, if_not_exists=if_not_exists))
 
     def drop_table(self, table: "Table", if_exists: bool = False) -> None:

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -984,7 +984,7 @@ class AbstractWarehouse(ABC, Serializable):
             *self.dataset_row_cls.sys_columns(),
             *columns,
         )
-        self.db.create_table(tbl, if_not_exists=True)
+        self.db.create_table(tbl, if_not_exists=True, kind="udf")
         return tbl
 
     @abstractmethod


### PR DESCRIPTION
Counterpart to https://github.com/iterative/studio/pull/12304

## Summary by Sourcery

Introduce an optional `kind` parameter to table creation methods to support table categorization and apply it when creating UDF tables.

Enhancements:
- Extend `Engine.create_table` signature to accept an optional `kind` parameter.
- Update `SQLiteEngine.create_table` implementation to include the `kind` argument.
- Pass `kind="udf"` when creating UDF tables in the warehouse layer.