### PR TITLE
fix: handle collision on column renames on merge

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1693,11 +1693,7 @@ class DataChain:
             )
 
         query = self._query.join(
-            right_ds._query,
-            sqlalchemy.and_(*ops),
-            inner,
-            full,
-            rname + "{name}",
+            right_ds._query, sqlalchemy.and_(*ops), inner, full, rname
         )
         query.feature_schema = None
         ds = self._evolve(query=query)

--- a/tests/func/test_dataset_query.py
+++ b/tests/func/test_dataset_query.py
@@ -713,7 +713,7 @@ def test_join_with_binary_expression(
 
     assert (
         sorted(
-            ((r["file__path"], r["file__path_right"]) for r in res), key=lambda x: x[0]
+            ((r["file__path"], r["right_file__path"]) for r in res), key=lambda x: x[0]
         )
         == expected
     )
@@ -765,7 +765,7 @@ def test_join_with_combination_binary_expression_and_column_predicates(
 
     assert (
         sorted(
-            ((r["file__path"], r["file__path_right"]) for r in res), key=lambda x: x[0]
+            ((r["file__path"], r["right_file__path"]) for r in res), key=lambda x: x[0]
         )
         == expected
     )
@@ -792,7 +792,7 @@ def test_join_with_binary_expression_with_arithmetics(
     ).to_db_records()
 
     assert sorted(
-        ((r["file__path"], r["file__path_right"]) for r in res), key=lambda x: x[0]
+        ((r["file__path"], r["right_file__path"]) for r in res), key=lambda x: x[0]
     ) == [
         ("cats/cat1", "dogs/dog2"),
         ("cats/cat2", "dogs/dog2"),
@@ -892,7 +892,7 @@ def test_join_with_using_functions_in_expression(
 
     assert (
         sorted(
-            ((r["file__path"], r["file__path_right"]) for r in res), key=lambda x: x[0]
+            ((r["file__path"], r["right_file__path"]) for r in res), key=lambda x: x[0]
         )
         == expected
     )

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -531,6 +531,59 @@ def test_merge():
     assert signals["f"] is MyType1
 
 
+def test_merge_nested_key_without_collision():
+    left = SignalSchema({"item.score": float})
+    right = SignalSchema({"metadata.score": float})
+
+    merged = left.merge(right, "right_")
+
+    assert merged.values["item.score"] is float
+    assert merged.values["metadata.score"] is float
+    assert "right_metadata.score" not in merged.values
+
+
+def test_merge_applies_suffix_when_prefixed_name_exists():
+    left = SignalSchema(
+        {
+            "item.score": float,
+            "right_item.score": float,
+        }
+    )
+    right = SignalSchema(
+        {
+            "item.confidence": int,
+            "item.score": int,
+        }
+    )
+
+    merged = left.merge(right, "right_")
+
+    assert merged.values["item.score"] is float
+    assert merged.values["right_item.score"] is float
+    assert merged.values["right_item_1.score"] is int
+    assert merged.values["right_item_1.confidence"] is int
+
+
+def test_merge_rename_collides_with_existing_column():
+    left = SignalSchema(
+        {
+            "item.score": float,
+        }
+    )
+    right = SignalSchema(
+        {
+            "item.score": int,
+            "right_item.score": str,
+        }
+    )
+
+    merged = left.merge(right, "right_")
+
+    assert merged.values["item.score"] is float
+    assert merged.values["right_item.score"] is str
+    assert merged.values["right_item_1.score"] is int
+
+
 def test_select_custom_type_backward_compatibility():
     schema = SignalSchema.deserialize(
         {

--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -195,7 +195,7 @@ def test_all_possible_steps(test_session):
             right_on=["player.name"],
         )
         .hash()
-    ) == "ff0ab3df5e69f5e4f14ee7ddbeeddecfa1f237540b83ba5166ca3671625c6d4d"
+    ) == "bd685bd97746a8e0e012c7029c7f2c8b17fc7eb5b7a5cd8fa5dacada57d75a07"
 
 
 def test_diff(test_session):
@@ -218,4 +218,4 @@ def test_diff(test_session):
             status_col="diff",
         )
         .hash()
-    ) == "8ffac19b12cf96e2916968914d357c4a9c1b81038c43ab5cf97ba1127fb86567"
+    ) == "26c2a097045166837f0e366c78636d83a2a2f92ba1fcc53327954c62cf8be960"


### PR DESCRIPTION
Fixes an issue first surfaced on a customer scenario with delta + retry (essentially `diff` that is using `merge` internally). There were many issues there in how we handle renames. Now signal schema is aligned (they use same logic) as join and handle different collisions.

Along the way fixes https://github.com/iterative/datachain/issues/1295

## Summary by Sourcery

Fix collision handling on column renames during merges by introducing a unified root mapping algorithm and aligning logic between SignalSchema.merge and SQLJoin.

Bug Fixes:
- Handle collisions on column renames in SignalSchema.merge to avoid duplicate field names.
- Resolve conflicting column names in SQLJoin.apply by renaming using a mapping strategy.

Enhancements:
- Add generate_merge_root_mapping to compute unique root name mappings with prefix/suffix rules.
- Refactor SignalSchema.merge and SQLJoin to use the new root mapping logic.
- Introduce helper methods _extract_root, _split_db_name, and _root_name for name parsing.
- Ensure default namespace_name and project_name are explicitly assigned and non-null.

Tests:
- Add unit tests for various merge collision scenarios including nested keys without collisions, prefixed root suffix conflicts, and existing column rename collisions.