### PR TITLE
Fix distributed tests

### DIFF
--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -75,18 +75,7 @@ jobs:
           path: './backend/datachain'
           fetch-depth: 0
 
-      - name: Install FFmpeg on Windows
-        if: runner.os == 'Windows'
-        run: choco install ffmpeg
-
-      - name: Install FFmpeg on macOS
-        if: runner.os == 'macOS'
-        run: |
-          brew install ffmpeg
-          echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
-
-      - name: Install FFmpeg on Ubuntu
-        if: runner.os == 'Linux'
+      - name: Install FFmpeg
         run: |
           sudo apt update
           sudo apt install -y ffmpeg
@@ -107,6 +96,35 @@ jobs:
 
       - name: Install dependencies
         run: uv pip install --system ./backend/datachain_server[tests] ./backend/datachain[tests]
+
+      - name: Initialize datachain venv
+        env:
+          PYTHON_VERSION: ${{ matrix.pyv }}
+          DATACHAIN_VENV_DIR: /tmp/local/datachain_venv/python${{ matrix.pyv }}
+        run: |
+          virtualenv -p "$(which python"${PYTHON_VERSION}")" "${DATACHAIN_VENV_DIR}"
+
+          pip_cache_dir="${DATACHAIN_VENV_DIR}/.cache/pip"
+          pip_wheel_dir="${pip_cache_dir}/wheels"
+          pip_bin="${DATACHAIN_VENV_DIR}/bin/pip"
+          mkdir -p "$pip_cache_dir"
+          mkdir -p "$pip_wheel_dir"
+
+          uv_cache_dir="${DATACHAIN_VENV_DIR}/.cache/uv"
+          mkdir -p "$uv_cache_dir"
+
+          $pip_bin install -U pip wheel setuptools \
+            --cache-dir="$pip_cache_dir"
+
+          $pip_bin wheel ./backend/datachain_server \
+            --wheel-dir="$pip_wheel_dir" \
+            --cache-dir="$pip_cache_dir"
+
+          uv venv --python "$PYTHON_VERSION" "${DATACHAIN_VENV_DIR}/default"
+          uv pip install -r ./backend/requirements-worker-venv.txt \
+            --find-links="$pip_wheel_dir" \
+            --cache-dir="${DATACHAIN_VENV_DIR}/.cache/uv" \
+            -p "${DATACHAIN_VENV_DIR}/default/bin/python"
 
       - name: Run tests
         # Generate `.test_durations` file with `pytest --store-durations --durations-path ../.github/.test_durations ...`

--- a/tests/func/test_checkpoints.py
+++ b/tests/func/test_checkpoints.py
@@ -11,6 +11,10 @@ def mock_is_script_run(monkeypatch):
     monkeypatch.setattr("datachain.query.session.is_script_run", lambda: True)
 
 
+@pytest.mark.skipif(
+    "os.environ.get('DATACHAIN_DISTRIBUTED')",
+    reason="Checkpoints test skipped in distributed mode",
+)
 def test_checkpoints_parallel(test_session_tmpfile, monkeypatch):
     def mapper_fail(num) -> int:
         raise Exception("Error")

--- a/tests/func/test_udf.py
+++ b/tests/func/test_udf.py
@@ -553,14 +553,8 @@ def test_udf_parallel_exec_error(cloud_test_catalog_tmpfile):
         .map(name_len_error, params=["file.path"], output={"name_len": int})
     )
 
-    if os.environ.get("DATACHAIN_DISTRIBUTED"):
-        # in distributed mode we expect DataChainError with the error message
-        with pytest.raises(DataChainError, match="Test Error!"):
-            chain.show()
-    else:
-        # while in local mode we expect RuntimeError with the error message
-        with pytest.raises(RuntimeError, match="UDF Execution Failed!"):
-            chain.show()
+    with pytest.raises(RuntimeError, match="UDF Execution Failed!"):
+        chain.show()
 
 
 @pytest.mark.parametrize(
@@ -736,12 +730,8 @@ def test_udf_parallel_interrupt(cloud_test_catalog_tmpfile, capfd):
         .settings(parallel=True)
         .map(name_len_interrupt, params=["file.path"], output={"name_len": int})
     )
-    if os.environ.get("DATACHAIN_DISTRIBUTED"):
-        with pytest.raises(KeyboardInterrupt):
-            chain.show()
-    else:
-        with pytest.raises(RuntimeError, match="UDF Execution Failed!"):
-            chain.show()
+    with pytest.raises(RuntimeError, match="UDF Execution Failed!"):
+        chain.show()
     captured = capfd.readouterr()
     assert "semaphore" not in captured.err
 
@@ -874,7 +864,7 @@ def test_udf_distributed_interrupt(
         .settings(parallel=parallel, workers=workers)
         .map(name_len_interrupt, params=["file.path"], output={"name_len": int})
     )
-    with pytest.raises(KeyboardInterrupt):
+    with pytest.raises(Exception, match="UDF task failed with exit code"):
         chain.show()
     captured = capfd.readouterr()
     assert "semaphore" not in captured.err

--- a/tests/unit/lib/test_checkpoints.py
+++ b/tests/unit/lib/test_checkpoints.py
@@ -21,6 +21,10 @@ def nums_dataset(test_session):
     return dc.read_values(num=[1, 2, 3], session=test_session).save("nums")
 
 
+@pytest.mark.skipif(
+    "os.environ.get('DATACHAIN_DISTRIBUTED')",
+    reason="Checkpoints test skipped in distributed mode",
+)
 @pytest.mark.parametrize("reset_checkpoints", [True, False])
 @pytest.mark.parametrize("with_delta", [True, False])
 @pytest.mark.parametrize("use_datachain_job_id_env", [True, False])
@@ -84,6 +88,10 @@ def test_checkpoints(
     assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
 
 
+@pytest.mark.skipif(
+    "os.environ.get('DATACHAIN_DISTRIBUTED')",
+    reason="Checkpoints test skipped in distributed mode",
+)
 @pytest.mark.parametrize("reset_checkpoints", [True, False])
 def test_checkpoints_modified_chains(
     test_session, monkeypatch, nums_dataset, reset_checkpoints
@@ -115,6 +123,10 @@ def test_checkpoints_modified_chains(
     assert len(list(catalog.metastore.list_checkpoints(second_job_id))) == 3
 
 
+@pytest.mark.skipif(
+    "os.environ.get('DATACHAIN_DISTRIBUTED')",
+    reason="Checkpoints test skipped in distributed mode",
+)
 @pytest.mark.parametrize("reset_checkpoints", [True, False])
 def test_checkpoints_multiple_runs(
     test_session, monkeypatch, nums_dataset, reset_checkpoints
@@ -180,6 +192,10 @@ def test_checkpoints_multiple_runs(
     assert len(list(catalog.metastore.list_checkpoints(fourth_job_id))) == 3
 
 
+@pytest.mark.skipif(
+    "os.environ.get('DATACHAIN_DISTRIBUTED')",
+    reason="Checkpoints test skipped in distributed mode",
+)
 def test_checkpoints_check_valid_chain_is_returned(
     test_session,
     monkeypatch,

--- a/tests/unit/test_catalog_loader.py
+++ b/tests/unit/test_catalog_loader.py
@@ -80,7 +80,9 @@ def test_get_warehouse_in_memory():
         warehouse.close()
 
 
-def test_get_distributed_class():
+def test_get_distributed_class(monkeypatch):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED_DISABLED", raising=False)
+
     with patch.dict(os.environ, {"DATACHAIN_DISTRIBUTED": ""}):
         assert get_udf_distributor_class() is None
 

--- a/tests/unit/test_job_management.py
+++ b/tests/unit/test_job_management.py
@@ -31,7 +31,9 @@ def test_reuse_job_from_env_var(test_session, monkeypatch):
     assert Session._JOB_STATUS is None
 
 
-def test_get_or_create_creates_job(test_session, patch_argv):
+def test_get_or_create_creates_job(test_session, patch_argv, monkeypatch):
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     job = test_session.get_or_create_job()
 
     db_job = test_session.catalog.metastore.get_job(job.id)
@@ -41,7 +43,9 @@ def test_get_or_create_creates_job(test_session, patch_argv):
     assert db_job.status == JobStatus.RUNNING
 
 
-def test_finalize_success(test_session, patch_argv):
+def test_finalize_success(test_session, patch_argv, monkeypatch):
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     job = test_session.get_or_create_job()
 
     test_session._finalize_job_success()
@@ -64,7 +68,10 @@ def test_finalize_failure(
     exception_type,
     expected_status,
     should_have_error,
+    monkeypatch,
 ):
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     job = test_session.get_or_create_job()
 
     try:
@@ -87,7 +94,9 @@ def test_finalize_failure(
         assert db_job.error_stack == ""
 
 
-def test_get_or_create_is_idempotent(test_session, patch_argv):
+def test_get_or_create_is_idempotent(test_session, patch_argv, monkeypatch):
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     job1 = test_session.get_or_create_job()
     job2 = test_session.get_or_create_job()
 
@@ -95,7 +104,9 @@ def test_get_or_create_is_idempotent(test_session, patch_argv):
     assert Session._CURRENT_JOB is job1
 
 
-def test_get_or_create_links_to_parent(test_session, patch_argv):
+def test_get_or_create_links_to_parent(test_session, patch_argv, monkeypatch):
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     job1 = test_session.get_or_create_job()
     test_session._finalize_job_success()
 
@@ -109,8 +120,10 @@ def test_get_or_create_links_to_parent(test_session, patch_argv):
     assert job2.parent_job_id == job1.id
 
 
-def test_nested_sessions_share_same_job(test_session, patch_argv):
+def test_nested_sessions_share_same_job(test_session, patch_argv, monkeypatch):
     """Test that nested sessions share the same job (one job per process)."""
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     # Outer session creates a job
     job1 = test_session.get_or_create_job()
 
@@ -132,8 +145,10 @@ def test_nested_sessions_share_same_job(test_session, patch_argv):
     assert job3 is job1
 
 
-def test_except_hook_delegates_to_original(test_session, patch_argv):
+def test_except_hook_delegates_to_original(test_session, patch_argv, monkeypatch):
     """Test that Session.except_hook delegates to ORIGINAL_EXCEPT_HOOK."""
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+
     # Set up global session for this test
     Session.GLOBAL_SESSION_CTX = test_session
     test_session.get_or_create_job()


### PR DESCRIPTION
Alternative to https://github.com/iterative/datachain/pull/1438
See also SaaS PRs.

## Summary by Sourcery

Fix distributed tests by centralizing job creation and environment setup, refactoring Celery worker orchestration, skipping incompatible tests in distributed mode, standardizing test fixtures, and updating CI workflow for unified FFmpeg installation and prebuilt datachain_server venv initialization.

Enhancements:
- Centralize job creation in tests with a new _create_job helper and propagate DATACHAIN_JOB_ID across fixtures
- Refactor run_datachain_worker to spawn multiple Celery workers with dynamic queues and set DATACHAIN_STEP_ID and UDF_RUNNER_QUEUE_NAME_LIST environment variables
- Update cloud_server_credentials fixture to session scope and use os.environ directly for AWS credentials
- Standardize SQLiteMetastore and SQLiteWarehouse fixtures to accept string paths

CI:
- Consolidate FFmpeg installation into a single apt-based step and add datachain venv initialization step to pre-build wheels and install dependencies

Tests:
- Clear DATACHAIN_JOB_ID in job management tests via monkeypatch for isolation
- Skip checkpoint tests when DATACHAIN_DISTRIBUTED is set
- Simplify UDF tests to always expect RuntimeError in both local and distributed modes