### PR TITLE
fix(model store): handle deeply nested models

### DIFF
--- a/tests/func/test_model_store_rebuild.py
+++ b/tests/func/test_model_store_rebuild.py
@@ -1,0 +1,83 @@
+import cloudpickle
+import pytest
+from pydantic import Field
+
+import datachain as dc
+
+
+class Metrics(dc.DataModel):
+    accuracy: float = 0.0
+    latency: float = 0.0
+
+
+class Contents(dc.DataModel):
+    metrics1: Metrics = Field(default_factory=Metrics)
+    metrics2: Metrics = Field(default_factory=Metrics)
+    metrics3: Metrics = Field(default_factory=Metrics)
+    metrics4: Metrics = Field(default_factory=Metrics)
+
+
+class Sample(dc.DataModel):
+    record_id: int = 0
+    contents: Contents = Field(default_factory=Contents)
+
+
+class Envelope(dc.DataModel):
+    sample: Sample = Field(default_factory=Sample)
+    origin: str = "builder"
+
+
+def build_envelopes(record_id: int):
+    nested = Metrics(accuracy=0.9 + 0.01 * record_id, latency=42.0 + record_id)
+    contents = Contents(
+        metrics1=nested,
+        metrics2=nested,
+        metrics3=nested,
+        metrics4=nested,
+    )
+    sample = Sample(record_id=record_id, contents=contents)
+    yield Envelope(sample=sample, origin="built")
+
+
+def process_envelopes(envelope: Envelope):
+    yield envelope
+
+
+def test_nested_datamodels_round_trip_parallel(
+    test_session_tmpfile,
+):
+    import tests.func.test_model_store_rebuild as this_module  # noqa: PLW0406
+
+    cloudpickle.register_pickle_by_value(this_module)
+
+    chain = (
+        dc.read_values(record_id=range(1, 1001), session=test_session_tmpfile)
+        .settings(parallel=2, prefetch=False)
+        .gen(
+            envelope=build_envelopes,
+            params=["record_id"],
+            output={"envelope": Envelope},
+        )
+        .gen(
+            processed_envelope=process_envelopes,
+            params=["envelope"],
+            output={"processed_envelope": Envelope},
+        )
+    )
+
+    rows = chain.to_list("processed_envelope")
+
+    assert len(rows) == 1000
+    for (envelope,) in rows:
+        assert isinstance(envelope, Envelope)
+        sample = envelope.sample
+        assert isinstance(sample, Sample)
+        assert isinstance(sample.contents, Contents)
+        assert isinstance(sample.contents.metrics1, Metrics)
+        assert sample.contents.metrics1.accuracy == pytest.approx(
+            0.9 + 0.01 * sample.record_id
+        )
+        assert sample.contents.metrics1.latency == pytest.approx(
+            42.0 + sample.record_id
+        )
+        assert envelope.origin == "built"

--- a/tests/unit/lib/test_feature.py
+++ b/tests/unit/lib/test_feature.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, Optional
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
@@ -142,6 +142,19 @@ def test_registry_versioned():
     assert ModelStore.get(MyTestXYZ.__name__, version=1) is None
     assert ModelStore.get(MyTestXYZ.__name__, version=42) == MyTestXYZ
     ModelStore.remove(MyTestXYZ)
+
+
+def test_model_store_rebuild_all_recursive():
+    class Node(DataModel):
+        value: int = 0
+        child: Optional["Node"] = None
+
+    try:
+        ModelStore.rebuild_all()
+        root = Node(value=1, child=Node(value=2))
+        assert root.child and root.child.value == 2
+    finally:
+        ModelStore.remove(Node)
 
 
 def test_inheritance():


### PR DESCRIPTION
Fixes issue when ModelStore is not properly rebuilt in workers due to models nestedness. In such cases order matters (kids should be rebuilt first).

## Summary by Sourcery

Fix the model store rebuilding logic to handle nested Pydantic models by performing a depth-first rebuild and add corresponding unit and functional tests

Bug Fixes:
- Fix ModelStore.rebuild_all to properly rebuild deeply nested models in dependency order

Enhancements:
- Introduce depth-first traversal in rebuild_all to ensure child models are rebuilt before their parents

Tests:
- Add unit test for recursive model rebuilding
- Add functional test for nested datamodel round-trip in parallel execution

Chores:
- Remove unused logging import in model_store