### PR TITLE
misc(delta): improve detection of schema drift

### DIFF
--- a/src/datachain/error.py
+++ b/src/datachain/error.py
@@ -2,6 +2,10 @@ class DataChainError(RuntimeError):
     pass
 
 
+class SchemaDriftError(DataChainError):
+    pass
+
+
 class InvalidDatasetNameError(RuntimeError):
     pass
 

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -56,6 +56,7 @@ from datachain.query.dataset import (
     DatasetQuery,
     PartitionByType,
     RegenerateSystemColumns,
+    UnionSchemaMismatchError,
 )
 from datachain.query.schema import DEFAULT_DELIMITER, Column
 from datachain.sql.functions import path as pathfunc
@@ -1714,7 +1715,16 @@ class DataChain:
         Parameters:
             other: chain whose rows will be added to `self`.
         """
-        self.signals_schema = self.signals_schema.clone_without_sys_signals()
+        self_schema = self.signals_schema
+        other_schema = other.signals_schema
+        missing_left, missing_right = self_schema.compare_signals(other_schema)
+        if missing_left or missing_right:
+            raise UnionSchemaMismatchError.from_column_sets(
+                missing_left,
+                missing_right,
+            )
+
+        self.signals_schema = self_schema.clone_without_sys_signals()
         return self._evolve(query=self._query.union(other._query))
 
     def subtract(  # type: ignore[override]

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1202,6 +1202,27 @@ class SQLGroupBy(SQLClause):
         return sqlalchemy.select(*unique_cols).select_from(subquery).group_by(*group_by)
 
 
+class UnionSchemaMismatchError(ValueError):
+    """Union input columns mismatch."""
+
+    @classmethod
+    def from_column_sets(
+        cls,
+        missing_left: set[str],
+        missing_right: set[str],
+    ) -> "UnionSchemaMismatchError":
+        def _describe(cols: set[str], side: str) -> str:
+            return f"{', '.join(sorted(cols))} only present in {side}"
+
+        parts = []
+        if missing_left:
+            parts.append(_describe(missing_left, "left"))
+        if missing_right:
+            parts.append(_describe(missing_right, "right"))
+
+        return cls(f"Cannot perform union. {'. '.join(parts)}")
+
+
 def _validate_columns(
     left_columns: Iterable[ColumnElement], right_columns: Iterable[ColumnElement]
 ) -> set[str]:
@@ -1211,27 +1232,10 @@ def _validate_columns(
     if left_names == right_names:
         return left_names
 
-    missing_right = left_names - right_names
-    missing_left = right_names - left_names
-
-    def _prepare_msg_part(missing_columns: set[str], side: str) -> str:
-        return f"{', '.join(sorted(missing_columns))} only present in {side}"
-
-    msg_parts = [
-        _prepare_msg_part(missing_columns, found_side)
-        for missing_columns, found_side in zip(
-            [
-                missing_right,
-                missing_left,
-            ],
-            ["left", "right"],
-            strict=False,
-        )
-        if missing_columns
-    ]
-    msg = f"Cannot perform union. {'. '.join(msg_parts)}"
-
-    raise ValueError(msg)
+    raise UnionSchemaMismatchError.from_column_sets(
+        left_names - right_names,
+        right_names - left_names,
+    )
 
 
 def _order_columns(


### PR DESCRIPTION
Makes error handling for delta mode user friendly.

## Summary by Sourcery

Improve delta mode schema drift detection by introducing explicit drift errors, schema comparison utilities, and wrapping union operations to emit clear user-facing messages when columns are added or removed.

New Features:
- Introduce SchemaDriftError and UnionSchemaMismatchError for explicit drift handling
- Add SignalSchema.user_signals and compare_signals methods for schema comparison

Enhancements:
- Wrap union operations in delta processing and DataChain.union to detect schema drift and raise user-friendly errors
- Implement detailed drift message formatting listing new and missing columns

Tests:
- Add functional tests to verify schema drift detection for added/removed columns and retry unions in delta mode