### PR TITLE
fix(udf): handle models serialization in complex types

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -83,7 +83,9 @@ class AbstractWarehouse(ABC, Serializable):
         """
 
         if ModelStore.is_pydantic(type(obj)):
-            return obj.model_dump()
+            # Use Pydantic's JSON mode to ensure datetime and other non-JSON
+            # native types are serialized in a compatible way.
+            return obj.model_dump(mode="json")
 
         if isinstance(obj, dict):
             out: dict[str, Any] = {}


### PR DESCRIPTION
Fixes primarily Files and other complex types serialization into DB, so that we can pass and operate on list[File] as a column for example. It is needed for `agg` and other scenarios.

This is a followup to a few other PRs I made recently to fix complex types handing. More to come.

## Summary by Sourcery

Enable seamless serialization of complex types such as list[File] in UDF pipelines by converting aggregated tuples to lists and using JSON-compatible model serialization, and validate this behavior with new functional tests

New Features:
- Support list[File] and other complex types as columns in UDF aggregation and persistence

Enhancements:
- Convert aggregated column values from tuples to lists in the UDF runner to align with public API type hints
- Use Pydantic’s model_dump with JSON mode for JSON-compatible serialization of models in the warehouse

Tests:
- Add functional tests for aggregating and counting list[File] columns via UDF
- Add functional tests for persisting and reading back list[File] columns from storage