### PR TITLE
fix(udf): don't allow silent wrong schema merges

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -850,14 +850,13 @@ class DataChain:
         if (prefetch := self._settings.prefetch) is not None:
             udf_obj.prefetch = prefetch
 
+        sys_schema = SignalSchema({"sys": Sys})
         return self._evolve(
             query=self._query.add_signals(
                 udf_obj.to_udf_wrapper(self._settings.batch_size),
                 **self._settings.to_dict(),
             ),
-            signal_schema=SignalSchema({"sys": Sys})
-            | self.signals_schema
-            | udf_obj.output,
+            signal_schema=sys_schema | self.signals_schema | udf_obj.output,
         )
 
     def gen(

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -683,11 +683,26 @@ class UDFSignal(UDFStep):
         signal_name_cols = {c.name: c for c in signal_cols}
         cols = signal_cols
 
-        overlap = {c.name for c in original_cols} & {c.name for c in cols}
+        original_names = {c.name for c in original_cols}
+        new_names = {c.name for c in cols}
+
+        overlap = original_names & new_names
         if overlap:
             raise ValueError(
                 "Column already exists or added in the previous steps: "
-                + ", ".join(overlap)
+                + ", ".join(sorted(overlap))
+            )
+
+        def _root(name: str) -> str:
+            return name.split(DEFAULT_DELIMITER, 1)[0]
+
+        existing_roots = {_root(name) for name in original_names}
+        new_roots = {_root(name) for name in new_names}
+        root_conflicts = existing_roots & new_roots
+        if root_conflicts:
+            raise ValueError(
+                "Signals already exist in the previous steps: "
+                + ", ".join(sorted(root_conflicts))
             )
 
         def q(*columns):

--- a/tests/func/test_udf.py
+++ b/tests/func/test_udf.py
@@ -12,7 +12,7 @@ import datachain as dc
 from datachain.func import path as pathfunc
 from datachain.lib.file import AudioFile, AudioFragment, File
 from datachain.lib.udf import Mapper
-from datachain.lib.utils import DataChainError
+from datachain.lib.utils import DataChainColumnError, DataChainError
 from tests.utils import LARGE_TREE, NUM_TREE
 
 
@@ -388,6 +388,23 @@ def test_udf_different_types(cloud_test_catalog):
             obj,
         )
     ]
+
+
+def test_udf_rejects_root_override(test_session):
+    class X(dc.DataModel):
+        x: int
+
+    chain = dc.read_values(x=[X(x=0), X(x=1)], session=test_session)
+
+    with pytest.raises(
+        DataChainColumnError,
+        match="Error for column x: signal already exists with a different type",
+    ):
+        chain.map(
+            lambda x: x.model_dump(),
+            params=["x"],
+            output={"x": dict},
+        )
 
 
 @pytest.mark.parametrize("use_cache", [False, True])


### PR DESCRIPTION
Fixes https://github.com/iterative/datachain/issues/1450

Makes things more strict overall for schema merges after UDFs (and in other places where we do `schema1 | schema2`).

## Summary by Sourcery

Enforce strict schema merging to catch type mismatches and root conflicts in SignalSchema unions and dataset column additions, preventing silent schema errors in UDF pipelines

Bug Fixes:
- Prevent silent wrong schema merges by raising errors on type or root conflicts in schema unions and dataset column additions

Enhancements:
- Implement strict conflict detection in SignalSchema.__or__, raising errors for differing types or root duplicates while allowing identical and system signals
- Introduce root-level conflict checks and sorted overlap error messages when adding columns in dataset queries
- Refactor UDF map operation to compose the sys schema before merging with existing and output schemas

Tests:
- Add unit tests for SignalSchema union behavior (type mismatches, root conflicts, system signal rules) and functional tests for UDF schema override rejection