### PR TITLE
fix(udf): don't use python enthropy for UDF temp names

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -1,7 +1,7 @@
 import glob
 import logging
 import posixpath
-import random
+import secrets
 import string
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
@@ -1045,7 +1045,5 @@ class AbstractWarehouse(ABC, Serializable):
 
 
 def _random_string(length: int) -> str:
-    return "".join(
-        random.choice(string.ascii_letters + string.digits)  # noqa: S311
-        for i in range(length)
-    )
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -3,7 +3,7 @@ import hashlib
 import inspect
 import logging
 import os
-import random
+import secrets
 import string
 import subprocess
 import sys
@@ -1372,10 +1372,7 @@ class DatasetQuery:
 
     @staticmethod
     def get_table() -> "TableClause":
-        table_name = "".join(
-            random.choice(string.ascii_letters)  # noqa: S311
-            for _ in range(16)
-        )
+        table_name = "".join(secrets.choice(string.ascii_letters) for _ in range(16))
         return sqlalchemy.table(table_name)
 
     @property


### PR DESCRIPTION
If job abruptly killed (regular on local debugging) we are leaving UDF tables behind ...

If script sets random seed (regular for ML workflow) we are getting names overlap and it is crashing

Here we use OS provided rnd, AFAIU regular seed doesn't affect it