### PR TITLE
Update Studio dependencies in CI only if branch is not 'main'

### DIFF
--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Update DataChain requirement in Studio
         if: ${{ env.BRANCH != 'main' }}
         working-directory: backend
-        run: make update_datachain_deps "$BRANCH"
+        run: make update_datachain_deps "${{ env.BRANCH }}"
 
       - name: Check out repository
         uses: actions/checkout@v5


### PR DESCRIPTION
Follow-up for this: https://github.com/datachain-ai/datachain/pull/1444/commits/4a0c6a1a52fc5793c252f21b150882d8e8eb8aa5 and this: https://github.com/datachain-ai/datachain/pull/1464#discussion_r2548443434