### PR TITLE
Fix 'ValuesToTupleError' exception

### DIFF
--- a/src/datachain/lib/convert/values_to_tuples.py
+++ b/src/datachain/lib/convert/values_to_tuples.py
@@ -8,9 +8,16 @@ from datachain.lib.utils import DataChainParamsError
 
 class ValuesToTupleError(DataChainParamsError):
     def __init__(self, ds_name: str, msg: str):
+        self.ds_name = ds_name
+        self.msg = msg
+
         if ds_name:
             ds_name = f"' {ds_name}'"
+
         super().__init__(f"Cannot convert signals for dataset{ds_name}: {msg}")
+
+    def __reduce__(self):
+        return ValuesToTupleError, (self.ds_name, self.msg)
 
 
 def _find_first_non_none(sequence: Sequence[Any]) -> Any | None:
@@ -164,7 +171,7 @@ def values_to_tuples(
     length = -1
     for k, v in fr_map.items():
         if not isinstance(v, Sequence) or isinstance(v, str):  # type: ignore[unreachable]
-            raise ValuesToTupleError(ds_name, f"signals '{k}' is not a sequence")
+            raise ValuesToTupleError(ds_name, f"signal '{k}' is not a sequence")
         len_ = len(v)
 
         if output:

--- a/tests/unit/lib/test_feature_utils.py
+++ b/tests/unit/lib/test_feature_utils.py
@@ -3,10 +3,7 @@ from typing import get_args, get_origin
 import pytest
 
 import datachain as dc
-from datachain.lib.convert.values_to_tuples import (
-    ValuesToTupleError,
-    values_to_tuples,
-)
+from datachain.lib.convert.values_to_tuples import ValuesToTupleError, values_to_tuples
 from datachain.query.schema import Column
 
 


### PR DESCRIPTION
Error during`ValuesToTupleError` exception serialization:

```
ValuesToTupleError.__init__() missing 1 required positional argument: 'msg'
```

Because of this the result error of job run is:

```
Query script exited with error code 1
```

After this fix job result error is:

```
Job failed with error ValuesToTupleError: Cannot convert signals for dataset: signal 'val' is not a sequence
```

Also fix mistype: `signal 'val' is not a sequence` instead of `signals 'val' is not a sequence`.