### PR TITLE
to_json/to_csv - return file written

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -41,7 +41,7 @@ CLOUD_STORAGE_PROTOCOLS = {"s3", "gs", "az", "hf"}
 ResultQueue = asyncio.Queue[Sequence["File"] | None]
 
 
-def _is_win_local_path(uri: str) -> bool:
+def is_win_local_path(uri: str) -> bool:
     if sys.platform == "win32":
         if len(uri) >= 1 and uri[0] == "\\":
             return True
@@ -95,7 +95,7 @@ class Client(ABC):
 
         protocol = urlparse(os.fspath(url)).scheme
 
-        if not protocol or _is_win_local_path(os.fspath(url)):
+        if not protocol or is_win_local_path(os.fspath(url)):
             return FileClient
         if protocol == ClientS3.protocol:
             return ClientS3
@@ -113,6 +113,11 @@ class Client(ABC):
             return HTTPSClient
 
         raise NotImplementedError(f"Unsupported protocol: {protocol}")
+
+    @classmethod
+    def path_to_uri(cls, path: str) -> str:
+        """Convert a path-like object to a URI. Default: identity."""
+        return path
 
     @staticmethod
     def is_data_source_uri(name: str) -> bool:

--- a/src/datachain/client/local.py
+++ b/src/datachain/client/local.py
@@ -9,7 +9,7 @@ from fsspec.implementations.local import LocalFileSystem
 
 from datachain.lib.file import File
 
-from .fsspec import Client
+from .fsspec import Client, is_win_local_path
 
 if TYPE_CHECKING:
     from datachain.cache import Cache
@@ -57,9 +57,13 @@ class FileClient(Client):
             /home/user/animals/ -> file:///home/user/animals/
             C:\\windows\animals -> file:///C:/windows/animals
         """
+        parsed = urlparse(path)
+        if parsed.scheme and not is_win_local_path(path):
+            return path
+
         uri = Path(path).expanduser().absolute().resolve().as_uri()
-        if path[-1] == os.sep:
-            # we should keep os separator from the end of the path
+        if path and path[-1] in (os.sep, "/"):
+            # keep trailing separator so directory URIs stay rooted
             uri += "/"  # in uri (file:///...) all separators are / regardless of os
 
         return uri

--- a/tests/func/test_file.py
+++ b/tests/func/test_file.py
@@ -1,4 +1,5 @@
 import io
+from pathlib import Path
 
 import pytest
 
@@ -198,6 +199,60 @@ def test_open_write_text(cloud_test_catalog):
     catalog.get_client(src_uri).fs.rm(file_path)
 
 
+def test_file_at_accepts_pathlike(tmp_dir, test_session_tmpfile, monkeypatch):
+    monkeypatch.chdir(tmp_dir)
+
+    as_str = File.at("rel.bin", session=test_session_tmpfile)
+    as_path = File.at(Path("rel.bin"), session=test_session_tmpfile)
+
+    assert as_str.path == as_path.path == "rel.bin"
+    expected_source = tmp_dir.as_uri()
+
+    assert as_str.source == as_path.source == expected_source
+
+
+def test_file_at_rejects_directory_uri(tmp_dir, test_session_tmpfile, monkeypatch):
+    monkeypatch.chdir(tmp_dir)
+
+    dir_uri = f"{tmp_dir}/"
+
+    with pytest.raises(ValueError):
+        File.at(dir_uri, session=test_session_tmpfile)
+
+
+def test_read_storage_returns_same_source_and_path(
+    tmp_dir, test_session_tmpfile, monkeypatch
+):
+    monkeypatch.chdir(tmp_dir)
+    import os
+
+    print(os.getcwd())
+
+    file_obj = File.at("rel.bin", session=test_session_tmpfile)
+    with file_obj.open("wb") as f:
+        f.write(b"hi")
+
+    import os
+
+    print(os.getcwd())
+
+    listed = dc.read_storage(tmp_dir, session=test_session_tmpfile).to_values("file")
+    assert len(listed) == 1
+    listed_file = listed[0]
+    print(listed_file.path)
+    print(listed_file.source)
+    # print pwd
+    import os
+
+    print(os.getcwd())
+    assert listed_file.path == "rel.bin"
+    assert listed_file.source == file_obj.source
+
+    assert (tmp_dir / "rel.bin").read_bytes() == b"hi"
+    assert file_obj.size == len(b"hi")
+    assert file_obj.read() == b"hi"
+
+
 @pytest.mark.parametrize("cloud_type", ["s3", "gs", "azure"], indirect=True)
 @pytest.mark.parametrize("version_aware", [True], indirect=True)
 def test_write_version_capture(cloud_test_catalog, cloud_type):
@@ -248,3 +303,34 @@ def test_write_version_capture(cloud_test_catalog, cloud_type):
         )
 
     client.fs.rm(file_path)
+
+
+@pytest.mark.parametrize("cloud_type", ["s3"], indirect=True)
+@pytest.mark.parametrize("version_aware", [True], indirect=True)
+def test_empty_upload_captures_version(cloud_test_catalog_upload, cloud_type):
+    ctc = cloud_test_catalog_upload
+    catalog = ctc.catalog
+    src_uri = ctc.src_uri
+
+    upload_path = f"{src_uri}/empty-upload.bin"
+    uploaded = File.upload(b"", upload_path, catalog)
+
+    assert uploaded.size == 0
+    assert uploaded.version
+    assert uploaded.read() == b""
+
+
+@pytest.mark.parametrize("cloud_type", ["s3"], indirect=True)
+@pytest.mark.parametrize("version_aware", [True], indirect=True)
+def test_empty_open_write_captures_version(cloud_test_catalog_upload, cloud_type):
+    ctc = cloud_test_catalog_upload
+    src_uri = ctc.src_uri
+
+    open_path = f"{src_uri}/empty-open.bin"
+    opened = File.at(open_path, ctc.session)
+    with opened.open("wb"):
+        pass
+
+    assert opened.size == 0
+    assert opened.version
+    assert opened.read() == b""

--- a/tests/func/test_to_csv.py
+++ b/tests/func/test_to_csv.py
@@ -1,0 +1,136 @@
+import csv
+import uuid
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+import datachain as dc
+from datachain.lib.file import File
+
+
+class MyFr(BaseModel):
+    nnn: str
+    count: int
+
+
+class MyNested(BaseModel):
+    label: str
+    fr: MyFr
+
+
+features = sorted(
+    [MyFr(nnn="n1", count=3), MyFr(nnn="n2", count=5), MyFr(nnn="n1", count=1)],
+    key=lambda f: (f.nnn, f.count),
+)
+
+features_nested = [
+    MyNested(fr=fr, label=f"label_{num}") for num, fr in enumerate(features)
+]
+
+
+def test_to_csv_features(tmp_dir, test_session):
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
+    path = tmp_dir / "test.csv"
+    dc_to.order_by("f1.nnn", "f1.count").to_csv(path)
+    with open(path) as f:
+        lines = f.read().split("\n")
+    assert lines == ["f1.nnn,f1.count,num", "n1,1,0", "n1,3,1", "n2,5,2", ""]
+
+
+def test_to_tsv_features(tmp_dir, test_session):
+    dc_to = dc.read_values(f1=features, num=range(len(features)), session=test_session)
+    path = tmp_dir / "test.csv"
+    dc_to.order_by("f1.nnn", "f1.count").to_csv(path, delimiter="\t")
+    with open(path) as f:
+        lines = f.read().split("\n")
+    assert lines == ["f1.nnn\tf1.count\tnum", "n1\t1\t0", "n1\t3\t1", "n2\t5\t2", ""]
+
+
+def test_to_csv_features_nested(tmp_dir, test_session):
+    dc_to = dc.read_values(sign1=features_nested, session=test_session)
+    path = tmp_dir / "test.csv"
+    dc_to.order_by("sign1.fr.nnn", "sign1.fr.count").to_csv(path)
+    with open(path) as f:
+        lines = f.read().split("\n")
+    assert lines == [
+        "sign1.label,sign1.fr.nnn,sign1.fr.count",
+        "label_0,n1,1",
+        "label_1,n1,3",
+        "label_2,n2,5",
+        "",
+    ]
+
+
+def test_to_csv_returns_file(tmp_dir, test_session):
+    chain = dc.read_values(value=[1, 2], session=test_session)
+    dest = tmp_dir / "values.csv"
+
+    stored = chain.order_by("value").to_csv(dest)
+
+    assert isinstance(stored, File)
+    assert stored.source.startswith("file://")
+    assert stored.path == dest.name
+    assert stored.size == dest.stat().st_size
+
+    with open(dest, newline="") as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0] == ["value"]
+    assert rows[1:] == [["1"], ["2"]]
+
+
+def test_to_csv_relative_path(tmp_dir, test_session, monkeypatch):
+    monkeypatch.chdir(tmp_dir)
+
+    chain = dc.read_values(value=[3, 4], session=test_session)
+    dest = Path("rel.csv")
+
+    stored = chain.to_csv(dest)
+
+    assert stored.source == tmp_dir.as_uri()
+    assert stored.path == dest.name
+
+    output_path = tmp_dir / dest
+    assert output_path.exists()
+    assert stored.size == output_path.stat().st_size
+
+    with open(output_path, newline="") as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0] == ["value"]
+    assert sorted(rows[1:]) == [["3"], ["4"]]
+
+
+@pytest.mark.parametrize("cloud_type", ["s3"], indirect=True)
+@pytest.mark.parametrize("version_aware", [True], indirect=True)
+def test_to_csv_returns_file_with_version(cloud_test_catalog_upload, cloud_type):
+    ctc = cloud_test_catalog_upload
+
+    chain = dc.read_values(value=[5, 6], session=ctc.session)
+    dest = f"{ctc.src_uri}/to-csv-{uuid.uuid4().hex}.csv"
+
+    stored = chain.order_by("value").to_csv(dest)
+
+    assert isinstance(stored, File)
+    assert stored.version
+    assert stored.source == ctc.src_uri
+    assert stored.path.endswith(".csv")
+
+    parsed = list(csv.reader(stored.read_text().splitlines()))
+    assert parsed[0] == ["value"]
+    assert parsed[1:] == [["5"], ["6"]]
+
+
+def test_to_csv_custom_delimiter(tmp_dir, test_session):
+    chain = dc.read_values(a=["x", "y"], b=[1, 2], session=test_session)
+    dest = tmp_dir / "values.tsv"
+
+    stored = chain.order_by("a").to_csv(dest, delimiter="\t")
+
+    assert isinstance(stored, File)
+    with open(dest, newline="") as f:
+        rows = list(csv.reader(f, delimiter="\t"))
+
+    assert rows[0] == ["a", "b"]
+    assert rows[1:] == [["x", "1"], ["y", "2"]]

--- a/tests/unit/test_client_local.py
+++ b/tests/unit/test_client_local.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+
+from datachain.client.local import FileClient
+
+
+def test_split_url_directory_preserves_leaf(tmp_path):
+    uri = tmp_path.as_uri()
+    bucket, rel = FileClient.split_url(uri)
+
+    # For directories, the parent directory becomes the bucket and the leaf
+    # directory becomes the relative path to keep downstream listings stable.
+    assert Path(bucket) == tmp_path.parent
+    assert rel == tmp_path.name
+
+
+def test_split_url_file_in_directory(tmp_path):
+    file_path = tmp_path / "sub" / "file.bin"
+    file_path.parent.mkdir(parents=True)
+    uri = file_path.as_uri()
+
+    bucket, rel = FileClient.split_url(uri)
+
+    # The bucket should be the directory containing the file;
+    # rel should be the filename.
+    assert Path(bucket) == file_path.parent
+    assert rel == "file.bin"
+
+
+def test_split_url_accepts_plain_directory_path(tmp_path):
+    bucket, rel = FileClient.split_url(str(tmp_path))
+
+    assert Path(bucket) == tmp_path.parent
+    assert rel == tmp_path.name
+
+
+def test_split_url_accepts_plain_file_path(tmp_path):
+    file_path = tmp_path / "leaf.txt"
+    file_path.write_text("data")
+
+    bucket, rel = FileClient.split_url(str(file_path))
+
+    assert Path(bucket) == file_path.parent
+    assert rel == "leaf.txt"
+
+
+def test_path_to_uri_preserves_trailing_slash(tmp_path):
+    dir_path = tmp_path / "trail"
+    dir_path.mkdir()
+
+    uri = FileClient.path_to_uri(f"{dir_path}{os.sep}")
+
+    # Trailing separator in the input should keep a trailing slash in the URI.
+    assert uri.endswith("/")
+    assert uri[:-1] == dir_path.resolve().as_uri()
+
+
+def test_path_to_uri_idempotent_for_file_uri(tmp_path):
+    uri = tmp_path.as_uri()
+
+    assert FileClient.path_to_uri(uri) == uri


### PR DESCRIPTION
Make `to_json` and `to_csv` return `File` instance and use File `at` / `open` to write files.

Need actual written File returned for a customer scenario.