### PR TITLE
Prevent double quoting in db_signals filtering

### DIFF
--- a/src/datachain/lib/meta_formats.py
+++ b/src/datachain/lib/meta_formats.py
@@ -97,6 +97,14 @@ def gen_datamodel_code(
             json_object = json_object[0]  # sample the 1st object from JSON array
         if format == "jsonl":
             format = "json"  # treat json line as plain JSON in auto-schema
+
+        from datachain.lib.utils import normalize_col_names
+
+        column_mapping = normalize_col_names(list(json_object.keys()))
+        json_object = {
+            new_key: json_object[old_key] for new_key, old_key in column_mapping.items()
+        }
+
         data_string = json.dumps(json_object)
 
     import datamodel_code_generator


### PR DESCRIPTION
Could fix https://github.com/datachain-ai/datachain/issues/1434

The bottom line of the issue was that when having a column name of the sort `xY`, doing `str` over that around [here](https://github.com/datachain-ai/datachain/blob/fedd11020fd04f0a66e7646ef96c3a3229a59a16/src/datachain/lib/signal_schema.py#L764) returned the doubled quote version `'"xY"'` (presumably because column names are lowercased by default) rendering the output list of `db_signal` to be empty 

After some conversations in the issue, we realised that DataChain is case insensitive which seems to point to the sanitization of inputs