### PR TITLE
hotfix: Update argument passed to create pipeline

### DIFF
--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -512,7 +512,7 @@ class StudioClient:
     # Pipeline API
     def create_pipeline(
         self,
-        datasets: list[dict[str, Any]],
+        datasets: list[str],
         team_name: str | None = None,
         review: bool = False,
     ) -> Response[Any]:

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -568,11 +568,9 @@ def create_pipeline(
     dataset_names: list[str],
     team_name: str | None = None,
 ):
-    datasets = [{"dataset_name": name} for name in dataset_names]
-
     client = StudioClient(team=team_name)
     response = client.create_pipeline(
-        datasets=datasets,
+        datasets=dataset_names,
         team_name=team_name,
         review=True,
     )


### PR DESCRIPTION
 In recent version of Studio, we now changed the datasets to be passed as
    list of fully qualified strings. This fixes the argument passed.
