### PR TITLE
add grab all param for UDFs

### DIFF
--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -1,5 +1,6 @@
 from datachain.lib.data_model import DataModel, DataType, is_chain_type
 from datachain.lib.dc import (
+    ALL,
     C,
     Column,
     DataChain,
@@ -46,6 +47,7 @@ from datachain.query import metrics, param
 from datachain.query.session import Session
 
 __all__ = [
+    "ALL",
     "AbstractUDF",
     "Aggregator",
     "ArrowRow",

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -1,6 +1,6 @@
 from .csv import read_csv
 from .database import read_database
-from .datachain import C, Column, DataChain
+from .datachain import ALL, C, Column, DataChain
 from .datasets import datasets, delete_dataset, move_dataset, read_dataset
 from .hf import read_hf
 from .json import read_json
@@ -13,6 +13,7 @@ from .utils import DatasetMergeError, DatasetPrepareError, Sys, is_local, is_stu
 from .values import read_values
 
 __all__ = [
+    "ALL",
     "C",
     "Column",
     "DataChain",


### PR DESCRIPTION
Adds a way to specify `params="*"` and get a dict of all values from a chain into UDF (vs specifying them one by one).

This is needed to simplify implementations for export (e.g. export to snowflake) that can be done in parallel. 

