### PR TITLE
Bump local DB schema version

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -68,7 +68,7 @@ quote_schema = sqlite_dialect.identifier_preparer.quote_schema
 quote = sqlite_dialect.identifier_preparer.quote
 
 # NOTE! This should be manually increased when we change our DB schema in codebase
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 OUTDATED_SCHEMA_ERROR_MESSAGE = (
     "You have an old version of the database schema. Please refer to the documentation"


### PR DESCRIPTION
In recent merged PR https://github.com/datachain-ai/datachain/pull/1512 there were some DB schema changes but we forgot to increase SCHEMA_VERSION in order for users to get nice error message saying DB schema is outdated and how to fix it.

This PR just increases mentioned DB schema version.