### PR TITLE
Removing `consistent_read`

### DIFF
--- a/src/datachain/data_storage/db_engine.py
+++ b/src/datachain/data_storage/db_engine.py
@@ -77,7 +77,6 @@ class DatabaseEngine(ABC, Serializable):
         query,
         cursor: Any | None = None,
         conn: Any | None = None,
-        consistent_read: bool = False,
     ) -> Iterator[tuple[Any, ...]]: ...
 
     def get_table(self, name: str) -> "Table":

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -230,7 +230,6 @@ class SQLiteDatabaseEngine(DatabaseEngine):
         query,
         cursor: sqlite3.Cursor | None = None,
         conn=None,
-        consistent_read: bool = False,
     ) -> sqlite3.Cursor:
         if self.is_closed:
             # Reconnect in case of being closed previously.

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -237,9 +237,9 @@ class AbstractWarehouse(ABC, Serializable):
         count_query = sa.select(sa.func.count(1)).select_from(query.subquery())
         return next(self.db.execute(count_query))[0]
 
-    def table_rows_count(self, table, consistent_read: bool = False) -> int:
+    def table_rows_count(self, table) -> int:
         count_query = sa.select(sa.func.count(1)).select_from(table)
-        return next(self.db.execute(count_query, consistent_read=consistent_read))[0]
+        return next(self.db.execute(count_query))[0]
 
     def dataset_select_paginated(
         self,
@@ -494,7 +494,7 @@ class AbstractWarehouse(ABC, Serializable):
         if size_columns:
             expressions = (*expressions, sa.func.sum(sum(size_columns)))
         query = sa.select(*expressions)
-        ((nrows, *rest),) = self.db.execute(query, consistent_read=True)
+        ((nrows, *rest),) = self.db.execute(query)
         return nrows, rest[0] if rest else 0
 
     @abstractmethod

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -1509,8 +1509,6 @@ class DatasetQuery:
         try:
             query = self.apply_steps().select()
             selected_columns = [c.name for c in query.selected_columns]
-            if "consistent_read" not in kwargs:
-                kwargs["consistent_read"] = True
             yield ResultIter(
                 self.catalog.warehouse.dataset_rows_select(query, **kwargs),
                 selected_columns,


### PR DESCRIPTION
Removing the consistent_read flag since it was only used for SaaS and now we will have consistent reads there by default. Companion Studio PR: https://github.com/datachain-ai/studio/pull/12501