### PR TITLE
Fix for local db migrations

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1914,10 +1914,13 @@ class AbstractDBMetastore(AbstractMetastore):
 
         # Validate run_group_id and rerun_from_job_id consistency
         if rerun_from_job_id:
-            # Rerun job: run_group_id must be provided by caller
-            assert run_group_id is not None, (
-                "run_group_id must be provided when rerun_from_job_id is set"
-            )
+            # Rerun job: run_group_id should be provided by caller
+            # If run_group_id is None, parent is a legacy job without run_group_id
+            # In this case, treat current job as first job in a new chain
+            # and break the link to the legacy parent
+            if run_group_id is None:
+                run_group_id = job_id
+                rerun_from_job_id = None
         else:
             # First job: run_group_id should not be provided (we set it here)
             assert run_group_id is None, (

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -241,9 +241,6 @@ class SQLiteDatabaseEngine(DatabaseEngine):
             result = conn.execute(*self.compile_to_args(query))
         else:
             result = self.db.execute(*self.compile_to_args(query))
-        if isinstance(query, CreateTable) and query.element.indexes:
-            for index in query.element.indexes:
-                self.execute(CreateIndex(index, if_not_exists=True), cursor=cursor)
         return result
 
     @retry_sqlite_locks


### PR DESCRIPTION
Fixing index creation for local db migrations.
Also, added backward compatibility for old local jobs that are already connected to parents but are missing new run_group_id field.