### PR TITLE
improve error message on type failures in UDFs

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -20,6 +20,7 @@ from datachain.dataset import DatasetRecord, StorageURI
 from datachain.lib.file import File
 from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
+from datachain.lib.udf import JsonSerializationError
 from datachain.node import DirType, DirTypeGroup, Node, NodeWithPath, get_path
 from datachain.query.batch import RowsOutput
 from datachain.query.schema import ColumnMeta
@@ -122,66 +123,53 @@ class AbstractWarehouse(ABC, Serializable):
         # Optimization: Precompute all the column type variables.
         value_type = type(val)
 
-        exc = None
-        try:
-            if col_python_type is list and value_type in (list, tuple, set):
-                if len(val) == 0:
-                    return []
+        if col_python_type is list and value_type in (list, tuple, set):
+            if len(val) == 0:
+                return []
 
-                item_python_type = self.python_type(col_type.item_type)
+            item_python_type = self.python_type(col_type.item_type)
 
-                if item_python_type is not list:
-                    if isinstance(val[0], item_python_type):
-                        # SQLite ARRAY storage expects a list; tuples/sets must be
-                        # converted to lists even when element types already match.
-                        return list(val)
-                    if item_python_type is float and isinstance(val[0], int):
-                        return [float(i) for i in val]
+            if item_python_type is not list:
+                if isinstance(val[0], item_python_type):
+                    # SQLite ARRAY storage expects a list; tuples/sets must be
+                    # converted to lists even when element types already match.
+                    return list(val)
+                if item_python_type is float and isinstance(val[0], int):
+                    return [float(i) for i in val]
 
-                # Optimization: Reuse these values for each function call within the
-                # list comprehension.
-                item_type_info = (
-                    col_type.item_type,
-                    item_python_type,
-                    type(col_type.item_type).__name__,
-                    col_name,
-                )
-                return [self.convert_type(i, *item_type_info) for i in val]
-            # Special use case with JSON type as we save it as string
-            if col_python_type is dict or col_type_name == "JSON":
-                if value_type is str:
-                    return val
-                try:
-                    json_ready = self._to_jsonable(val)
-                    return json.dumps(json_ready, ensure_ascii=False)
-                except Exception as e:
-                    raise ValueError(
-                        f"Cannot convert value {val!r} with type {value_type} to JSON"
-                    ) from e
+            # Optimization: Reuse these values for each function call within the
+            # list comprehension.
+            item_type_info = (
+                col_type.item_type,
+                item_python_type,
+                type(col_type.item_type).__name__,
+                col_name,
+            )
+            return [self.convert_type(i, *item_type_info) for i in val]
 
-            if isinstance(val, col_python_type):
+        # Special use case with JSON type as we save it as string
+        if col_python_type is dict or col_type_name == "JSON":
+            if value_type is str:
                 return val
-            if col_python_type is float and isinstance(val, int):
-                return float(val)
-        except Exception as e:  # noqa: BLE001
-            exc = e
-        ve = ValueError(
+            json_ready = self._to_jsonable(val)
+            try:
+                return json.dumps(json_ready, ensure_ascii=False)
+            except TypeError as e:
+                raise JsonSerializationError(
+                    f"JSON serialization error: {e}",
+                    column_name=col_name,
+                    value=val,
+                ) from e
+
+        if isinstance(val, col_python_type):
+            return val
+        if col_python_type is float and isinstance(val, int):
+            return float(val)
+
+        raise ValueError(
             f"Value {val!r} with type {value_type} incompatible for "
             f"column type {col_type_name}"
         )
-        # This is the same as "from exc" when not raising the exception.
-        if exc:
-            ve.__cause__ = exc
-        # Optimization: Log here, so only one try/except is needed, since the ValueError
-        # above is raised after logging.
-        logger.exception(
-            "Error while validating/converting type for column "
-            "%s with value %s, original error %s",
-            col_name,
-            val,
-            ve,
-        )
-        raise ve
 
     @abstractmethod
     def clone(self, use_new_connection: bool = False) -> "AbstractWarehouse":

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -145,10 +145,10 @@ def read_records(
         {c.name: c.type for c in columns if isinstance(c.type, SQLType)},
     )
 
-    # Automatically flatten DataModel objects in records
     flattened_records = (_flatten_record(record, signal_schema) for record in to_insert)
     records = (
-        adjust_outputs(warehouse, record, col_types) for record in flattened_records
+        adjust_outputs(warehouse, record, col_types, signal_schema)
+        for record in flattened_records
     )
     warehouse.insert_rows(table, records)
     warehouse.insert_rows_done(table)

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -54,6 +54,13 @@ class UdfError(DataChainParamsError):
         return self.__class__, (self.message,)
 
 
+class JsonSerializationError(UdfError):
+    def __init__(self, message: str, column_name: str, value: Any) -> None:
+        self.column_name = column_name
+        self.value = value
+        super().__init__(message)
+
+
 class UdfRunError(Exception):
     """Exception raised when UDF execution fails."""
 

--- a/src/datachain/lib/udf_signature.py
+++ b/src/datachain/lib/udf_signature.py
@@ -66,9 +66,24 @@ class UdfSignature:  # noqa: PLW1641
                 f"UDF '{callable_name(udf_func)}' is not callable",
             )
 
-        func_params_map_sign, func_outs_sign, is_iterator = cls._func_signature(
-            chain, udf_func
+        func_params_map_sign, func_outs_sign, is_iterator, has_return_annotation = (
+            cls._func_signature(chain, udf_func)
         )
+
+        # For generators/aggregators, users must return an Iterator/Generator.
+        # Previously, this validation only happened when `output` was not explicitly
+        # provided, which allowed easy-to-miss return-shape bugs (e.g. returning a
+        # tuple row instead of yielding it).
+        if is_generator and has_return_annotation and not is_iterator:
+            raise UdfSignatureError(
+                chain,
+                (
+                    f"function '{callable_name(udf_func)}' cannot be used in "
+                    "generator/aggregator because it returns a type that is "
+                    "not Iterator/Generator. "
+                    f"Instead, it returns '{func_outs_sign}'"
+                ),
+            )
 
         udf_params: dict[str, DataType | Any] = {}
         if params:
@@ -101,17 +116,6 @@ class UdfSignature:  # noqa: PLW1641
                     chain,
                     "signal name is not specified."
                     " Define it as signal name 's1=func() or in 'output'",
-                )
-
-            if is_generator and not is_iterator:
-                raise UdfSignatureError(
-                    chain,
-                    (
-                        f"function '{callable_name(udf_func)}' cannot be used in "
-                        "generator/aggregator because it returns a type that is "
-                        "not Iterator/Generator. "
-                        f"Instead, it returns '{func_outs_sign}'"
-                    ),
                 )
 
             if isinstance(func_outs_sign, tuple):
@@ -180,7 +184,7 @@ class UdfSignature:  # noqa: PLW1641
     @staticmethod
     def _func_signature(
         chain: str, udf_func: Callable | UDFBase
-    ) -> tuple[dict[str, type], Sequence[type], bool]:
+    ) -> tuple[dict[str, type], Sequence[type], bool, bool]:
         if isinstance(udf_func, AbstractUDF):
             func = udf_func.process  # type: ignore[unreachable]
         else:
@@ -192,6 +196,7 @@ class UdfSignature:  # noqa: PLW1641
         is_iterator = False
 
         anno = sign.return_annotation
+        has_return_annotation = anno != inspect.Signature.empty
         if anno == inspect.Signature.empty:
             output_types: list[type] = []
         else:
@@ -228,4 +233,4 @@ class UdfSignature:  # noqa: PLW1641
         if not output_types:
             output_types = [UdfSignature.DEFAULT_RETURN_TYPE]
 
-        return input_map, output_types, is_iterator
+        return input_map, output_types, is_iterator, has_return_annotation

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -40,7 +40,8 @@ from datachain.func.base import Function
 from datachain.hash_utils import hash_column_elements
 from datachain.lib.listing import is_listing_dataset, listing_dataset_expired
 from datachain.lib.signal_schema import SignalSchema, generate_merge_root_mapping
-from datachain.lib.udf import UDFAdapter, _get_cache
+from datachain.lib.udf import JsonSerializationError, UdfError, _get_cache
+from datachain.lib.utils import type_to_str
 from datachain.progress import CombinedDownloadCallback, TqdmCombinedDownloadCallback
 from datachain.project import Project
 from datachain.query.schema import DEFAULT_DELIMITER, C, UDFParamSpec, normalize_param
@@ -294,6 +295,8 @@ def adjust_outputs(
     warehouse: "AbstractWarehouse",
     row: dict[str, Any],
     col_types: list[tuple[str, SQLType, type, str, Any]],
+    signal_schema: SignalSchema,
+    udf_kind: str | None = None,
 ) -> dict[str, Any]:
     """
     This function does a couple of things to prepare a row for inserting into the db:
@@ -310,17 +313,59 @@ def adjust_outputs(
         col_type_name,
         default_value,
     ) in col_types:
-        row_val = row.get(col_name)
+        # Fill missing values with defaults
+        if col_name not in row:
+            row[col_name] = default_value
+            continue
 
-        # Fill None or missing values with defaults (get returns None if not in the row)
+        row_val = row[col_name]
+
+        # Fill explicit None values with defaults
         if row_val is None:
             row[col_name] = default_value
             continue
 
         # Validate and convert type if needed and possible
-        row[col_name] = warehouse.convert_type(
-            row_val, col_type, col_python_type, col_type_name, col_name
-        )
+        try:
+            row[col_name] = warehouse.convert_type(
+                row_val, col_type, col_python_type, col_type_name, col_name
+            )
+        except Exception as e:
+            expected_type = type_to_str(signal_schema.get_column_type(col_name))
+
+            if isinstance(e, JsonSerializationError):
+                msg = (
+                    f"UDF returned an invalid value for output column {col_name!r}. "
+                    f"Expected JSON-serializable {expected_type}. "
+                    f"{e.message}"
+                )
+            else:
+                actual_type_name = type(row_val).__name__
+                msg = (
+                    f"UDF returned an invalid value for output column {col_name!r}. "
+                    f"Expected {expected_type}, got {row_val!r} "
+                    f"(type: {actual_type_name})."
+                )
+
+            if udf_kind is not None:
+                udf_values = sum(1 for k in row if not str(k).startswith("sys__"))
+                expected = len(col_types)
+                if udf_values != expected:
+                    value_word = "value" if udf_values == 1 else "values"
+                    are_word = "is" if expected == 1 else "are"
+                    msg += (
+                        f" Note: UDF call returned {udf_values} {value_word} "
+                        f"while {expected} {are_word} expected "
+                        f"per output definition"
+                    )
+                    if udf_kind in ("agg", "gen"):
+                        msg += (
+                            f", {udf_kind}() UDFs usually use yield "
+                            "and have return type Iterator."
+                        )
+                    else:
+                        msg += "."
+            raise UdfError(msg) from e
     return row
 
 
@@ -353,6 +398,15 @@ def process_udf_outputs(
 ) -> None:
     # Optimization: Compute row types once, rather than for every row.
     udf_col_types = get_col_types(warehouse, udf.output)
+    udf_signal_schema = udf.inner.output
+
+    # Determine UDF kind based on batching behavior
+    if udf.inner.is_input_batched and udf.inner.is_output_batched:
+        udf_kind = "agg"
+    elif udf.inner.is_output_batched:
+        udf_kind = "gen"
+    else:
+        udf_kind = "map"
 
     def _insert_rows():
         for udf_output in udf_results:
@@ -362,7 +416,13 @@ def process_udf_outputs(
             with safe_closing(udf_output):
                 for row in udf_output:
                     cb.relative_update()
-                    yield adjust_outputs(warehouse, row, udf_col_types)
+                    yield adjust_outputs(
+                        warehouse,
+                        row,
+                        udf_col_types,
+                        udf_signal_schema,
+                        udf_kind=udf_kind,
+                    )
 
     warehouse.insert_rows(udf_table, _insert_rows(), batch_size=batch_size)
     warehouse.insert_rows_done(udf_table)

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -976,10 +976,14 @@ def test_gen_with_new_columns_wrong_type(cloud_test_catalog, dogs_dataset):
     def gen_func():
         yield (0.5)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(dc.DataChainError) as exc_info:
         dc.read_storage(cloud_test_catalog.src_uri, session=session).gen(
             new_val=gen_func, output={"new_val": int}
         ).show()
+    assert "invalid value" in str(exc_info.value)
+    assert "new_val" in str(exc_info.value)
+    assert "Expected int" in str(exc_info.value)
+    assert "got 0.5" in str(exc_info.value)
 
 
 def test_similarity_search(cloud_test_catalog):

--- a/tests/func/test_udf.py
+++ b/tests/func/test_udf.py
@@ -503,9 +503,10 @@ def test_gen_file(cloud_test_catalog, use_cache, prefetch, monkeypatch):
 
         return wrapped
 
-    def new_signal(file: File) -> list[str]:
+    def new_signal(file: File):
         with file.open("rb") as f:
-            return [file.name, f.read().decode("utf-8")]
+            yield file.name
+            yield f.read().decode("utf-8")
 
     chain = (
         dc.read_storage(ctc.src_uri, session=ctc.session)

--- a/tests/unit/lib/test_udf.py
+++ b/tests/unit/lib/test_udf.py
@@ -1,8 +1,10 @@
 import pytest
 from cloudpickle import dumps, loads
 
+import datachain as dc
 from datachain import Mapper
-from datachain.lib.udf import UDFBase, UdfError, UdfRunError
+from datachain.lib.udf import JsonSerializationError, UDFBase, UdfError, UdfRunError
+from datachain.lib.utils import DataChainError
 
 from .test_udf_signature import get_sign
 
@@ -107,3 +109,174 @@ def test_udf_verbose_name_unknown():
     udf = UDFBase._create(sign, sign.output_schema)
     udf._func = None
     assert udf.verbose_name == "<unknown>"
+
+
+def test_udf_output_type_error_message(monkeypatch, test_session):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED", raising=False)
+
+    chain = dc.read_values(a=["ok"], session=test_session)
+
+    with pytest.raises(DataChainError) as excinfo:
+        list(
+            chain.map(
+                measurement_ids=lambda a: "2",
+                params="a",
+                output={"measurement_ids": list[str]},
+            ).to_list()
+        )
+
+    msg = str(excinfo.value)
+
+    # Example message:
+    # UdfError: UDF returned an invalid value for output column 'measurement_ids'.
+    # Expected list[str], got '2' (type: str).
+    assert "invalid value" in msg
+    assert "measurement_ids" in msg
+    assert "Expected list[str]" in msg
+    assert "got '2'" in msg
+    assert "type: str" in msg
+
+
+def test_udf_output_type_error_message_scalar(monkeypatch, test_session):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED", raising=False)
+
+    chain = dc.read_values(a=["ok"], session=test_session)
+
+    with pytest.raises(DataChainError) as excinfo:
+        list(chain.map(my_int=lambda a: "2", params="a", output=int).to_list())
+
+    msg = str(excinfo.value)
+
+    # Example message:
+    # UdfError: UDF returned an invalid value for output column 'my_int'.
+    # Expected int, got '2' (type: str).
+    assert "invalid value" in msg
+    assert "my_int" in msg
+    assert "Expected int" in msg
+    assert "got '2'" in msg
+    assert "type: str" in msg
+
+
+def test_udf_output_type_error_message_includes_missing_outputs(
+    monkeypatch, test_session
+):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED", raising=False)
+
+    chain = dc.read_values(a=["ok"], session=test_session)
+
+    # Output expects two columns, but UDF returns a single scalar.
+    with pytest.raises(DataChainError) as excinfo:
+        list(
+            chain.map(
+                lambda a: "2",
+                params="a",
+                output={"measurement_ids": list[str], "x": int},
+            ).to_list()
+        )
+
+    msg = str(excinfo.value)
+
+    # Example message:
+    # UdfError: UDF returned an invalid value for output column 'measurement_ids'.
+    # Expected list[str], got '2' (type: str). Note: UDF call returned 1 value
+    # while 2 are expected per output definition.
+    assert "measurement_ids" in msg
+    assert "Expected list[str]" in msg
+    assert "UDF call returned 1 value" in msg
+    assert "while 2 are expected per output definition" in msg
+
+
+def test_udf_output_type_error_message_agg_returning_tuple(monkeypatch, test_session):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED", raising=False)
+
+    chain = dc.read_values(a=["ok"], session=test_session)
+
+    # This mirrors an aggregation mistake:
+    # returning a single tuple value instead of yielding rows.
+    def bad_agg(a):
+        return ("2",)
+
+    with pytest.raises(DataChainError) as excinfo:
+        list(
+            chain.agg(
+                func=bad_agg,
+                params="a",
+                output={"measurement_ids": list[str], "x": int},
+            ).to_list()
+        )
+
+    msg = str(excinfo.value)
+
+    # Example message:
+    # UdfError: UDF returned an invalid value for output column 'measurement_ids'.
+    # Expected list[str], got '2' (type: str). Note: UDF call returned 1 value
+    # while 2 are expected per output definition, agg() UDFs usually use yield
+    # and have return type Iterator.
+    assert "measurement_ids" in msg
+    assert "Expected list[str]" in msg
+    assert "got '2'" in msg
+    assert "type: str" in msg
+    assert "UDF call returned 1 value" in msg
+    assert "usually use yield" in msg
+
+
+def test_udf_extra_return_values_are_ignored(monkeypatch, test_session):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED", raising=False)
+
+    chain = dc.read_values(a=["ok"], session=test_session)
+
+    # Current behavior: extra values are truncated by zip(strict=False).
+    out = list(
+        chain.map(
+            lambda a: (1, 2, 3),
+            params="a",
+            output={"x": int, "y": int},
+        ).to_list()
+    )
+
+    assert len(out) == 1
+    # to_list() returns all columns; new columns are appended after inputs.
+    assert out[0][1:] == (1, 2)
+
+
+def test_udf_output_type_error_message_json_serialization_failure(
+    monkeypatch, test_session
+):
+    monkeypatch.delenv("DATACHAIN_DISTRIBUTED", raising=False)
+
+    chain = dc.read_values(a=["ok"], session=test_session)
+
+    # Create an object that can't be serialized to JSON
+    class NonSerializable:
+        pass
+
+    def bad_func(a):
+        return {"key": NonSerializable()}
+
+    with pytest.raises(DataChainError) as exc_info:
+        list(
+            chain.map(
+                bad_func,
+                params="a",
+                output={"data": dict},
+            ).to_list()
+        )
+
+    msg = str(exc_info.value)
+
+    # Example message:
+    # UdfError: UDF returned an invalid value for output column 'data'.
+    # Expected JSON-serializable dict.
+    # JSON serialization error: Object of type NonSerializable is not JSON serializable
+    assert "invalid value" in msg
+    assert "data" in msg
+    assert "JSON-serializable dict" in msg
+    assert "JSON serialization error" in msg
+    assert "not JSON serializable" in msg
+
+    # The exception chain still preserves the underlying error
+    # UdfError -> JsonSerializationError -> TypeError
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, JsonSerializationError)
+    assert exc_info.value.__cause__.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__.__cause__, TypeError)

--- a/tests/unit/lib/test_udf_signature.py
+++ b/tests/unit/lib/test_udf_signature.py
@@ -209,3 +209,20 @@ def test_unparameterized_iterator_defaults_to_str():
 
     sign = get_sign(s1=iter_func)
     assert sign.output_schema.values == {"s1": str}
+
+
+def test_generator_requires_iterator_return_annotation_even_with_output_override():
+    def not_iter(p1) -> tuple[int, int]:
+        return (1, 2)
+
+    with pytest.raises(
+        UdfSignatureError, match="cannot be used in generator/aggregator"
+    ):
+        UdfSignature.parse(
+            "test",
+            {},
+            not_iter,
+            None,
+            {"a": int, "b": int},
+            True,
+        )

--- a/tests/unit/lib/test_utils.py
+++ b/tests/unit/lib/test_utils.py
@@ -24,7 +24,10 @@ from datachain.lib.utils import (
     rebase_path,
     type_to_str,
 )
-from datachain.sql.types import Array, String
+from datachain.sql.types import (
+    Array,
+    String,
+)
 
 
 class MyModel(BaseModel):


### PR DESCRIPTION
Improving error message on UDF failure.

```
    UdfError: UDF returned an invalid value for output column 'measurement_ids'.
    Expected list[str], got '2' (type: str). Note: UDF call returned 1 value
    while 2 are expected per output definition, agg() UDFs usually use yield
    and have return type Iterator.
```

vs something like this:

```  
ValueError: Value '2' with type <class 'str'> incompatible for column type Array
```