### PR TITLE
Using exact ffmpeg version to avoid 504 errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Install FFmpeg on Windows
         if: runner.os == 'Windows'
-        run: choco install ffmpeg --version 7.0
+        run: choco install ffmpeg --version 7.0.2
 
       - name: Install FFmpeg on macOS
         if: runner.os == 'macOS'


### PR DESCRIPTION
Trying to fix 504 error when installing ffmpeg for windows in test worfklow

Error was found in this action https://github.com/datachain-ai/datachain/actions/runs/21244822862/job/61136347812

```
Run choco install ffmpeg --version 7.0
Chocolatey v2.6.0
Installing the following packages:
ffmpeg
By installing, you accept licenses for the packages.
Unable to connect to source 'https://community.chocolatey.org/api/v2/':
 Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(Id='ffmpeg',Version='7.0.0')' with following message : Response status code does not indicate success: 504 (Gateway Time-out).
ffmpeg not installed. The package was not found with the source(s) listed.
 Source(s): 'https://community.chocolatey.org/api/v2/'
 NOTE: When you specify explicit sources, it overrides default sources.
If the package version is a prerelease and you didn't specify `--pre`,
 the package may not be found.
Version was specified as '7.0'. It is possible that version
 does not exist for 'ffmpeg' at the source specified.
Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 assistance.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - ffmpeg - ffmpeg not installed. The package was not found with the source(s) listed.
 Source(s): 'https://community.chocolatey.org/api/v2/'
 NOTE: When you specify explicit sources, it overrides default sources.
If the package version is a prerelease and you didn't specify `--pre`,
 the package may not be found.
Version was specified as '7.0'. It is possible that version
 does not exist for 'ffmpeg' at the source specified.
Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 assistance.
```