### PR TITLE
improve --env handling in CLI job run

### DIFF
--- a/docs/commands/job/run.md
+++ b/docs/commands/job/run.md
@@ -74,7 +74,16 @@ datachain job run --workers 4 --files utils.py config.json query.py
 datachain job run --env API_KEY=123 --req pandas numpy query.py
 ```
 
-6. Run a job with a repository (will be cloned in the job working directory):
+6. Run a job with multiple environment variables:
+```bash
+# Multiple vars in a single --env
+datachain job run --env API_KEY=123 REGION=us-east-1 query.py
+
+# Multiple --env flags
+datachain job run --env API_KEY=123 --env REGION=us-east-1 query.py
+```
+
+7. Run a job with a repository (will be cloned in the job working directory):
 ```bash
 datachain job run --repository https://github.com/datachain-ai/datachain query.py
 
@@ -85,7 +94,7 @@ datachain job run --repository https://github.com/datachain-ai/datachain@main qu
 datachain job run --repository git@github.com:datachain-ai/datachain.git@main query.py
 ```
 
-7. Run a job with higher priority
+8. Run a job with higher priority
 ```bash
 datachain job run --priority 2 query.py
 ```

--- a/src/datachain/cli/parser/job.py
+++ b/src/datachain/cli/parser/job.py
@@ -53,6 +53,7 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
     studio_run_parser.add_argument(
         "--env",
         nargs="+",
+        action="append",
         help="Environment variables in KEY=VALUE format",
     )
 

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -17,7 +17,7 @@ from datachain.dataset import (
 )
 from datachain.error import DataChainError
 from datachain.remote.studio import StudioClient
-from datachain.utils import STUDIO_URL
+from datachain.utils import STUDIO_URL, flatten
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -444,7 +444,8 @@ def create_job(
     with open(query_file) as f:
         query = f.read()
 
-    environment = "\n".join(env) if env else ""
+    env_values = list(flatten(env)) if env else []
+    environment = "\n".join(env_values) if env_values else ""
     if env_file:
         with open(env_file) as f:
             environment = f.read() + "\n" + environment

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -390,6 +390,9 @@ def test_studio_run(capsys, mocker, tmp_dir):
                     "env_file.txt",
                     "--env",
                     "ENV_FROM_ARGS=1",
+                    "--env",
+                    "ENV2=2",
+                    "ENV3=3",
                     "--workers",
                     "2",
                     "--files",
@@ -437,7 +440,7 @@ def test_studio_run(capsys, mocker, tmp_dir):
     assert second_request.json() == {
         "query": "print(1)",
         "query_type": "PYTHON",
-        "environment": "ENV_FROM_FILE=1\nENV_FROM_ARGS=1",
+        "environment": "ENV_FROM_FILE=1\nENV_FROM_ARGS=1\nENV2=2\nENV3=3",
         "workers": 2,
         "query_name": "example_query.py",
         "files": ["1"],


### PR DESCRIPTION
Now we can pass:

```
--env something=value \
--env something_else=value1
```

to `datachain job run` - it confused me, it confused AI, etc (it was silently just using the last entry)
