### PR TITLE
Lock torchcodec dependency to version <0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ hf = [
   "torch<2.10.0 ; (sys_platform == 'linux' or sys_platform == 'darwin')",
   # Pin torchcodec due to compatibility issues with version 0.10.0+
   # See test_hf_audio failures in SaaS, re-enable when resolved
-  "torchcodec<0.10.0"
+  "torchcodec<0.10.0 ; (sys_platform == 'linux' or sys_platform == 'darwin')"
 ]
 video = [
   "ffmpeg-python",


### PR DESCRIPTION
`torchcodec` version `0.10.0` was released Jan 22, 2026. SaaS tests are now failing. Lock dependency until fix.