### PR TITLE
fix(udf): fix errors pickling / unpicking to show proper messages

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -169,7 +169,7 @@ class AbstractWarehouse(ABC, Serializable):
                 raise JsonSerializationError(
                     f"JSON serialization error: {e}",
                     column_name=col_name,
-                    value=val,
+                    value_repr=repr(val),
                 ) from e
 
         if isinstance(val, col_python_type):

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -49,16 +49,18 @@ class UdfError(DataChainParamsError):
     def __str__(self) -> str:
         return f"{self.__class__.__name__!s}: {self.message!s}"
 
-    def __reduce__(self):
-        """Custom reduce method for pickling."""
+    def __reduce__(self) -> tuple[type, tuple]:
         return self.__class__, (self.message,)
 
 
 class JsonSerializationError(UdfError):
-    def __init__(self, message: str, column_name: str, value: Any) -> None:
+    def __init__(self, message: str, column_name: str, value_repr: str) -> None:
         self.column_name = column_name
-        self.value = value
+        self.value_repr = value_repr
         super().__init__(message)
+
+    def __reduce__(self) -> tuple[type, tuple]:
+        return self.__class__, (self.message, self.column_name, self.value_repr)
 
 
 class UdfRunError(Exception):
@@ -82,7 +84,7 @@ class UdfRunError(Exception):
             return f"{self.error.__class__.__name__!s}: {self.error!s}"
         return f"{self.__class__.__name__!s}: {self.error!s}"
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[type, tuple]:
         """Custom reduce method for pickling."""
         return self.__class__, (self.error, self.stacktrace, self.udf_name)
 


### PR DESCRIPTION
Fixes error handing in `setup()` and in some other case. 

We don't really show error message now if setup fails in distributed / parallel mode. We show some ugly pickle error since it can't restore the error properly.