### PR TITLE
fix: replace 2 bare excepts with except Exception

### DIFF
--- a/src/datachain/asyn.py
+++ b/src/datachain/asyn.py
@@ -126,7 +126,7 @@ class AsyncMapper(Generic[InputT, ResultT]):
             )
             self.gather_exceptions(done)
             assert join.done()
-        except:
+        except Exception:
             await self.cancel_all()
             await self._break_iteration()
             raise

--- a/src/datachain/nodes_thread_pool.py
+++ b/src/datachain/nodes_thread_pool.py
@@ -96,7 +96,7 @@ class NodesThreadPool(ABC):
 
                 self.tasks = self.tasks - done
                 self.update_progress_bar(progress_bar)
-        except:
+        except Exception:
             self.cancel_all()
             raise
         else:


### PR DESCRIPTION
Replace 2 bare `except:` with `except Exception:`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.