### PR TITLE
docs: add version check to quick start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,6 +18,13 @@ title: Quick Start
     uv add datachain
     ```
 
+## Version check
+
+```py
+import datachain
+
+print(datachain.__version__)
+```
 
 ## Selecting files using JSON metadata
 


### PR DESCRIPTION
## Summary
- add a short "Version check" snippet to `docs/quick-start.md`
- show how to verify installed version via `datachain.__version__`

## Why
Users often validate installation before running examples; this provides a quick, explicit check in the quick-start flow.

## Testing
- [x] docs-only change
