### PR TITLE
docs: fix Mistral client usage in quick-start example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -163,6 +163,8 @@ structure (class `ChatCompletionResponse`), DataChain can
 serialize the entire LLM response to the internal DB:
 
 ``` py
+import os
+
 from mistralai import Mistral
 from mistralai.models import ChatCompletionResponse
 import datachain as dc
@@ -170,8 +172,8 @@ import datachain as dc
 PROMPT = "Was this dialog successful? Answer in a single word: Success or Failure."
 
 def eval_dialog(file: dc.File) -> ChatCompletionResponse:
-     client = MistralClient()
-     return client.chat(
+     client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+     return client.chat.complete(
          model="open-mixtral-8x22b",
          messages=[{"role": "system", "content": PROMPT},
                    {"role": "user", "content": file.read()}])


### PR DESCRIPTION
## Summary
- fix the quick-start "Serializing Python-objects" snippet to use `Mistral(...)` consistently
- replace `client.chat(...)` with `client.chat.complete(...)` to match current SDK usage in this doc
- add missing `import os` for `MISTRAL_API_KEY`

## Why
The existing snippet used `MistralClient()` without import and mixed API styles, which can confuse users copying the example.

## Testing
- [x] docs-only change
