### PR TITLE
docs: clean up wording in serialization section

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -153,10 +153,10 @@ $ ls output_mistral/datachain-demo/chatbot-KiT/ | wc -l
 31
 ```
 
-## Serializing Python-objects
+## Serializing Python objects
 
-LLM responses may contain valuable information for analytics -- such as
-the number of tokens used, or the model performance parameters.
+LLM responses may contain valuable information for analytics, such as
+the number of tokens used or the model performance parameters.
 
 Instead of extracting this information from the Mistral response data
 structure (class `ChatCompletionResponse`), DataChain can


### PR DESCRIPTION
## Summary
- rename section title `Serializing Python-objects` to `Serializing Python objects`
- simplify punctuation and wording in the opening sentence

## Why
Small readability cleanup in a frequently read quick-start section.

## Testing
- [x] docs-only change
