### PR TITLE
docs: fix PyTorch and TensorFlow capitalization

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ database for easy and efficient querying.
         embeddings.
     -   High-performance vectorized operations on Python objects: sum,
         count, avg, etc.
-    -   Pass datasets to Pytorch and Tensorflow, or export them back
+    -   Pass datasets to PyTorch and TensorFlow, or export them back
         into storage.
 
 


### PR DESCRIPTION
## Summary
- fix framework name capitalization in `docs/index.md`
- update `Pytorch` -> `PyTorch`
- update `Tensorflow` -> `TensorFlow`

## Why
Matches official framework naming and improves docs polish.

## Testing
- [x] docs-only change
