### PR TITLE
docs: fix PyTorch spelling in examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -260,7 +260,7 @@ For in-depth review of working with JSON metadata, please follow this tutorial:
 
 ### Passing data to training
 
-Chain results can be exported or passed directly to Pytorch dataloader. For example, if we are interested in passing three columns to training, the following Pytorch code will do it:
+Chain results can be exported or passed directly to a PyTorch dataloader. For example, if we are interested in passing three columns to training, the following PyTorch code will do it:
 
 ```python
 


### PR DESCRIPTION
## Summary
- fix `Pytorch` spelling in `docs/examples.md`
- update wording to `a PyTorch dataloader`

## Why
Uses official framework naming and improves documentation clarity.

## Testing
- [x] docs-only change
