### PR TITLE
docs: fix DataFrame capitalization

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ database for easy and efficient querying.
     including LLMs.
 2.  **Analytics.** DataChain dataset is a table that combines all the
     information about data objects in one place + it provides
-    dataframe-like API and vectorized engine to do analytics on these
+    DataFrame-like API and vectorized engine to do analytics on these
     tables at scale.
 3.  **Versioning.** DataChain doesn't store, require moving or copying
     data. Perfect use case is a bucket with thousands or millions of


### PR DESCRIPTION
## Summary
- fix DataFrame capitalization in `docs/index.md`
- update `dataframe-like` -> `DataFrame-like` to match pandas naming convention

## Why
Uses the proper capitalization for pandas DataFrame API references.

## Testing
- [x] docs-only change
