### PR TITLE
Remove outdated 'uri' param from Metastore constructor

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -54,7 +54,6 @@ from datachain.dataset import (
     DatasetRecord,
     DatasetStatus,
     DatasetVersion,
-    StorageURI,
     parse_schema,
 )
 from datachain.error import (
@@ -96,8 +95,6 @@ class AbstractMetastore(ABC, Serializable):
     This manages the storing, searching, and retrieval of indexed metadata.
     """
 
-    uri: StorageURI
-
     schema: "schema.Schema"
     namespace_class: type[Namespace] = Namespace
     project_class: type[Project] = Project
@@ -111,12 +108,6 @@ class AbstractMetastore(ABC, Serializable):
     checkpoint_class: type[Checkpoint] = Checkpoint
     checkpoint_event_class: type[CheckpointEvent] = CheckpointEvent
 
-    def __init__(
-        self,
-        uri: StorageURI | None = None,
-    ):
-        self.uri = uri or StorageURI("")
-
     def __enter__(self) -> Self:
         """Returns self upon entering context manager."""
         return self
@@ -127,10 +118,9 @@ class AbstractMetastore(ABC, Serializable):
     @abstractmethod
     def clone(
         self,
-        uri: StorageURI | None = None,
         use_new_connection: bool = False,
     ) -> "AbstractMetastore":
-        """Clones AbstractMetastore implementation for some Storage input.
+        """Clones AbstractMetastore implementation.
         Setting use_new_connection will always use a new database connection.
         New connections should only be used if needed due to errors with
         closed connections."""
@@ -684,10 +674,6 @@ class AbstractDBMetastore(AbstractMetastore):
     CHECKPOINT_EVENTS_TABLE = "checkpoint_events"
 
     db: "DatabaseEngine"
-
-    def __init__(self, uri: StorageURI | None = None):
-        uri = uri or StorageURI("")
-        super().__init__(uri)
 
     def close(self) -> None:
         """Closes any active database connections."""

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -448,14 +448,11 @@ class SQLiteMetastore(AbstractDBMetastore):
 
     def __init__(
         self,
-        uri: StorageURI | None = None,
         db: SQLiteDatabaseEngine | None = None,
         db_file: str | None = None,
         in_memory: bool = False,
     ):
-        uri = uri or StorageURI("")
         self.schema: DefaultSchema = DefaultSchema()
-        super().__init__(uri)
 
         # needed for dropping tables in correct order for tests because of
         # foreign keys
@@ -478,14 +475,9 @@ class SQLiteMetastore(AbstractDBMetastore):
 
     def clone(
         self,
-        uri: StorageURI | None = None,
         use_new_connection: bool = False,
     ) -> "SQLiteMetastore":
-        uri = uri or StorageURI("")
-        if not uri and self.uri:
-            uri = self.uri
-
-        return SQLiteMetastore(uri=uri, db=self.db.clone())
+        return SQLiteMetastore(db=self.db.clone())
 
     def clone_params(self) -> tuple[Callable[..., Any], list[Any], dict[str, Any]]:
         """
@@ -496,7 +488,6 @@ class SQLiteMetastore(AbstractDBMetastore):
             SQLiteMetastore.init_after_clone,
             [],
             {
-                "uri": self.uri,
                 "db_clone_params": self.db.clone_params(),
             },
         )
@@ -509,11 +500,10 @@ class SQLiteMetastore(AbstractDBMetastore):
     def init_after_clone(
         cls,
         *,
-        uri: StorageURI,
         db_clone_params: tuple[Callable, list, dict[str, Any]],
     ) -> "SQLiteMetastore":
         (db_class, db_args, db_kwargs) = db_clone_params
-        return cls(uri=uri, db=db_class(*db_args, **db_kwargs))
+        return cls(db=db_class(*db_args, **db_kwargs))
 
     @cached_property
     def _meta(self) -> Table:

--- a/tests/unit/test_catalog_loader.py
+++ b/tests/unit/test_catalog_loader.py
@@ -14,7 +14,6 @@ from datachain.data_storage.sqlite import (
     SQLiteMetastore,
     SQLiteWarehouse,
 )
-from datachain.dataset import StorageURI
 
 
 class DistributedClass:
@@ -23,11 +22,8 @@ class DistributedClass:
 
 
 def test_get_metastore(sqlite_db):
-    uri = StorageURI("s3://bucket")
-
-    metastore = SQLiteMetastore(uri, sqlite_db.clone())
+    metastore = SQLiteMetastore(db=sqlite_db.clone())
     try:
-        assert metastore.uri == uri
         assert metastore.db.db_file == sqlite_db.db_file
 
         with patch.dict(os.environ, {"DATACHAIN__METASTORE": metastore.serialize()}):
@@ -35,7 +31,6 @@ def test_get_metastore(sqlite_db):
             try:
                 assert metastore2
                 assert isinstance(metastore2, SQLiteMetastore)
-                assert metastore2.uri == uri
                 assert metastore2.db.db_file == sqlite_db.db_file
                 assert metastore2.clone_params() == metastore.clone_params()
             finally:
@@ -146,8 +141,7 @@ def test_get_distributed_class(monkeypatch):
 
 
 def test_get_catalog(sqlite_db):
-    uri = StorageURI("s3://bucket")
-    metastore = SQLiteMetastore(uri, sqlite_db.clone())
+    metastore = SQLiteMetastore(db=sqlite_db.clone())
     warehouse = SQLiteWarehouse(sqlite_db.clone())
     env = {
         "DATACHAIN__METASTORE": metastore.serialize(),
@@ -161,7 +155,6 @@ def test_get_catalog(sqlite_db):
 
             assert catalog.metastore
             assert isinstance(catalog.metastore, SQLiteMetastore)
-            assert catalog.metastore.uri == uri
             assert catalog.metastore.db.db_file == sqlite_db.db_file
             assert catalog.metastore.clone_params() == metastore.clone_params()
 

--- a/tests/unit/test_metastore.py
+++ b/tests/unit/test_metastore.py
@@ -5,23 +5,18 @@ import pytest
 
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SCHEMA_VERSION, SQLiteMetastore
-from datachain.dataset import StorageURI
 from datachain.error import OutdatedDatabaseSchemaError
 from tests.conftest import cleanup_sqlite_db
 
 
 def test_sqlite_metastore(sqlite_db):
-    uri = StorageURI("s3://bucket")
-
-    obj = SQLiteMetastore(uri, sqlite_db)
-    assert obj.uri == uri
+    obj = SQLiteMetastore(db=sqlite_db)
     assert obj.db == sqlite_db
 
     # Test clone
     obj2 = obj.clone()
     try:
         assert isinstance(obj2, SQLiteMetastore)
-        assert obj2.uri == uri
         assert obj2.db.db_file == sqlite_db.db_file
         assert obj2.clone_params() == obj.clone_params()
 
@@ -32,7 +27,6 @@ def test_sqlite_metastore(sqlite_db):
         data = json.loads(raw.decode())
         assert data["callable"] == "sqlite.metastore.init_after_clone"
         assert data["args"] == []
-        assert data["kwargs"]["uri"] == uri
         nested = data["kwargs"]["db_clone_params"]
         assert nested["callable"] == "sqlite.from_db_file"
         assert nested["args"] == [":memory:"]
@@ -41,7 +35,6 @@ def test_sqlite_metastore(sqlite_db):
         obj3 = deserialize(serialized)
         try:
             assert isinstance(obj3, SQLiteMetastore)
-            assert obj3.uri == uri
             assert obj3.db.db_file == sqlite_db.db_file
             assert obj3.clone_params() == obj.clone_params()
         finally:


### PR DESCRIPTION
Follow-up for the https://github.com/datachain-ai/datachain/pull/544

After partial tables support was removed, `uri` param in Metastore constructor is obsolete.