### PR TITLE
Fixing output when using progress bar in REPL

### DIFF
--- a/src/datachain/cache.py
+++ b/src/datachain/cache.py
@@ -84,7 +84,7 @@ class Cache:  # noqa: PLW1641
         size = file.size
         if size < 0:
             size = await client.get_size(from_path, version_id=file.version)
-        from tqdm.auto import tqdm
+        from datachain.progress import tqdm
 
         cb = callback or TqdmCallback(
             tqdm_kwargs={"desc": odb_fs.name(from_path), "bytes": True, "leave": False},

--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -22,7 +22,6 @@ else:
 
 import sqlalchemy as sa
 from sqlalchemy import Column
-from tqdm.auto import tqdm
 
 from datachain.cache import Cache
 from datachain.checkpoint import Checkpoint, CheckpointStatus
@@ -53,6 +52,7 @@ from datachain.error import (
 from datachain.lib.listing import get_listing
 from datachain.node import DirType, Node, NodeWithPath
 from datachain.nodes_thread_pool import NodesThreadPool
+from datachain.progress import tqdm
 from datachain.project import Project
 from datachain.sql.types import DateTime, SQLType
 from datachain.utils import DataChainDir, DatasetIdentifier, interprocess_file_lock

--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -2,9 +2,9 @@ from typing import Any
 from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 from adlfs import AzureBlobFileSystem
-from tqdm.auto import tqdm
 
 from datachain.lib.file import File
+from datachain.progress import tqdm
 
 from .fsspec import DELIMITER, Client, ResultQueue
 

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -16,12 +16,12 @@ from urllib.parse import urlparse
 from dvc_objects.fs.system import reflink
 from fsspec.asyn import get_loop, sync
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
-from tqdm.auto import tqdm
 
 from datachain.cache import Cache
 from datachain.client.fileslice import FileWrapper
 from datachain.nodes_fetcher import NodesFetcher
 from datachain.nodes_thread_pool import NodeChunk
+from datachain.progress import tqdm
 
 if TYPE_CHECKING:
     from fsspec.spec import AbstractFileSystem

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -7,9 +7,9 @@ from typing import Any, cast
 
 from dateutil.parser import isoparse
 from gcsfs import GCSFileSystem
-from tqdm.auto import tqdm
 
 from datachain.lib.file import File
+from datachain.progress import tqdm
 
 from .fsspec import DELIMITER, Client, ResultQueue
 

--- a/src/datachain/client/s3.py
+++ b/src/datachain/client/s3.py
@@ -5,9 +5,9 @@ from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 from botocore.exceptions import NoCredentialsError
 from s3fs import S3FileSystem
-from tqdm.auto import tqdm
 
 from datachain.lib.file import File
+from datachain.progress import tqdm
 
 from .fsspec import DELIMITER, Client, ResultQueue
 

--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -23,7 +23,6 @@ from sqlalchemy.sql import func
 from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList
 from sqlalchemy.sql.expression import bindparam, cast
 from sqlalchemy.sql.selectable import Select
-from tqdm.auto import tqdm
 
 import datachain.sql.sqlite
 from datachain.data_storage import AbstractDBMetastore, AbstractWarehouse
@@ -37,6 +36,7 @@ from datachain.error import (
     TableMissingError,
 )
 from datachain.namespace import Namespace
+from datachain.progress import tqdm
 from datachain.project import Project
 from datachain.sql.sqlite import create_user_defined_sql_functions, sqlite_dialect
 from datachain.sql.sqlite.base import load_usearch_extension

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 import pyarrow as pa
 from pyarrow._csv import ParseOptions
 from pyarrow.dataset import CsvFileFormat, dataset
-from tqdm.auto import tqdm
 
 from datachain import json
 from datachain.fs.reference import ReferenceFileSystem
@@ -15,6 +14,7 @@ from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.udf import Generator
 from datachain.lib.utils import normalize_col_names
+from datachain.progress import tqdm
 
 if TYPE_CHECKING:
     from datasets.features.features import Features

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -19,7 +19,6 @@ from typing import (
 import sqlalchemy
 from pydantic import BaseModel
 from sqlalchemy.sql.elements import ColumnElement
-from tqdm import tqdm
 
 from datachain import json, semver
 from datachain.checkpoint_event import CheckpointEventType, CheckpointStepType
@@ -53,6 +52,7 @@ from datachain.lib.signal_schema import (
 from datachain.lib.udf import Aggregator, BatchMapper, Generator, Mapper, UDFBase
 from datachain.lib.udf_signature import UdfSignature
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
+from datachain.progress import tqdm
 from datachain.project import Project
 from datachain.query import Session
 from datachain.query.dataset import (

--- a/src/datachain/lib/hf.py
+++ b/src/datachain/lib/hf.py
@@ -29,12 +29,12 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 import PIL
-from tqdm.auto import tqdm
 
 from datachain.lib.arrow import arrow_type_mapper
 from datachain.lib.data_model import DataModel, DataType, dict_to_data_model
 from datachain.lib.udf import Generator
 from datachain.lib.utils import normalize_col_names
+from datachain.progress import tqdm
 
 if TYPE_CHECKING:
     import pyarrow as pa

--- a/src/datachain/listing.py
+++ b/src/datachain/listing.py
@@ -12,9 +12,9 @@ else:
 
 from sqlalchemy import Column
 from sqlalchemy.sql import func
-from tqdm.auto import tqdm
 
 from datachain.node import DirType, Node, NodeWithPath
+from datachain.progress import tqdm
 from datachain.sql.functions import path as pathfunc
 from datachain.utils import suffix_to_number
 

--- a/src/datachain/progress.py
+++ b/src/datachain/progress.py
@@ -1,5 +1,27 @@
 from fsspec import Callback
 from fsspec.callbacks import TqdmCallback
+from tqdm.auto import tqdm as _tqdm
+
+
+class Tqdm(_tqdm):
+    """tqdm subclass that erases residual characters on close.
+
+    When tqdm clears a bar (leave=False), it writes \\r + spaces + \\r.
+    The space characters remain on the terminal line and corrupt subsequent
+    output such as the Python REPL prompt or DataFrame text (#1581).
+    Writing the ANSI "Erase in Line" sequence after close removes them.
+    """
+
+    def close(self):
+        was_enabled = not self.disable
+        super().close()
+        if was_enabled:
+            self.fp.write("\r\033[K")
+            self.fp.flush()
+
+
+# Alias for drop-in replacement of tqdm imports
+tqdm = Tqdm
 
 
 class CombinedDownloadCallback(Callback):

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -26,7 +26,6 @@ from sqlalchemy.sql.elements import ColumnClause, ColumnElement, Label
 from sqlalchemy.sql.expression import label
 from sqlalchemy.sql.schema import TableClause
 from sqlalchemy.sql.selectable import Select
-from tqdm.auto import tqdm
 
 from datachain.asyn import ASYNC_WORKERS, AsyncMapper, OrderedMapper
 from datachain.catalog.catalog import clone_catalog_with_cache
@@ -54,7 +53,11 @@ from datachain.lib.listing import is_listing_dataset, listing_dataset_expired
 from datachain.lib.signal_schema import SignalSchema, generate_merge_root_mapping
 from datachain.lib.udf import JsonSerializationError, UdfError, _get_cache
 from datachain.lib.utils import type_to_str
-from datachain.progress import CombinedDownloadCallback, TqdmCombinedDownloadCallback
+from datachain.progress import (
+    CombinedDownloadCallback,
+    TqdmCombinedDownloadCallback,
+    tqdm,
+)
 from datachain.project import Project
 from datachain.query.schema import DEFAULT_DELIMITER, C, UDFParamSpec, normalize_param
 from datachain.query.session import Session

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -495,6 +495,15 @@ def test_to_storage_files_filename_placement_not_unique_files(tmp_dir, test_sess
         df.to_storage(tmp_dir / "output", placement="filename")
 
 
+def test_progress_bar_cleanup(capsys, test_session):
+    """tqdm bars should erase residual chars after closing (#1581)."""
+    dc.read_values(val=[1, 2, 3], session=test_session).map(
+        doubled=lambda val: val * 2, output=int
+    ).to_pandas()
+    captured = capsys.readouterr()
+    assert "\033[K" in captured.err
+
+
 def test_show(capsys, test_session):
     first_name = ["Alice", "Bob", "Charlie"]
     dc.read_values(


### PR DESCRIPTION
When tqdm closes a bar with `leave=False`, it "erases" it by writing `\r` + spaces + `\r` to stderr. The cursor returns to column 0, but the space characters remain on the terminal line. Any subsequent output (DataFrame text from `show()`, or the `>>>` REPL
prompt) only overwrites as many characters as it writes — the rest of the spaces stay, producing visible corruption like  `Prvalsdoubledrows [00:00, ? rows/s]` or `>>>                               `.                                                 

Added a `Tqdm` subclass in `src/datachain/progress.py` that overrides `close()` to write the ANSI "Erase in Line" sequence (`\r\033[K`) after the bar is cleared, which properly removes the residual characters. 
Replaced all `from tqdm.auto import tqdm` imports across the codebase (11 files) with `from datachain.progress import tqdm`, so any future tqdm usage automatically gets
the fix.