### PR TITLE
Make `read_records` return deterministic hash

### DIFF
--- a/src/datachain/hash_utils.py
+++ b/src/datachain/hash_utils.py
@@ -67,6 +67,49 @@ def serialize_column_element(expr: str | ColumnElement) -> dict:
     return {"type": "other", "repr": str(expr)}
 
 
+def _normalize_for_hash(val):
+    """Normalize a value for deterministic JSON serialization."""
+    from pydantic import BaseModel
+
+    if val is None or isinstance(val, (str, int, float, bool)):
+        return val
+    if isinstance(val, BaseModel):
+        return val.model_dump()
+    if isinstance(val, dict):
+        return {k: _normalize_for_hash(v) for k, v in sorted(val.items())}
+    if isinstance(val, (list, tuple)):
+        return [_normalize_for_hash(v) for v in val]
+    return str(val)
+
+
+def hash_data(records: "Sequence[dict]") -> str:
+    """Compute a deterministic streaming SHA256 hash from a sequence of record dicts.
+
+    Each record is serialized individually and fed to the hasher incrementally,
+    so memory usage is constant regardless of the number of records.
+    """
+    h = hashlib.sha256()
+    for record in records:
+        normalized = {k: _normalize_for_hash(v) for k, v in sorted(record.items())}
+        h.update(json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode())
+    return h.hexdigest()
+
+
+def hash_values(**fr_map) -> str:
+    """Compute a deterministic streaming SHA256 hash from keyword-argument value
+    sequences, as used by read_values().
+    """
+    h = hashlib.sha256()
+    for key in sorted(fr_map):
+        h.update(key.encode())
+        for val in fr_map[key]:
+            normalized = _normalize_for_hash(val)
+            h.update(
+                json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode()
+            )
+    return h.hexdigest()
+
+
 def hash_column_elements(columns: ColumnLike | Sequence[ColumnLike]) -> str:
     """
     Hash a list of ColumnElements deterministically, dialect agnostic.

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -5,6 +5,7 @@ import sqlalchemy
 from pydantic import BaseModel
 
 from datachain.dataset import DatasetStatus
+from datachain.hash_utils import hash_data
 from datachain.lib.convert.flatten import flatten
 from datachain.lib.data_model import DataType
 from datachain.lib.model_store import ModelStore
@@ -135,6 +136,11 @@ def read_records(
     elif not to_insert:
         to_insert = []
 
+    # Compute content hash for concrete data (lists)
+    content_hash = None
+    if isinstance(to_insert, list):
+        content_hash = hash_data(to_insert)
+
     warehouse = catalog.warehouse
     dr = warehouse.dataset_rows(dsr)
     table = dr.get_table()
@@ -158,4 +164,7 @@ def read_records(
         dsr, DatasetStatus.COMPLETE, version=dsr.latest_version
     )
 
-    return read_dataset(name=dsr.full_name, session=session, settings=settings)
+    chain = read_dataset(name=dsr.full_name, session=session, settings=settings)
+    if content_hash:
+        chain._query._content_hash = content_hash
+    return chain

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -136,11 +136,6 @@ def read_records(
     elif not to_insert:
         to_insert = []
 
-    # Compute content hash for concrete data (lists)
-    content_hash = None
-    if isinstance(to_insert, list):
-        content_hash = hash_data(to_insert)
-
     warehouse = catalog.warehouse
     dr = warehouse.dataset_rows(dsr)
     table = dr.get_table()
@@ -165,6 +160,6 @@ def read_records(
     )
 
     chain = read_dataset(name=dsr.full_name, session=session, settings=settings)
-    if content_hash:
-        chain._query._content_hash = content_hash
+    if isinstance(to_insert, list):
+        chain._query._content_hash = hash_data(to_insert)
     return chain

--- a/src/datachain/lib/dc/values.py
+++ b/src/datachain/lib/dc/values.py
@@ -32,6 +32,8 @@ def read_values(
         dc.read_values(fib=[1, 2, 3, 5, 8])
         ```
     """
+    from datachain.hash_utils import hash_values as _hash_values
+
     tuple_type, output, tuples = values_to_tuples(ds_name, output, **fr_map)
 
     def _func_fr() -> Iterator[tuple_type]:  # type: ignore[valid-type]
@@ -48,6 +50,8 @@ def read_values(
         settings=settings,
         in_memory=in_memory,
     )
+    # Override seed-data hash with actual input data hash
+    chain._query._content_hash = _hash_values(**fr_map)
     if column:
         output = {column: dict_to_data_model(column, output)}  # type: ignore[arg-type]
     return chain.gen(_func_fr, output=output)

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -2147,6 +2147,7 @@ class DatasetQuery:
         self.listing_fn: Callable | None = None
         self.update = update
         self.checkpoints_enabled: bool = True
+        self._content_hash: str | None = None
 
         self.list_ds_name: str | None = None
 
@@ -2192,6 +2193,8 @@ class DatasetQuery:
 
     @property
     def _starting_step_hash(self) -> str:
+        if self._content_hash:
+            return self._content_hash
         if self.starting_step:
             return self.starting_step.hash()
         assert self.list_ds_name

--- a/tests/unit/test_datachain_hash.py
+++ b/tests/unit/test_datachain_hash.py
@@ -60,12 +60,24 @@ def mock_get_listing():
         yield mock
 
 
+def test_read_records_list():
+    assert (
+        dc.read_records([{"x": 1}, {"x": 2}], schema={"x": int}).hash()
+        == "72b7a8f063617534dd32b1a4682b194af023d770be7ae77dca0ac51cfcebc133"
+    )
+
+
+def test_read_records_generator():
+    """Generators cannot be hashed deterministically yet (known limitation)."""
+    h1 = dc.read_records(({"x": i} for i in range(3)), schema={"x": int}).hash()
+    h2 = dc.read_records(({"x": i} for i in range(3)), schema={"x": int}).hash()
+    assert h1 != h2
+
+
 def test_read_values():
-    """
-    Hash of the chain started with read_values is currently inconsistent.
-    Goal of this test is just to check it doesn't break.
-    """
-    assert dc.read_values(num=[1, 2, 3]).hash() is not None
+    assert dc.read_values(num=[1, 2, 3]).hash() == (
+        "37b04ca5f63c90089d1b544da9ba43bcb6160840913e262cfeb44659cbee1b6e"
+    )
 
 
 def test_read_csv(test_session, tmp_dir):
@@ -93,12 +105,19 @@ def test_read_json(test_session, tmp_dir):
 
 
 def test_read_pandas(test_session, tmp_dir):
-    """
-    Hash of the chain started with read_pandas is currently inconsistent.
-    Goal of this test is just to check it doesn't break.
-    """
     df = pd.DataFrame(DF_DATA)
-    assert dc.read_pandas(df, session=test_session).hash() is not None
+    assert dc.read_pandas(df, session=test_session).hash() == (
+        "6771b82a927962033fc5b8d755ad653eba36f3a9dee1d40108cde54c9f1ae384"
+    )
+
+
+def test_read_hf():
+    from datasets import Dataset
+
+    ds = Dataset.from_dict(DF_DATA)
+    assert dc.read_hf(ds).hash() == (
+        "fc70f8c7eb5b3ca85cb1b29dc35f5259e47d90a425e5251966d0d93ada324664"
+    )
 
 
 def test_read_parquet(test_session, tmp_dir):

--- a/tests/unit/test_hash_utils.py
+++ b/tests/unit/test_hash_utils.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 import pytest
+from pydantic import BaseModel
 from sqlalchemy import (
     Float,
     Integer,
@@ -16,7 +19,12 @@ from sqlalchemy import (
 from sqlalchemy import func as sa_func
 
 from datachain import C, func
-from datachain.hash_utils import hash_callable, hash_column_elements
+from datachain.hash_utils import (
+    hash_callable,
+    hash_column_elements,
+    hash_data,
+    hash_values,
+)
 
 
 def double(x):
@@ -423,3 +431,97 @@ def test_hash_column_elements_single_element():
     single_hash = hash_column_elements(C("name"))
     list_hash = hash_column_elements([C("name")])
     assert single_hash == list_hash
+
+
+# ---- hash_data / hash_values tests ----
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+class _Address(BaseModel):
+    city: str
+
+
+class _Employee(BaseModel):
+    name: str
+    addr: _Address
+
+
+@pytest.mark.parametrize(
+    "records,expected",
+    [
+        ([], "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+        ([{}], "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"),
+        (
+            [{"x": 1}],
+            "5041bf1f713df204784353e82f6a4a535931cb64f1f4b4a5aeaffcb720918b22",
+        ),
+        (
+            [{"x": 1}, {"x": 2}, {"x": 3}],
+            "b666ef6aea469103ee7fb7af20732681604bb74fd64660eaef8f38d5895b52ab",
+        ),
+        (
+            [{"s": "hello", "i": 42, "f": 3.14, "b": True, "n": None}],
+            "a9c7cb80f63c5250f017a66d7e66e24e26e5f68e5c34cb76abb78fcdf9e5fa7f",
+        ),
+        (
+            [{"person": _Person(name="Alice", age=30)}],
+            "fda5c302c1148b50c8c459f9fc8d6e8320be60b7996d550f21a8dd07b6fb9df7",
+        ),
+        (
+            [{"emp": _Employee(name="Bob", addr=_Address(city="NYC"))}],
+            "730b6b3564e1e6701735f3715740ac80d6d61ca110546c77251e03e53723e0ce",
+        ),
+        (
+            [{"meta": {"key": "val", "num": 1}}],
+            "6250568f1c5746c46b42147ae8997382bf7380a1e2b68bec61fb84149e4dd07c",
+        ),
+        (
+            [{"tags": [1, 2, 3]}],
+            "8d29f57624dabfa3f60343092f1a72938971b85568dbe1b9e251ac27d264a83d",
+        ),
+        (
+            [{"coords": (1.0, 2.0)}],
+            "8706809744dc93aebda51625e3bf15c9134a4c7637d6822a5a9473591e18fcb8",
+        ),
+        (
+            [{"ts": datetime(2024, 1, 1, 12, 0, 0)}],
+            "fe1d38f42c181ca1d4522de3f4faf3779c6d155139641a21f9c745493032b0f6",
+        ),
+        (
+            [{"data": b"hello"}],
+            "985b5c54920cb559f8ae1926e8ecaa81114ab19cd76df4a6e872d01bd747197a",
+        ),
+    ],
+)
+def test_hash_data(records, expected):
+    assert hash_data(records) == expected
+
+
+def test_hash_data_key_order_invariant():
+    assert hash_data([{"b": 2, "a": 1}]) == hash_data([{"a": 1, "b": 2}])
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({}, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+        (
+            {"num": [1, 2, 3]},
+            "1fed18a6d326406c3c60459404ec8028e93b689a33fce56ff8d4587184405130",
+        ),
+        (
+            {"name": ["Alice", "Bob"], "age": [30, 25]},
+            "3f9cfde1f544cac4a3cf986c91c96fa32470f271997591469c2b8e34015933ed",
+        ),
+        (
+            {"person": [_Person(name="Alice", age=30)]},
+            "3a6c8fa67bca8e596064456c09a77e146ce59d218370f6253a1ace377835b2b1",
+        ),
+    ],
+)
+def test_hash_values(kwargs, expected):
+    assert hash_values(**kwargs) == expected


### PR DESCRIPTION
`read_records()` creates a temp dataset with a random UUID name. The starting checkpoint hash is derived from this name, making it different on every run — so checkpoints can never be reused for `read_values`, `read_pandas`, `read_hf`, and direct `read_records` calls with list data.                                                           
                
This adds deterministic content-based hashing: when `read_records` receives a concrete list (not a generator/iterator), a SHA256 hash is computed from the actual data and set as the starting checkpoint hash, overriding the random temp dataset name. `read_values` similarly computes a hash from its keyword arguments. This makes checkpoint reuse work for `read_values`, `read_pandas`, `read_hf`, and `read_records` with list input.

Generator/iterator-based inputs (e.g. `read_database`, `read_records` with a generator) still produce non-deterministic hashes since the data is consumed lazily and can't be hashed without buffering it all in memory. - in order to fix this we would need change how we approach to hash calculation in DataChain as currently it can be calculated without applying steps, but in order to support generators we need to move hash calculation into applying steps itself.