### PR TITLE
fix db locked when iterator is not consumed

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -34,7 +34,7 @@ from datachain.query.batch import RowsOutput
 from datachain.query.schema import ColumnMeta
 from datachain.sql.functions import path as pathfunc
 from datachain.sql.types import SQLType
-from datachain.utils import sql_escape_like
+from datachain.utils import safe_closing, sql_escape_like
 
 if TYPE_CHECKING:
     from sqlalchemy.sql._typing import (
@@ -421,10 +421,10 @@ class AbstractWarehouse(ABC, Serializable):
         """
         Fetch dataset rows from database.
         """
-        rows = self.db.execute(query, **kwargs)
-        yield from convert_rows_custom_column_types(
-            query.selected_columns, rows, self.db.dialect
-        )
+        with safe_closing(self.db.execute(query, **kwargs)) as rows:
+            yield from convert_rows_custom_column_types(
+                query.selected_columns, rows, self.db.dialect
+            )
 
     def dataset_rows_select_from_ids(
         self,

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -2201,6 +2201,10 @@ class ResultIter:
     def __iter__(self):
         yield from self._row_iter
 
+    def close(self) -> None:
+        if hasattr(self._row_iter, "close"):
+            self._row_iter.close()  # type: ignore[attr-defined]
+
 
 class DatasetQuery:
     def __init__(
@@ -2508,14 +2512,18 @@ class DatasetQuery:
 
     @contextlib.contextmanager
     def as_iterable(self, **kwargs) -> Iterator[ResultIter]:
+        result: ResultIter | None = None
         try:
             query = self.apply_steps().select()
             selected_columns = [c.name for c in query.selected_columns]
-            yield ResultIter(
+            result = ResultIter(
                 self.catalog.warehouse.dataset_rows_select(query, **kwargs),
                 selected_columns,
             )
+            yield result
         finally:
+            if result is not None:
+                result.close()
             self.cleanup()
 
     def extract(


### PR DESCRIPTION
Fixing more flakiness in tests and `db locked` on interruptions