### PR TITLE
fix: replace bare except with except BaseException

### DIFF
--- a/src/datachain/nodes_thread_pool.py
+++ b/src/datachain/nodes_thread_pool.py
@@ -96,7 +96,7 @@ class NodesThreadPool(ABC):
 
                 self.tasks = self.tasks - done
                 self.update_progress_bar(progress_bar)
-        except:
+        except BaseException:
             self.cancel_all()
             raise
         else:


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except BaseException:` in `nodes_thread_pool.py`.

A bare `except:` catches *everything*, including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intentional. Since this block re-raises with `raise`, `BaseException` is the correct replacement — it preserves the broad catch while making the intent explicit and PEP 8-compliant.

**Change:**
```python
# Before
except:
    self.cancel_all()
    raise

# After
except BaseException:
    self.cancel_all()
    raise
```

## Testing
No behavior change — this is a style/correctness fix only. The exception handling logic is identical.