### PR TITLE
fix: replace bare except with except BaseException in asyn.py

### DIFF
--- a/src/datachain/asyn.py
+++ b/src/datachain/asyn.py
@@ -126,7 +126,7 @@ class AsyncMapper(Generic[InputT, ResultT]):
             )
             self.gather_exceptions(done)
             assert join.done()
-        except:
+        except BaseException:
             await self.cancel_all()
             await self._break_iteration()
             raise


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except BaseException:` in `asyn.py`.

The bare `except:` silently catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intentional. Since this block re-raises immediately with `raise`, `BaseException` is the semantically correct replacement — it preserves identical runtime behaviour while satisfying PEP 8 and making intent explicit.

**Change:**
```python
# Before
except:
    await self.cancel_all()
    await self._break_iteration()
    raise

# After
except BaseException:
    await self.cancel_all()
    await self._break_iteration()
    raise
```

## Testing
No behavior change — style/correctness fix only.