### PR TITLE
fix(dataset_info): handle None attrs in DatasetInfo validator

### DIFF
--- a/src/datachain/lib/dataset_info.py
+++ b/src/datachain/lib/dataset_info.py
@@ -84,6 +84,13 @@ class DatasetInfo(DataModel):
     def validate_metrics(cls, v):
         return cls._validate_dict(v)
 
+    @field_validator("attrs", mode="before")
+    @classmethod
+    def validate_attrs(cls, v):
+        if v is None:
+            return []
+        return v
+
     @classmethod
     def from_models(
         cls,


### PR DESCRIPTION
## Summary

`DatasetInfo.attrs` is typed as `list[str]` but in some DB configurations (e.g. Django's `JSONField(null=True)`), the column value can be `NULL`, causing a Pydantic validation error:

```
1 validation error for ListingInfo
attrs
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
```

## Changes

- Add a `field_validator` for `attrs` that coerces `None` to `[]` before Pydantic validates the type, consistent with the existing validators for `params` and `metrics`.

## Testing

- Existing test suite covers `DatasetInfo` / `ListingInfo` behaviour
- The validator follows the same pattern as `validate_location` and `validate_metrics`