### PR TITLE
fix: replace bare except with except BaseException in nodes_thread_pool

### DIFF
--- a/src/datachain/nodes_thread_pool.py
+++ b/src/datachain/nodes_thread_pool.py
@@ -96,7 +96,7 @@ class NodesThreadPool(ABC):
 
                 self.tasks = self.tasks - done
                 self.update_progress_bar(progress_bar)
-        except:
+        except BaseException:
             self.cancel_all()
             raise
         else:


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except BaseException:` in `nodes_thread_pool.py`.

A bare `except:` catches *everything* including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never the intended behaviour. Since the block immediately re-raises with `raise`, using `except BaseException:` is the correct, explicit form that matches the original intent while making the scope clear to readers and linters.

**Change:**
```python
# Before
        except:
            self.cancel_all()
            raise

# After
        except BaseException:
            self.cancel_all()
            raise
```

## Testing
No behaviour change — this is a correctness/style fix only. The exception is immediately re-raised so runtime behaviour is identical.