### PR TITLE
fix: replace bare except with except BaseException in asyn.py

### DIFF
--- a/src/datachain/asyn.py
+++ b/src/datachain/asyn.py
@@ -126,7 +126,7 @@ class AsyncMapper(Generic[InputT, ResultT]):
             )
             self.gather_exceptions(done)
             assert join.done()
-        except:
+        except BaseException:
             await self.cancel_all()
             await self._break_iteration()
             raise


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except BaseException:` in `asyn.py`.

A bare `except:` silently intercepts `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` — exceptions that typically should not be caught. Since this block immediately re-raises via `raise`, the correct explicit form is `except BaseException:`, which preserves identical runtime behaviour while clearly documenting intent and satisfying PEP 8 / linter warnings.

**Change:**
```python
# Before
        except:
            await self.cancel_all()
            await self._break_iteration()
            raise

# After
        except BaseException:
            await self.cancel_all()
            await self._break_iteration()
            raise
```

## Testing
No behaviour change — exception is immediately re-raised so runtime behaviour is identical.