### PR TITLE
fix(catalog): use for loop in remove_dataset to handle skipped versions

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1604,8 +1604,8 @@ class Catalog:
             self.remove_dataset_version(dataset, version)
             return
 
-        while dataset.versions:
-            version = dataset.versions[0].version
+        for v in dataset.versions:
+            version = v.version
             self.remove_dataset_version(
                 dataset,
                 version,


### PR DESCRIPTION
## Summary
Fix infinite loop in \`Catalog.remove_dataset\` when \`remove_dataset_version\` silently skips a version (e.g. when \`deletion_lock\` is set).

The previous \`while dataset.versions:\` loop never terminated if a version was skipped without being removed from the list. Switching to a \`for\` loop over the original list avoids this.

## Changes
- Replace \`while dataset.versions:\` with \`for v in dataset.versions:\` in \`Catalog.remove_dataset\`

**Required by studio change:** datachain-ai/studio#12735

## Testing
Covered by studio integration tests.