### PR TITLE
fix(gcs): avoid slow credential resolution

### DIFF
--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -19,6 +19,8 @@ from .fsspec import DELIMITER, Client, ResultQueue
 
 # Patch gcsfs for consistency with s3fs
 GCSFileSystem.set_session = GCSFileSystem._set_session
+# Skip the GCE metadata check — it adds latency and hangs outside GCE.
+os.environ.setdefault("NO_GCE_CHECK", "true")
 PageQueue = asyncio.Queue[Iterable[dict[str, Any]] | None]
 
 
@@ -34,6 +36,7 @@ class GCSClient(Client):
         if kwargs.pop("anon", False):
             kwargs["token"] = "anon"  # noqa: S105
 
+        kwargs.setdefault("token", "google_default")
         return cast("GCSFileSystem", super().create_fs(**kwargs))
 
     def url(

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -36,7 +36,6 @@ class GCSClient(Client):
         if kwargs.pop("anon", False):
             kwargs["token"] = "anon"  # noqa: S105
 
-        kwargs.setdefault("token", "google_default")
         return cast("GCSFileSystem", super().create_fs(**kwargs))
 
     def url(


### PR DESCRIPTION
Closes #740, depends on https://github.com/fsspec/gcsfs/pull/803; see fsspec/filesystem_spec#1768 

> ## Summary
> 
> - Default `GCSFileSystem` token to `"google_default"` instead of `None`, avoiding the sequential try-all-methods fallback that includes probing the GCE metadata server
> - Set `NO_GCE_CHECK=true` at module level to skip the metadata service DNS lookup entirely
> 
> Without credentials, `GCSFileSystem` initialization takes 20-30s outside GCE because `method=None` tries `["google_default", "cache", "cloud", "anon"]` sequentially, and the `"cloud"` method hits `metadata.google.internal` with exponential backoff retries on DNS failure. Both changes target the single chokepoint (`GCSClient.create_fs`) that all GCS code paths funnel through.
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)