### PR TITLE
remove legacy compatibility code

### DIFF
--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -290,7 +290,7 @@ class DatasetVersion:
     _preview_data: str | list[dict] | None = field(
         default=None, metadata={"alias": "preview"}
     )
-    _preview_loaded: bool = False
+    _preview_loaded: bool = field(kw_only=True)
     sources: str = ""
     query_script: str = ""
     job_id: str | None = None
@@ -391,12 +391,6 @@ class DatasetVersion:
         result = {}
         for f in fields(self):
             value = object.__getattribute__(self, f.name)
-            # Exclude True to avoid crashing old clients that don't know
-            # about this field.  Receivers infer True (loaded) when the
-            # key is missing.  (Can be removed once all clients
-            # are upgraded.)
-            if f.name == "_preview_loaded" and value is True:
-                continue
             result[f.metadata.get("alias", f.name)] = value
         return result
 
@@ -412,9 +406,6 @@ class DatasetVersion:
             if f.name in d and f.name != "_preview_data"
         }
         kwargs["_preview_data"] = d["preview"]
-        # Infer loaded=True when the key is absent (same rationale as
-        # DatasetRecord.from_dict — see comment there).
-        kwargs.setdefault("_preview_loaded", True)
         return cls(**kwargs)
 
 
@@ -504,7 +495,7 @@ class DatasetRecord:
     script_output: str = ""
     sources: str = ""
     query_script: str = ""
-    _versions_loaded: bool = False
+    _versions_loaded: bool = field(kw_only=True)
 
     @property
     def versions(self) -> list[DatasetVersion]:
@@ -836,12 +827,6 @@ class DatasetRecord:
         result = {}
         for f in fields(self):
             value = object.__getattribute__(self, f.name)
-            # Exclude True to avoid crashing old clients that don't know
-            # about this field.  Receivers infer True (loaded) when the
-            # key is missing.  (Can be removed once all clients
-            # are upgraded.)
-            if f.name == "_versions_loaded" and value is True:
-                continue
             key = f.metadata.get("alias", f.name)
             if hasattr(value, "to_dict"):
                 value = value.to_dict()
@@ -863,11 +848,6 @@ class DatasetRecord:
             for f in fields(cls)
             if f.name in d and f.name not in {"_versions", "project"}
         }
-        # Infer loaded=True when the key is absent: either the server
-        # excluded it (True is omitted for backward compat) or an old
-        # server never sent it.  In both cases the versions were
-        # deserialized from the dict, so they are loaded.
-        kwargs.setdefault("_versions_loaded", True)
         return cls(**kwargs, _versions=versions, project=project)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -711,6 +711,7 @@ def dataset_record():
                 script_output="",
                 schema=None,
                 _preview_data=[],
+                _preview_loaded=True,
             )
         ],
         _versions_loaded=True,

--- a/tests/func/test_pull.py
+++ b/tests/func/test_pull.py
@@ -49,6 +49,7 @@ def remote_dataset_version(
             'from datachain.query.dataset import DatasetQuery\nDatasetQuery(path="s3://ldb-public")',
         ),
         "created_by_id": 1,
+        "_preview_loaded": True,
     }
 
 
@@ -80,6 +81,7 @@ def remote_dataset(
         "warehouse_id": None,
         "created_by_id": 1,
         "versions": [remote_dataset_version],
+        "_versions_loaded": True,
     }
 
 

--- a/tests/func/test_read_dataset_remote.py
+++ b/tests/func/test_read_dataset_remote.py
@@ -58,6 +58,7 @@ def remote_dataset_version_v1(
             'DatasetQuery(path="s3://test-bucket")',
         ),
         "created_by_id": 1,
+        "_preview_loaded": True,
     }
 
 
@@ -87,6 +88,7 @@ def remote_dataset_version_v2(
             'DatasetQuery(path="s3://test-bucket")',
         ),
         "created_by_id": 1,
+        "_preview_loaded": True,
     }
 
 
@@ -118,6 +120,7 @@ def remote_dataset_single_version(
         "warehouse_id": None,
         "created_by_id": 1,
         "versions": [remote_dataset_version_v1],
+        "_versions_loaded": True,
     }
 
 
@@ -150,6 +153,7 @@ def remote_dataset_multi_version(
         "warehouse_id": None,
         "created_by_id": 1,
         "versions": [remote_dataset_version_v1, remote_dataset_version_v2],
+        "_versions_loaded": True,
     }
 
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -129,6 +129,7 @@ def test_dataset_version_from_dict(use_string):
         "num_objects": 100,
         "size": 1000000,
         "preview": preview_data,
+        "_preview_loaded": True,
     }
 
     dataset_version = DatasetVersion.from_dict(data)
@@ -325,9 +326,8 @@ def test_parse_invalid_dataset_schema(schema_dict, exc, match_error):
 
 
 def test_dataset_record_roundtrip_versions_loaded_true(dataset_record):
-    # True is omitted from the dict to avoid crashing old clients
     d = dataset_record.to_dict()
-    assert "_versions_loaded" not in d
+    assert d["_versions_loaded"] is True
     restored = DatasetRecord.from_dict(d)
     assert restored._versions_loaded is True
     assert restored.versions[0].version == "1.0.0"
@@ -342,12 +342,11 @@ def test_dataset_record_roundtrip_versions_loaded_false(dataset_record):
 
 
 def test_dataset_version_roundtrip_preview_loaded_true(dataset_record):
-    # True is omitted from the dict to avoid crashing old clients
     version = replace(
         dataset_record.versions[0], _preview_data=[{"a": 1}], _preview_loaded=True
     )
     d = version.to_dict()
-    assert "_preview_loaded" not in d
+    assert d["_preview_loaded"] is True
     restored = DatasetVersion.from_dict(d)
     assert restored._preview_loaded is True
     assert restored.preview == [{"a": 1}]
@@ -359,6 +358,25 @@ def test_dataset_version_roundtrip_preview_loaded_false(dataset_record):
     assert d["_preview_loaded"] is False
     restored = DatasetVersion.from_dict(d)
     assert restored._preview_loaded is False
+
+
+def test_dataset_version_from_dict_requires_preview_loaded(dataset_record):
+    version = replace(
+        dataset_record.versions[0], _preview_data=[{"a": 1}], _preview_loaded=True
+    )
+    d = version.to_dict()
+    d.pop("_preview_loaded")
+
+    with pytest.raises(TypeError, match="_preview_loaded"):
+        DatasetVersion.from_dict(d)
+
+
+def test_dataset_record_from_dict_requires_versions_loaded(dataset_record):
+    d = dataset_record.to_dict()
+    d.pop("_versions_loaded")
+
+    with pytest.raises(TypeError, match="_versions_loaded"):
+        DatasetRecord.from_dict(d)
 
 
 def test_dataset_version_from_dict_rejects_internal_preview_key(dataset_record):

--- a/tests/unit/test_metastore.py
+++ b/tests/unit/test_metastore.py
@@ -177,7 +177,7 @@ def test_update_dataset_version_marks_preview_loaded_after_explicit_preview_upda
 
     assert updated._preview_loaded is True
     assert updated.preview == [{"sys__id": 1, "value": "updated"}]
-    assert "_preview_loaded" not in updated.to_dict()
+    assert updated.to_dict()["_preview_loaded"] is True
 
 
 def test_dataset_record_versions_setter_marks_loaded(test_session):

--- a/tests/unit/test_query_steps_hash.py
+++ b/tests/unit/test_query_steps_hash.py
@@ -434,6 +434,7 @@ def test_query_step_hash_uses_version_uuid():
                 script_output="",
                 schema=None,
                 _preview_data=[],
+                _preview_loaded=True,
             ),
         ],
         _versions_loaded=True,


### PR DESCRIPTION
This PR removes legacy rollout compatibility leftovers around dataset loading by tightening the metastore request contract to require explicit `versions` and `include_preview` fields, removing wire-format inference for loaded-state flags such as `_preview_loaded` and `_versions_loaded`, and aligning the Studio-side parsing and tests with the current DataChain contract so we only support the modern request and response shapes going forward.
