### PR TITLE
feat(file): add content type and extension metadata

### DIFF
--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -5,7 +5,7 @@ from adlfs import AzureBlobFileSystem
 from datachain.lib.file import File
 from datachain.progress import tqdm
 
-from .fsspec import DELIMITER, Client, ResultQueue
+from .fsspec import DELIMITER, Client, ResultQueue, resolve_content_type
 
 
 class AzureClient(Client):
@@ -23,6 +23,7 @@ class AzureClient(Client):
             is_latest=version_id is None or bool(v.get("is_current_version")),
             last_modified=v["last_modified"],
             size=v.get("size", ""),
+            content_type=resolve_content_type(v),
         )
 
     def url(

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -40,6 +40,33 @@ CLOUD_STORAGE_PROTOCOLS = {"s3", "gs", "az", "hf"}
 
 ResultQueue = asyncio.Queue[Sequence["File"] | None]
 
+# Keys that storage backends use to expose MIME / content-type on info dicts:
+#   - S3 (HEAD / s3fs `_info`): "ContentType"
+#   - GCS (object resource):    "contentType"
+#   - Azure (adlfs `_details`): "content_type"
+#   - HTTP (fsspec `_file_info` from Content-Type header): "mimetype"
+_STORAGE_CONTENT_TYPE_KEYS: tuple[str, ...] = (
+    "ContentType",
+    "contentType",
+    "content_type",
+    "mimetype",
+)
+
+
+def resolve_content_type(info: dict[str, Any]) -> str:
+    """Extract a MIME content-type from a storage info dict.
+
+    Returns the first non-empty value found under one of the known keys,
+    normalized to lowercase and stripped of any ``;``-delimited parameters
+    (e.g. charset). Returns an empty string when the backend does not
+    surface a content-type — no extension-based fallback.
+    """
+    for key in _STORAGE_CONTENT_TYPE_KEYS:
+        v = info.get(key)
+        if v:
+            return str(v).split(";", 1)[0].strip().lower()
+    return ""
+
 
 def is_cloud_uri(uri: str) -> bool:
     protocol = urlparse(uri).scheme

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -43,7 +43,7 @@ ResultQueue = asyncio.Queue[Sequence["File"] | None]
 # Keys that storage backends use to expose MIME / content-type on info dicts:
 #   - S3 (HEAD / s3fs `_info`): "ContentType"
 #   - GCS (object resource):    "contentType"
-#   - Azure (adlfs `_details`): "content_type"
+#   - Azure (adlfs `_details`): "content_settings".content_type
 #   - HTTP (fsspec `_file_info` from Content-Type header): "mimetype"
 _STORAGE_CONTENT_TYPE_KEYS: tuple[str, ...] = (
     "ContentType",
@@ -65,6 +65,17 @@ def resolve_content_type(info: dict[str, Any]) -> str:
         v = info.get(key)
         if v:
             return str(v).split(";", 1)[0].strip().lower()
+
+    content_settings = info.get("content_settings")
+    if content_settings:
+        v = (
+            content_settings.get("content_type")
+            if isinstance(content_settings, dict)
+            else getattr(content_settings, "content_type", None)
+        )
+        if v:
+            return str(v).split(";", 1)[0].strip().lower()
+
     return ""
 
 

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -15,7 +15,7 @@ from datachain.client.fileslice import FileWrapper
 from datachain.lib.file import File
 from datachain.progress import tqdm
 
-from .fsspec import DELIMITER, Client, ResultQueue
+from .fsspec import DELIMITER, Client, ResultQueue, resolve_content_type
 
 # Patch gcsfs for consistency with s3fs
 GCSFileSystem.set_session = GCSFileSystem._set_session
@@ -221,4 +221,5 @@ class GCSClient(Client):
             is_latest=not v.get("timeDeleted"),
             last_modified=self.parse_timestamp(v["updated"]),
             size=v.get("size", ""),
+            content_type=resolve_content_type(v),
         )

--- a/src/datachain/client/hf.py
+++ b/src/datachain/client/hf.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from datachain.lib.file import File
 
-from .fsspec import Client
+from .fsspec import Client, resolve_content_type
 
 
 class classproperty:  # noqa: N801
@@ -97,6 +97,7 @@ class HfClient(Client):
             etag=v.get("blob_id", ""),
             version=last_commit.oid,
             last_modified=last_commit.date,
+            content_type=resolve_content_type(v),
         )
 
     def rel_path(self, path):

--- a/src/datachain/client/http.py
+++ b/src/datachain/client/http.py
@@ -7,7 +7,7 @@ from fsspec.implementations.http import HTTPFileSystem
 from datachain.dataset import StorageURI
 from datachain.lib.file import File
 
-from .fsspec import Client
+from .fsspec import Client, resolve_content_type
 
 if TYPE_CHECKING:
     from datachain.cache import Cache
@@ -143,6 +143,7 @@ class HTTPClient(Client):
             version="",
             is_latest=True,
             last_modified=last_modified,
+            content_type=resolve_content_type(v),
         )
 
     def upload(self, data: bytes, path: str) -> "File":

--- a/src/datachain/client/local.py
+++ b/src/datachain/client/local.py
@@ -10,7 +10,7 @@ from fsspec.implementations.local import LocalFileSystem
 from datachain.fs.utils import path_to_fsspec_uri
 from datachain.lib.file import File
 
-from .fsspec import Client
+from .fsspec import Client, resolve_content_type
 
 if TYPE_CHECKING:
     from datachain.cache import Cache
@@ -216,6 +216,7 @@ class FileClient(Client):
             etag=v["mtime"].hex(),
             is_latest=True,
             last_modified=datetime.fromtimestamp(v["mtime"], timezone.utc),
+            content_type=resolve_content_type(v),
         )
 
     def fetch_nodes(

--- a/src/datachain/client/s3.py
+++ b/src/datachain/client/s3.py
@@ -8,7 +8,7 @@ from s3fs import S3FileSystem
 from datachain.lib.file import File
 from datachain.progress import tqdm
 
-from .fsspec import DELIMITER, Client, ResultQueue
+from .fsspec import DELIMITER, Client, ResultQueue, resolve_content_type
 
 UPDATE_CHUNKSIZE = 1000
 
@@ -149,6 +149,7 @@ class ClientS3(Client):
             is_latest=v.get("IsLatest", True),
             last_modified=v.get("LastModified", ""),
             size=v["Size"],
+            content_type=resolve_content_type(v),
         )
 
     async def _fetch_dir(
@@ -198,4 +199,5 @@ class ClientS3(Client):
             etag=v.get("ETag", "").strip('"'),
             is_latest=v.get("IsLatest", True),
             last_modified=v.get("LastModified", ""),
+            content_type=resolve_content_type(v),
         )

--- a/src/datachain/data_storage/schema.py
+++ b/src/datachain/data_storage/schema.py
@@ -303,6 +303,8 @@ class DataTable:
             sa.Column("file__is_latest", Boolean()),
             sa.Column("file__last_modified", DateTime()),
             sa.Column("file__location", JSON()),
+            sa.Column("file__content_type", String()),
+            sa.Column("file__ext", String()),
         ]
 
     def dir_expansion(self):

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -214,6 +214,12 @@ class File(DataModel):
             Defaults to Unix epoch (`1970-01-01T00:00:00`).
         location (dict | list[dict], optional): The location of the file.
             Defaults to `None`.
+        content_type (str): The MIME content type as reported by the storage
+            backend (e.g., 'image/jpeg'). Empty string when the backend does
+            not provide one. Defaults to an empty string.
+        ext (str): The file extension parsed from ``path`` (lowercase, no dot,
+            e.g., 'jpg'). Auto-derived from ``path`` if left blank.
+            Defaults to an empty string.
     """
 
     source: str = Field(default="")
@@ -224,6 +230,8 @@ class File(DataModel):
     is_latest: bool = Field(default=True)
     last_modified: datetime = Field(default=TIME_ZERO)
     location: dict | list[dict] | None = Field(default=None)
+    content_type: str = Field(default="")
+    ext: str = Field(default="")
 
     _datachain_column_types: ClassVar[dict[str, Any]] = {
         "source": String,
@@ -234,6 +242,8 @@ class File(DataModel):
         "is_latest": Boolean,
         "last_modified": DateTime,
         "location": JSON,
+        "content_type": String,
+        "ext": String,
     }
     _hidden_fields: ClassVar[list[str]] = [
         "source",
@@ -298,6 +308,16 @@ class File(DataModel):
             and (not self.source or self.source.startswith("file://"))
         ):
             self.path = self.path.replace("\\", "/")
+        return self
+
+    @model_validator(mode="after")
+    def _derive_ext(self) -> "File":
+        # Auto-derive `ext` from `path` when not explicitly set so that all
+        # `File` instances expose a consistent extension column regardless of
+        # how they were constructed (per-backend listing, manual, warehouse
+        # round-trip).
+        if not self.ext and self.path:
+            self.ext = PurePosixPath(self.path).suffix.lstrip(".").lower()
         return self
 
     @field_validator("source")

--- a/src/datachain/lib/file.py
+++ b/src/datachain/lib/file.py
@@ -252,6 +252,8 @@ class File(DataModel):
         "is_latest",
         "last_modified",
         "location",
+        "content_type",
+        "ext",
     ]
 
     _unique_id_keys: ClassVar[list[str]] = [

--- a/src/datachain/node.py
+++ b/src/datachain/node.py
@@ -59,6 +59,8 @@ class Node:
     size: int = 0
     location: str | None = None
     source: StorageURI = StorageURI("")  # noqa: RUF009
+    content_type: str = ""
+    ext: str = ""
     dir_type: int = DirType.FILE
 
     @property
@@ -102,6 +104,8 @@ class Node:
             is_latest=self.is_latest,
             location=self.location,
             last_modified=self.last_modified or TIME_ZERO,
+            content_type=self.content_type,
+            ext=self.ext,
         )
 
     @classmethod
@@ -115,6 +119,8 @@ class Node:
             last_modified=f.last_modified,
             version=f.version,
             location=str(f.location) if f.location else None,
+            content_type=f.content_type,
+            ext=f.ext,
             dir_type=DirType.FILE,
         )
 
@@ -134,6 +140,8 @@ class Node:
             last_modified=_dval("last_modified"),
             version=_dval("version"),
             location=_dval("location"),
+            content_type=_dval("content_type") or "",
+            ext=_dval("ext") or "",
             dir_type=DirType.FILE,
         )
 

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -3324,6 +3324,11 @@ class DatasetQuery:
         if old_fp != new_fp:
             return None
 
+        old_schema_keys = set(dataset.get_version(prev_version).schema)
+        new_schema_keys = set(dataset.get_version(version).schema)
+        if old_schema_keys != new_schema_keys:
+            return None
+
         self.catalog.remove_dataset_version(dataset, version)
         # updating TTL of a bucket listing
         self.catalog.metastore.update_dataset_version(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1100,6 +1100,8 @@ def remote_dataset_schema():
         "file__size": {"type": "Int64"},
         "file__location": {"type": "String"},
         "file__source": {"type": "String"},
+        "file__content_type": {"type": "String"},
+        "file__ext": {"type": "String"},
         "version": {"type": "String"},
     }
 
@@ -1123,6 +1125,8 @@ def remote_file_feature_schema():
                     "is_latest": "bool",
                     "last_modified": "datetime",
                     "location": "Union[dict, list[dict], NoneType]",
+                    "content_type": "str",
+                    "ext": "str",
                 },
                 "bases": [
                     ["File", "datachain.lib.file", "File@v1"],

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -621,6 +621,35 @@ def test_listings_reindex(test_session, tmp_dir):
     assert listings[0].version == "1.0.0"
 
 
+def test_listings_reindex_keeps_schema_changes(test_session, tmp_dir):
+    df = pd.DataFrame(DF_DATA)
+    df.to_parquet(tmp_dir / "df.parquet")
+
+    uri = tmp_dir.as_uri()
+    catalog = test_session.catalog
+
+    dc.read_storage(uri, session=test_session).exec()
+    ds_name, _, _ = parse_listing_uri(uri)
+    dataset = catalog.get_dataset(ds_name, versions=["1.0.0"])
+    current_schema = dataset.get_version("1.0.0").schema
+
+    def _to_schema_dict(column_type):
+        column_type = column_type() if isinstance(column_type, type) else column_type
+        return column_type.to_dict()
+
+    legacy_schema = {
+        name: _to_schema_dict(column_type)
+        for name, column_type in current_schema.items()
+        if name not in {"file__content_type", "file__ext"}
+    }
+    catalog.metastore.update_dataset_version(dataset, "1.0.0", schema=legacy_schema)
+
+    dc.read_storage(uri, session=test_session, update=True).exec()
+
+    listings = list(dc.listings(session=test_session).to_values("listing"))
+    assert [listing.version for listing in listings] == ["1.0.0", "2.0.0"]
+
+
 def test_listings_reindex_subpath_local_file_system(test_session, tmp_dir):
     subdir = tmp_dir / "subdir"
     os.mkdir(subdir)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -4862,6 +4862,8 @@ def test_union_does_not_break_schema_order(test_session):
         "file__is_latest",
         "file__last_modified",
         "file__location",
+        "file__content_type",
+        "file__ext",
         "meta__name",
         "meta__count",
     ]

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -977,38 +977,37 @@ def test_file_ext_explicit_override_preserved():
     assert file.ext == "custom"
 
 
-def test_file_content_type_default_blank():
-    """`content_type` defaults to empty string when not provided."""
-    file = File(path="x.jpg", source="s3://bucket")
-    assert file.content_type == ""
+@pytest.mark.parametrize(
+    "kwargs,expected_content_type",
+    [
+        ({}, ""),
+        ({"content_type": "image/jpeg"}, "image/jpeg"),
+    ],
+)
+def test_file_content_type(kwargs, expected_content_type):
+    file = File(path="x.jpg", source="s3://bucket", **kwargs)
+    assert file.content_type == expected_content_type
 
 
-def test_file_content_type_explicit():
-    file = File(path="x.jpg", source="s3://bucket", content_type="image/jpeg")
-    assert file.content_type == "image/jpeg"
-
-
-def test_resolve_content_type_storage_keys():
-    """Each known storage key yields a normalized MIME string."""
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        ({"ContentType": "image/JPEG"}, "image/jpeg"),
+        ({"contentType": "video/mp4"}, "video/mp4"),
+        ({"content_type": "text/plain"}, "text/plain"),
+        ({"mimetype": "application/json"}, "application/json"),
+        ({"content_settings": Mock(content_type="image/JPEG")}, "image/jpeg"),
+        (
+            {"content_settings": {"content_type": "application/JSON; charset=utf-8"}},
+            "application/json",
+        ),
+        ({"mimetype": "text/html; charset=utf-8"}, "text/html"),
+        ({"size": 10}, ""),
+        ({}, ""),
+        ({"ContentType": ""}, ""),
+    ],
+)
+def test_resolve_content_type(info, expected):
     from datachain.client.fsspec import resolve_content_type
 
-    assert resolve_content_type({"ContentType": "image/JPEG"}) == "image/jpeg"
-    assert resolve_content_type({"contentType": "video/mp4"}) == "video/mp4"
-    assert resolve_content_type({"content_type": "text/plain"}) == "text/plain"
-    assert resolve_content_type({"mimetype": "application/json"}) == "application/json"
-
-
-def test_resolve_content_type_strips_parameters():
-    """Charset / parameters after `;` are stripped."""
-    from datachain.client.fsspec import resolve_content_type
-
-    assert resolve_content_type({"mimetype": "text/html; charset=utf-8"}) == "text/html"
-
-
-def test_resolve_content_type_blank_when_missing():
-    """No fallback to extension — blank when the dict has no MIME key."""
-    from datachain.client.fsspec import resolve_content_type
-
-    assert resolve_content_type({"size": 10}) == ""
-    assert resolve_content_type({}) == ""
-    assert resolve_content_type({"ContentType": ""}) == ""
+    assert resolve_content_type(info) == expected

--- a/tests/unit/lib/test_file.py
+++ b/tests/unit/lib/test_file.py
@@ -952,3 +952,63 @@ def test_audio_get_channel_name():
     # Test out of range indices
     assert Audio.get_channel_name(2, 5) == "Ch6"
     assert Audio.get_channel_name(1, 1) == "Ch2"
+
+
+@pytest.mark.parametrize(
+    "path,expected_ext",
+    [
+        ("dir/image.JPG", "jpg"),
+        ("dir/sub/clip.mp4", "mp4"),
+        ("data/file.tar.gz", "gz"),
+        (".hidden", ""),
+        ("noext", ""),
+        ("dir/", ""),
+    ],
+)
+def test_file_ext_auto_derived(path, expected_ext):
+    """`ext` is auto-derived from `path` via the model_validator."""
+    file = File(path=path, source="s3://bucket")
+    assert file.ext == expected_ext
+
+
+def test_file_ext_explicit_override_preserved():
+    """An explicit `ext` value is preserved (not overwritten by validator)."""
+    file = File(path="data/x.txt", source="s3://bucket", ext="custom")
+    assert file.ext == "custom"
+
+
+def test_file_content_type_default_blank():
+    """`content_type` defaults to empty string when not provided."""
+    file = File(path="x.jpg", source="s3://bucket")
+    assert file.content_type == ""
+
+
+def test_file_content_type_explicit():
+    file = File(path="x.jpg", source="s3://bucket", content_type="image/jpeg")
+    assert file.content_type == "image/jpeg"
+
+
+def test_resolve_content_type_storage_keys():
+    """Each known storage key yields a normalized MIME string."""
+    from datachain.client.fsspec import resolve_content_type
+
+    assert resolve_content_type({"ContentType": "image/JPEG"}) == "image/jpeg"
+    assert resolve_content_type({"contentType": "video/mp4"}) == "video/mp4"
+    assert resolve_content_type({"content_type": "text/plain"}) == "text/plain"
+    assert resolve_content_type({"mimetype": "application/json"}) == "application/json"
+
+
+def test_resolve_content_type_strips_parameters():
+    """Charset / parameters after `;` are stripped."""
+    from datachain.client.fsspec import resolve_content_type
+
+    assert resolve_content_type({"mimetype": "text/html; charset=utf-8"}) == "text/html"
+
+
+def test_resolve_content_type_blank_when_missing():
+    """No fallback to extension — blank when the dict has no MIME key."""
+    from datachain.client.fsspec import resolve_content_type
+
+    assert resolve_content_type({"size": 10}) == ""
+    assert resolve_content_type({}) == ""
+    assert resolve_content_type({"ContentType": ""}) == ""

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1464,7 +1464,7 @@ def test_column_types(column_type, signal_type):
         ),
         (
             {"file": File},
-            "26a08b3793e738814f199c89c4582f9bde052ff3dcba84c2020535063df4c36c",
+            "d3cbe27c0a980058bbc675d05b47d1f514e7aa8c603a8895f2edca317150d647",
         ),
         (
             {},

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1464,7 +1464,7 @@ def test_column_types(column_type, signal_type):
         ),
         (
             {"file": File},
-            "d3cbe27c0a980058bbc675d05b47d1f514e7aa8c603a8895f2edca317150d647",
+            "9a0f6498120868dcf356f1ef1a232a929254f143cb005b2f37160cf32e04d72c",
         ),
         (
             {},


### PR DESCRIPTION
## Summary
Add `content_type` and `ext` to DataChain `File` metadata so storage listings can persist MIME type when providers expose it and always expose a path-derived extension.
## Details
- Add `File.content_type` and `File.ext` fields, including warehouse column types and listing table columns.
- Derive `ext` from `File.path` automatically when it is not explicitly provided.
- Resolve provider-reported MIME values from GCS, Azure/adlfs, HTTP, and S3 info dictionaries when available.
- Preserve the provider-sourced contract: `content_type` stays blank when storage listing metadata does not expose a MIME type.
## S3 Note
S3 bulk listings (`ListObjectsV2` / version listing) do not include object `ContentType`, so `content_type` is expected to be blank for normal S3 listing rows even when `ext` is available, e.g. `jpg`.
If we need accurate S3 MIME types, we can add an opt-in enrichment path that performs HEAD requests per object and reads `ContentType`. That would be significantly more expensive and slower for large buckets, so this PR avoids doing it by default.
## Testing
- Added unit coverage for extension derivation and content-type resolution across provider metadata shapes.
- Updated schema/hash fixtures for the new `File` fields.