### PR TITLE
Making hash calculation deterministic for single file read storage

### DIFF
--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .datachain import DataChain
 
 
-def _single_file_starting_hash(files: Sequence[File]) -> str:
+def _files_starting_hash(files: Sequence[File]) -> str:
     """Return an order-independent sha256 over (source, path, version-or-etag)
     of the given files."""
     keys = sorted((f.source, f.path, f.version or f.etag) for f in files)
@@ -268,9 +268,7 @@ def read_storage(
         file_chain.signals_schema = file_chain.signals_schema.mutate(
             {f"{column}": file_type}
         )
-        file_chain._query.override_starting_hash(
-            _single_file_starting_hash(file_values)
-        )
+        file_chain._query.override_starting_hash(_files_starting_hash(file_values))
         storage_chain = storage_chain.union(file_chain) if storage_chain else file_chain
 
     assert storage_chain is not None

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 from collections.abc import Sequence
 from functools import reduce
@@ -10,12 +11,23 @@ from datachain.lib.dc.storage_pattern import (
     split_uri_pattern,
     validate_cloud_bucket_name,
 )
-from datachain.lib.file import FileType, get_file_type
+from datachain.lib.file import File, FileType, get_file_type
 from datachain.lib.listing import get_file_info, get_listing, list_bucket, ls
 from datachain.query import Session
 
 if TYPE_CHECKING:
     from .datachain import DataChain
+
+
+def _single_file_starting_hash(files: Sequence[File]) -> str:
+    # Identifier mirrors calc_fingerprint: prefer version (versioned bucket)
+    # over etag (which can be unstable on GCS/Azure due to internal storage
+    # operations).
+    keys = sorted((f.source, f.path, f.version or f.etag) for f in files)
+    h = hashlib.sha256()
+    for source, path, identifier in keys:
+        h.update(f"{source}\0{path}\0{identifier}\0".encode())
+    return h.hexdigest()
 
 
 def read_storage(
@@ -256,6 +268,9 @@ def read_storage(
         )
         file_chain.signals_schema = file_chain.signals_schema.mutate(
             {f"{column}": file_type}
+        )
+        file_chain._query.override_starting_hash(
+            _single_file_starting_hash(file_values)
         )
         storage_chain = storage_chain.union(file_chain) if storage_chain else file_chain
 

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -20,9 +20,8 @@ if TYPE_CHECKING:
 
 
 def _single_file_starting_hash(files: Sequence[File]) -> str:
-    # Identifier mirrors calc_fingerprint: prefer version (versioned bucket)
-    # over etag (which can be unstable on GCS/Azure due to internal storage
-    # operations).
+    """Return an order-independent sha256 over (source, path, version-or-etag)
+    of the given files."""
     keys = sorted((f.source, f.path, f.version or f.etag) for f in files)
     h = hashlib.sha256()
     for source, path, identifier in keys:

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -2437,6 +2437,7 @@ class DatasetQuery:
         self.checkpoints_enabled = checkpoints_enabled
 
         self.list_ds_name: str | None = None
+        self._starting_hash_override: str | None = None
         self.dialect = self.catalog.warehouse.db.dialect
 
         if name is None:
@@ -2501,6 +2502,8 @@ class DatasetQuery:
 
     @property
     def _starting_step_hash(self) -> str:
+        if self._starting_hash_override is not None:
+            return self._starting_hash_override
         if self.starting_step:
             return self.starting_step.hash()
         if self.list_ds_name:
@@ -2509,6 +2512,25 @@ class DatasetQuery:
                 "Call resolve_listing() first."
             )
         return ""
+
+    def override_starting_hash(self, hash_value: str) -> None:
+        """Replace the starting-step hash with a caller-supplied value.
+
+        The default starting hash comes from the underlying dataset version's
+        UUID. That works when the chain starts from a "real" dataset (an
+        explicit dataset, or a listing whose version UUID is content-stable
+        thanks to the listing fingerprint). It does NOT work when the chain
+        starts from a temp dataset created on-the-fly with a random UUID
+        (e.g. read_values / read_records / single-file read_storage), because
+        the random UUID makes the chain hash non-deterministic across runs
+        and checkpoints can never be reused.
+
+        Callers that have a content-derived identifier for the starting data
+        (e.g. file URI + etag/version for single-file reads) can use this to
+        pin the starting hash so identical inputs across runs produce
+        identical chain hashes.
+        """
+        self._starting_hash_override = hash_value
 
     def __iter__(self):
         return iter(self.db_results())

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -1,5 +1,5 @@
+import os
 import sys
-import time
 
 import pandas as pd
 import pytest
@@ -223,8 +223,9 @@ def test_read_storage_single_local_file_hash_changes_on_edit(test_session, tmp_d
 
     h1 = dc.read_storage(uri, session=test_session)._query.hash()
 
-    time.sleep(0.01)
     f.write_text("hello world")
+    st = f.stat()
+    os.utime(f, ns=(st.st_atime_ns, st.st_mtime_ns + 5 * 10**9))
 
     h2 = dc.read_storage(uri, session=test_session)._query.hash()
     assert h1 != h2

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -1,5 +1,7 @@
 import sys
+import time
 
+import pandas as pd
 import pytest
 
 import datachain as dc
@@ -203,3 +205,86 @@ def test_calc_fingerprint_order_independent(test_session):
     fp1 = calc_fingerprint(test_session, ds1, ds1.latest_version)
     fp2 = calc_fingerprint(test_session, ds2, ds2.latest_version)
     assert fp1 == fp2
+
+
+def test_read_storage_single_local_file_deterministic_hash(test_session, tmp_dir):
+    (tmp_dir / "a.txt").write_text("hello")
+    uri = (tmp_dir / "a.txt").as_uri()
+
+    h1 = dc.read_storage(uri, session=test_session)._query.hash()
+    h2 = dc.read_storage(uri, session=test_session)._query.hash()
+    assert h1 == h2
+
+
+def test_read_storage_single_local_file_hash_changes_on_edit(test_session, tmp_dir):
+    f = tmp_dir / "a.txt"
+    f.write_text("hello")
+    uri = f.as_uri()
+
+    h1 = dc.read_storage(uri, session=test_session)._query.hash()
+
+    time.sleep(0.01)
+    f.write_text("hello world")
+
+    h2 = dc.read_storage(uri, session=test_session)._query.hash()
+    assert h1 != h2
+
+
+def test_read_storage_single_file_deterministic_hash_across_clouds(
+    cloud_test_catalog,
+):
+    ctc = cloud_test_catalog
+    uri = f"{ctc.src_uri}/description"
+
+    h1 = dc.read_storage(uri, session=ctc.session)._query.hash()
+    h2 = dc.read_storage(uri, session=ctc.session)._query.hash()
+    assert h1 == h2
+
+
+def test_read_csv_single_local_file_deterministic_hash(test_session, tmp_dir):
+    f = tmp_dir / "data.csv"
+    pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]}).to_csv(f, index=False)
+    uri = f.as_uri()
+
+    h1 = dc.read_csv(uri, session=test_session)._query.hash()
+    h2 = dc.read_csv(uri, session=test_session)._query.hash()
+    assert h1 == h2
+
+
+def test_read_parquet_single_local_file_deterministic_hash(test_session, tmp_dir):
+    f = tmp_dir / "data.parquet"
+    pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]}).to_parquet(f)
+    uri = f.as_uri()
+
+    h1 = dc.read_parquet(uri, session=test_session)._query.hash()
+    h2 = dc.read_parquet(uri, session=test_session)._query.hash()
+    assert h1 == h2
+
+
+def test_read_storage_multiple_single_files_order_independent(test_session, tmp_dir):
+    (tmp_dir / "a.txt").write_text("hello")
+    (tmp_dir / "b.txt").write_text("world")
+    uri_a = (tmp_dir / "a.txt").as_uri()
+    uri_b = (tmp_dir / "b.txt").as_uri()
+
+    h1 = dc.read_storage([uri_a, uri_b], session=test_session)._query.hash()
+    h2 = dc.read_storage([uri_b, uri_a], session=test_session)._query.hash()
+    assert h1 == h2
+
+
+def test_read_storage_mixed_single_file_and_dir_deterministic(test_session, tmp_dir):
+    sub = tmp_dir / "sub"
+    sub.mkdir()
+    (sub / "a.txt").write_text("hello")
+    (sub / "b.txt").write_text("world")
+    standalone = tmp_dir / "standalone.txt"
+    standalone.write_text("solo")
+
+    dir_uri = sub.as_uri()
+    file_uri = standalone.as_uri()
+
+    chain1 = dc.read_storage([dir_uri, file_uri], session=test_session)
+    chain2 = dc.read_storage([dir_uri, file_uri], session=test_session)
+    chain1._query.resolve_all_listings()
+    chain2._query.resolve_all_listings()
+    assert chain1._query.hash() == chain2._query.hash()


### PR DESCRIPTION
Fixes #1640.

Single-file `read_storage` / `read_csv` / `read_parquet` produced non-deterministic chain hashes (random temp-dataset UUID), so checkpoints could never be reused. Directories/globs already work via the listing fingerprint (#1722).

Fix: `DatasetQuery.override_starting_hash()` lets callers pin the starting-step hash. `read_storage` sets it for single-file inputs, hashing sorted `(source, path, version_or_etag)` tuples — same identifier choice as `calc_fingerprint` (version preferred, etag fallback).

Tests (`tests/func/test_listing.py`): local + cross-cloud (file/s3/gs/azure × version_aware), CSV, Parquet, multi-URI order independence, mixed dir + single-file.