### PR TITLE
Removing `get_last_checkpoint`

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -581,10 +581,6 @@ class AbstractMetastore(ABC, Serializable):
         """List checkpoints, optionally filtered by job IDs and/or status."""
 
     @abstractmethod
-    def get_last_checkpoint(self, job_id: str) -> Checkpoint | None:
-        """Get last created checkpoint for some job."""
-
-    @abstractmethod
     def get_checkpoint_by_id(self, checkpoint_id: str) -> Checkpoint:
         """Gets single checkpoint by id"""
 
@@ -2607,18 +2603,6 @@ class AbstractDBMetastore(AbstractMetastore):
             ch.c.job_id == job_id,
             ch.c.hash == _hash,
             ch.c.status == CheckpointStatus.ACTIVE,
-        )
-        rows = list(self.db.execute(query))
-        if not rows:
-            return None
-        return self.checkpoint_class.parse(*rows[0])
-
-    def get_last_checkpoint(self, job_id: str) -> Checkpoint | None:
-        query = (
-            self._checkpoints_query()
-            .where(self._checkpoints.c.job_id == job_id)
-            .order_by(desc(self._checkpoints.c.created_at))
-            .limit(1)
         )
         rows = list(self.db.execute(query))
         if not rows:


### PR DESCRIPTION
Removing not used method. Was left for backward compatibility but not needed any more