### PR TITLE
improve docs for filter, add tests

### DIFF
--- a/docs/guide/functions.md
+++ b/docs/guide/functions.md
@@ -112,7 +112,21 @@ String operations via `dc.func.string.*`:
 - `length(col)`: string length
 - `split(col, sep)`: split on separator
 - `replace(col, old, new)`: substring replacement
-- `regexp_replace(col, pattern, replacement)`: regex-based replacement
+- `regexp_replace(col, pattern, replacement)`: regex-based replacement. Matching
+  is case-sensitive by default — prepend the `(?i)` inline flag to the pattern
+  for case-insensitive matching (e.g. `r"(?i)foo"`).
+
+```python
+import datachain as dc
+from datachain.func import string
+
+chain.mutate(
+    # Replace any digit run with "X"
+    masked=string.regexp_replace("text", r"\d+", "X"),
+    # Case-insensitive replacement: matches "foo", "FOO", "Foo", ...
+    normalized=string.regexp_replace("text", r"(?i)foo", "bar"),
+)
+```
 
 ## Numeric / Bit Functions
 

--- a/src/datachain/func/string.py
+++ b/src/datachain/func/string.py
@@ -157,11 +157,16 @@ def regexp_replace(col: ColT, regex: str, replacement: str) -> Func:
                 r"\s+",
                 "_",
             ),
+            # Case-insensitive matching via the `(?i)` inline flag:
+            # matches "foo", "FOO", "Foo", etc.
+            s4=func.string.regexp_replace("signal.name", r"(?i)foo", "bar"),
         )
         ```
 
     Notes:
         - The result column will always be of type string.
+        - Matching is case-sensitive by default. For case-insensitive matching
+          prepend the `(?i)` inline flag to the pattern (e.g. `r"(?i)foo"`).
     """
 
     def inner(arg):

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -2685,7 +2685,7 @@ class DataChain:
 
     @resolve_columns
     def filter(self, *args: Any) -> "Self":
-        """Filter the chain according to conditions.
+        r"""Filter the chain according to conditions.
 
         Example:
             Basic usage with built-in operators
@@ -2693,9 +2693,23 @@ class DataChain:
             dc.filter(C("width") < 200)
             ```
 
-            Using glob to match patterns
+            Using glob to match patterns (case-sensitive, shell-style wildcards)
             ```py
             dc.filter(C("file.path").glob("*.jpg"))
+            ```
+
+            Using `like` / `ilike` for SQL pattern matching with `%` and `_`
+            wildcards. `like` is case-sensitive; `ilike` is case-insensitive:
+            ```py
+            dc.filter(C("text").like("%empty vehicle%"))
+            dc.filter(C("text").ilike("%empty vehicle%"))
+            ```
+
+            Using `regexp` for regular-expression matching. Case-sensitive by
+            default; prepend the `(?i)` inline flag for case-insensitive:
+            ```py
+            dc.filter(C("file.name").regexp(r"^IMG_\d+\.jpg$"))
+            dc.filter(C("file.name").regexp(r"(?i)^img_\d+\.jpg$"))
             ```
 
             Using in to match lists
@@ -2751,6 +2765,16 @@ class DataChain:
             ```py
             dc.filter(~(C("file.path").glob("*.jpg")))
             ```
+
+            Quick reference for column-level filter operators:
+
+            | Operator          | Wildcards / syntax     | Case sensitive?  |
+            |-------------------|------------------------|------------------|
+            | `glob(pattern)`   | shell: `*`, `?`, `[…]` | yes              |
+            | `like(pattern)`   | SQL: `%`, `_`          | yes              |
+            | `ilike(pattern)`  | SQL: `%`, `_`          | **no**           |
+            | `regexp(pattern)` | regular expression     | yes (use `(?i)`) |
+            | `in_(values)`     | exact values           | yes              |
         """
         return self._evolve(query=self._query.filter(*args))
 

--- a/src/datachain/skill/core/SKILL.md
+++ b/src/datachain/skill/core/SKILL.md
@@ -486,7 +486,7 @@ chain.filter(C("name").startswith("al"))
 chain.filter(C("name").endswith("ob"))
 chain.filter(C("name").like("%ob"))
 chain.filter(C("name").ilike("AL%"))
-chain.filter(C("name").regexp_match("^al"))
+chain.filter(C("name").regexp("^al"))
 # NULL checks
 chain.filter(C("name").isnot(None))
 chain.filter(C("name").is_(None))

--- a/tests/func/functions/test_string.py
+++ b/tests/func/functions/test_string.py
@@ -171,6 +171,30 @@ def test_string_regexp_replace(test_session):
     ]
 
 
+def test_string_regexp_replace_case_insensitive(test_session):
+    ds = list(
+        dc.read_values(
+            id=(1, 2, 3),
+            s=("Foo bar FOO", "no match here", "FOObarfoo"),
+            session=test_session,
+        )
+        .mutate(
+            # case-sensitive (default): only lowercase "foo" replaced
+            cs=func.string.regexp_replace("s", r"foo", "X"),
+            # inline (?i) flag enables case-insensitive matching
+            ci=func.string.regexp_replace("s", r"(?i)foo", "X"),
+        )
+        .order_by("id")
+        .to_list("cs", "ci")
+    )
+
+    assert ds == [
+        ("Foo bar FOO", "X bar X"),
+        ("no match here", "no match here"),
+        ("FOObarX", "XbarX"),
+    ]
+
+
 def test_string_byte_hamming_distance(test_session):
     class Data(dc.DataModel):
         s1: str

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2901,6 +2901,59 @@ def test_filter_with_glob_patterns(test_session):
     ]
 
 
+def test_filter_with_like_and_ilike(test_session):
+    """`like` is case-sensitive, `ilike` is case-insensitive (SQL LIKE)."""
+    chain = dc.read_values(
+        id=[1, 2, 3, 4, 5],
+        text=[
+            "empty vehicle on road",
+            "Empty Vehicle parked",
+            "EMPTY VEHICLE detected",
+            "loaded vehicle moving",
+            "no match here",
+        ],
+        session=test_session,
+    )
+
+    # like is case-sensitive: only the exact-cased "empty vehicle" matches
+    assert sorted(chain.filter(C("text").like("%empty vehicle%")).to_values("id")) == [
+        1
+    ]
+
+    # ilike is case-insensitive: matches all three casings
+    assert sorted(chain.filter(C("text").ilike("%empty vehicle%")).to_values("id")) == [
+        1,
+        2,
+        3,
+    ]
+
+    # Wildcards: `_` matches a single character
+    assert sorted(chain.filter(C("text").ilike("empty_vehicle%")).to_values("id")) == [
+        1,
+        2,
+        3,
+    ]
+
+
+def test_filter_with_regexp(test_session):
+    """`regexp` is case-sensitive by default; `(?i)` makes it insensitive."""
+    chain = dc.read_values(
+        id=[1, 2, 3, 4],
+        name=["IMG_001.jpg", "img_002.jpg", "Img_003.JPG", "video.mp4"],
+        session=test_session,
+    )
+
+    # case-sensitive default: only lowercase "img_" with lowercase ".jpg" matches
+    assert sorted(
+        chain.filter(C("name").regexp(r"^img_\d+\.jpg$")).to_values("id")
+    ) == [2]
+
+    # inline (?i) flag: case-insensitive across name and extension
+    assert sorted(
+        chain.filter(C("name").regexp(r"(?i)^img_\d+\.jpg$")).to_values("id")
+    ) == [1, 2, 3]
+
+
 def test_filter_with_in_operator(test_session):
     """Test filter with 'in' operator."""
     chain = dc.read_values(


### PR DESCRIPTION
Document case-insensitive string matching in DataChain. Adds a note + example to `dc.func.string.regexp_replace` in `docs/guide/functions.md` showing the `(?i)` inline regex flag for case-insensitive replacement. Expands the `DataChain.filter()` docstring with examples for `glob`, `like`/`ilike`, `regexp` (with `(?i)`), `in_`, and `func`-based predicates, plus a quick-reference table of column-level filter operators and their case-sensitivity. Updates the internal SKILL example from `regexp_match` to the datachain-native `regexp`. Adds tests covering `like`/`ilike` filtering, `regexp` filtering with and without `(?i)`, and `regexp_replace` case-insensitive behavior. No API changes.