### PR TITLE
Fix e2e tests cloud-fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -530,17 +530,16 @@ def datachain_job_id(test_session, monkeypatch):
 
 
 @pytest.fixture(scope="session")
-def cloud_server_credentials(cloud_server):
+def cloud_server_credentials(cloud_server, monkeypatch_session):
     if cloud_server.kind == "s3":
         cfg = cloud_server.src.fs.client_kwargs
-        try:
-            os.environ.pop("AWS_PROFILE")
-        except KeyError:
-            pass
-        os.environ["AWS_ACCESS_KEY_ID"] = cfg.get("aws_access_key_id")
-        os.environ["AWS_SECRET_ACCESS_KEY"] = cfg.get("aws_secret_access_key")
-        os.environ["AWS_SESSION_TOKEN"] = cfg.get("aws_session_token")
-        os.environ["AWS_DEFAULT_REGION"] = cfg.get("region_name")
+        monkeypatch_session.delenv("AWS_PROFILE", raising=False)
+        monkeypatch_session.setenv("AWS_ACCESS_KEY_ID", cfg["aws_access_key_id"])
+        monkeypatch_session.setenv(
+            "AWS_SECRET_ACCESS_KEY", cfg["aws_secret_access_key"]
+        )
+        monkeypatch_session.setenv("AWS_SESSION_TOKEN", cfg["aws_session_token"])
+        monkeypatch_session.setenv("AWS_DEFAULT_REGION", cfg["region_name"])
 
 
 def get_cloud_test_catalog(cloud_server, tmp_path, metastore, warehouse):

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -1,4 +1,3 @@
-import os
 import os.path
 import subprocess
 from textwrap import dedent
@@ -6,7 +5,7 @@ from textwrap import dedent
 import pytest
 import tabulate
 
-from tests.utils import skip_if_not_sqlite
+from tests.utils import e2e_subprocess_env, skip_if_not_sqlite
 
 
 def _tabulated_datasets(name, version):
@@ -227,11 +226,7 @@ def run_step(step, catalog):
         capture_output=True,
         check=True,
         encoding="utf-8",
-        env={
-            **os.environ,
-            "DATACHAIN__METASTORE": catalog.metastore.serialize(),
-            "DATACHAIN__WAREHOUSE": catalog.warehouse.serialize(),
-        },
+        env=e2e_subprocess_env(catalog),
     )
 
     if step.get("sort_expected_lines"):

--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -1,4 +1,3 @@
-import os
 import os.path
 import signal
 import subprocess
@@ -11,6 +10,8 @@ from threading import Thread
 from typing import IO
 
 import pytest
+
+from tests.utils import e2e_subprocess_env
 
 tests_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -185,13 +186,11 @@ def run_step(step, catalog):
         popen_args = {"start_new_session": True}
     stdin_path = step.get("stdin_file")
     with open(stdin_path) if stdin_path else nullcontext(None) as stdin_file:
-        # Build env without DATACHAIN_MAIN_PROCESS_PID so script starts fresh
-        # as its own main process (with checkpoints enabled)
-        script_env = {
-            k: v for k, v in os.environ.items() if k != "DATACHAIN_MAIN_PROCESS_PID"
-        }
-        script_env["DATACHAIN__METASTORE"] = catalog.metastore.serialize()
-        script_env["DATACHAIN__WAREHOUSE"] = catalog.warehouse.serialize()
+        # Strip DATACHAIN_MAIN_PROCESS_PID so script starts fresh as its own
+        # main process (with checkpoints enabled).
+        script_env = e2e_subprocess_env(
+            catalog, exclude_keys={"DATACHAIN_MAIN_PROCESS_PID"}
+        )
 
         process = subprocess.Popen(  # noqa: S603
             command,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,6 +176,23 @@ def wait_for_condition(
     raise TimeoutError(f"Timeout expired while waiting for: {message}")
 
 
+def e2e_subprocess_env(
+    catalog: Catalog, exclude_keys: set[str] | None = None
+) -> dict[str, str]:
+    # Strip AWS_* so the subprocess talks to real public S3 instead of inheriting
+    # moto/pytest-servers credentials and region from cloud-emulator fixtures
+    # that ran earlier in the same pytest process.
+    exclude = exclude_keys or set()
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("AWS_") and k not in exclude
+    }
+    env["DATACHAIN__METASTORE"] = catalog.metastore.serialize()
+    env["DATACHAIN__WAREHOUSE"] = catalog.warehouse.serialize()
+    return env
+
+
 def run_test_subprocess(command, env: dict[str, str], capture_output: bool = True):
     stdout = subprocess.PIPE if capture_output else None
     stderr = subprocess.PIPE if capture_output else None


### PR DESCRIPTION
The session-scoped `cloud_server_credentials` fixture was writing `AWS_DEFAULT_REGION=pytest-servers-region` (and AWS keys) directly to `os.environ`. In CI configurations that run cloud-fixture tests and the e2e tests in the same Python process (Studio tests), the e2e subprocess inherited those vars via `env={**os.environ, ...}` and boto3 built `https://<bucket>.s3.pytest-servers-region.amazonaws.com/`.

Fix: add `tests.utils.e2e_subprocess_env()` that strips `AWS_*` before adding DataChain overrides.
Improvement: switch `cloud_server_credentials` to `monkeypatch_session` so the AWS env is undone at session teardown instead of leaking permanently.

Example of failed tests (4 times in a row): https://github.com/datachain-ai/datachain/actions/runs/25605189540/job/75176712858?pr=1755

Note: AI was used to investigate and fix this nasty issue