### PR TITLE
fix(save): roll back claimed version on post-claim failure

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -3389,47 +3389,50 @@ class DatasetQuery:
 
             version = version or dataset.latest_version
 
-            # Phase 3: Rename staging table to the final dataset table name.
-            final_table_name = self.catalog.warehouse.dataset_table_name(
-                dataset, version
-            )
-            self.catalog.warehouse.rename_table(temp_table, final_table_name)
-            self.temp_table_names.remove(temp_table_name)
-
-            # Link this dataset version to the job that created it
-            if job_id:
-                self.catalog.metastore.link_dataset_version_to_job(
-                    dataset.get_version(version).id, job_id, is_creator=True
+            # Phases 3-7: roll back the claim if anything below fails so we
+            # never leave an orphan CREATED row in the metastore.
+            with self._rollback_version_on_failure(dataset, version):
+                # Phase 3: Rename staging table to the final dataset table name.
+                final_table_name = self.catalog.warehouse.dataset_table_name(
+                    dataset, version
                 )
+                self.catalog.warehouse.rename_table(temp_table, final_table_name)
+                self.temp_table_names.remove(temp_table_name)
 
-            if dependencies:
-                # overriding dependencies
-                self.dependencies = set()
-                for dep in dependencies:
-                    self.dependencies.add(
-                        (
-                            self.catalog.get_dataset(
-                                dep.name,
-                                namespace_name=dep.namespace,
-                                project_name=dep.project,
-                                versions=[dep.version],
-                                include_incomplete=False,
-                            ),
-                            dep.version,
-                        )
+                # Link this dataset version to the job that created it
+                if job_id:
+                    self.catalog.metastore.link_dataset_version_to_job(
+                        dataset.get_version(version).id, job_id, is_creator=True
                     )
 
-            self._add_dependencies(dataset, version)  # type: ignore [arg-type]
+                if dependencies:
+                    # overriding dependencies
+                    self.dependencies = set()
+                    for dep in dependencies:
+                        self.dependencies.add(
+                            (
+                                self.catalog.get_dataset(
+                                    dep.name,
+                                    namespace_name=dep.namespace,
+                                    project_name=dep.project,
+                                    versions=[dep.version],
+                                    include_incomplete=False,
+                                ),
+                                dep.version,
+                            )
+                        )
 
-            if kwargs.get("listing"):
-                reused = self._reuse_listing_if_unchanged(
-                    dataset, version, name, project
-                )
-                if reused is not None:
-                    return reused
+                self._add_dependencies(dataset, version)  # type: ignore [arg-type]
 
-            # Mark as COMPLETE only after all operations succeed.
-            self.catalog.complete_dataset_version(dataset, version)
+                if kwargs.get("listing"):
+                    reused = self._reuse_listing_if_unchanged(
+                        dataset, version, name, project
+                    )
+                    if reused is not None:
+                        return reused
+
+                # Mark as COMPLETE only after all operations succeed.
+                self.catalog.complete_dataset_version(dataset, version)
         finally:
             self.cleanup()
         return self.__class__(
@@ -3439,6 +3442,26 @@ class DatasetQuery:
             version=version,
             catalog=self.catalog,
         )
+
+    @contextlib.contextmanager
+    def _rollback_version_on_failure(
+        self, dataset: "DatasetRecord", version: str
+    ) -> Iterator[None]:
+        """Remove the just-claimed dataset version on any exception so the
+        metastore never holds an orphan CREATED row when post-claim phases
+        fail (e.g. SQLite contention during rename or stats refresh)."""
+        try:
+            yield
+        except BaseException:
+            try:
+                self.catalog.remove_dataset_version(dataset, version, drop_rows=True)
+            except Exception:
+                logger.exception(
+                    "Failed to roll back claimed version %s of dataset %s",
+                    version,
+                    dataset.name,
+                )
+            raise
 
     def _reuse_listing_if_unchanged(
         self,

--- a/tests/test_atomicity.py
+++ b/tests/test_atomicity.py
@@ -6,7 +6,10 @@ import uuid
 import pytest
 import sqlalchemy as sa
 
+import datachain as dc
+from datachain.catalog.catalog import Catalog
 from datachain.dataset import DatasetStatus
+from datachain.error import DatasetNotFoundError
 from datachain.sql.types import Float32
 from tests.utils import (
     run_test_subprocess,
@@ -189,8 +192,36 @@ def test_concurrent_save_fails_after_max_retries(tmp_dir, catalog_tmpfile):
     stored_versions = sorted(v.version for v in dataset.versions if v.version)
     assert stored_versions == expected_versions
 
+    # No orphan CREATED/FAILED versions should remain: post-claim failures
+    # must roll back the claim so the metastore stays consistent.
+    for v in dataset.versions:
+        assert v.status == DatasetStatus.COMPLETE, (
+            f"orphan version {v.version} status={v.status}"
+        )
+
     for version in stored_versions:
         dataset_version = dataset.get_version(version)
         table_name = catalog_tmpfile.warehouse.dataset_table_name(dataset, version)
         assert dataset_version.status == DatasetStatus.COMPLETE
         assert table_row_count(catalog_tmpfile.warehouse.db, table_name) == 1
+
+
+def test_save_rolls_back_claimed_version_on_post_claim_failure(
+    test_session, monkeypatch
+):
+    """If save() fails after claiming a version, the claim must be rolled back
+    so the metastore stays consistent (no orphan CREATED rows)."""
+    dataset_name = f"rollback_test_{uuid.uuid4().hex}"
+    boom = RuntimeError("simulated post-claim failure")
+
+    def failing_complete(self, dataset, version, **kwargs):
+        raise boom
+
+    monkeypatch.setattr(Catalog, "complete_dataset_version", failing_complete)
+
+    with pytest.raises(RuntimeError, match="simulated post-claim failure"):
+        dc.read_values(num=[1], session=test_session).save(dataset_name)
+
+    catalog = test_session.catalog
+    with pytest.raises(DatasetNotFoundError):
+        catalog.get_dataset(dataset_name, include_incomplete=True, versions=None)


### PR DESCRIPTION
Wrap phase 3-7 of `DatasetQuery.save()` in a context manager that removes the just-claimed dataset version if any subsequent step raises (rename, link-job, dependencies, complete). Without this, post-claim failures (e.g. SQLite contention) left orphan `CREATED` rows in the metastore, which made _next_auto_version skip ahead and caused the flaky tests.

Test failure examples: 
- https://github.com/datachain-ai/datachain/actions/runs/25605283753/job/75202371624
- https://github.com/datachain-ai/datachain/actions/runs/25619068862/job/75202286502

```
=================================== FAILURES ===================================
_________________ test_concurrent_save_fails_after_max_retries _________________
[gw1] linux -- Python 3.10.20 /home/runner/work/datachain/datachain/.nox/e2e-3-10/bin/python3

tmp_dir = PosixPath('/tmp/pytest-of-runner/pytest-1/popen-gw1/datachain-test2')
catalog_tmpfile = <datachain.catalog.catalog.Catalog object at 0x7f1c1a081e10>

    @skip_if_not_sqlite
    @pytest.mark.e2e
    @pytest.mark.xdist_group(name="tmpfile")
    def test_concurrent_save_fails_after_max_retries(tmp_dir, catalog_tmpfile):
        dataset_name = f"concurrent_save_max_{uuid.uuid4().hex}"
        barrier_dir = tmp_dir / "concurrent-save-max-barrier"
        script = os.path.join(tests_dir, "scripts", "concurrent_save.py")
        process_count = 10
    
        env = {
            **os.environ,
            "DATACHAIN__METASTORE": catalog_tmpfile.metastore.serialize(),
            "DATACHAIN__WAREHOUSE": catalog_tmpfile.warehouse.serialize(),
            "DATACHAIN_CONCURRENT_SAVE_DATASET": dataset_name,
            "DATACHAIN_CONCURRENT_SAVE_BARRIER_DIR": os.fspath(barrier_dir),
            "DATACHAIN_CONCURRENT_SAVE_PARTIES": str(process_count),
            "DATACHAIN_CONCURRENT_SAVE_SYNC_ALL": "1",
        }
    
        processes = [
            run_test_subprocess(
                (python_exc, script),
                {**env, "DATACHAIN_CONCURRENT_SAVE_WORKER": str(worker_id)},
            )
            for worker_id in range(1, process_count + 1)
        ]
    
        results = []
        for process in processes:
            _, stdout, stderr = wait_for_test_subprocess(
                process, timeout=E2E_STEP_TIMEOUT_SEC
            )
            assert stdout.strip(), stderr
            results.append(json.loads(stdout.strip().splitlines()[-1]))
    
        successes = [result for result in results if result["status"] == "success"]
        failures = [result for result in results if result["status"] == "error"]
    
        # At least one worker must succeed, and under heavy contention some may
        # fail (barrier timeouts, lock retries, etc.), so we don't assert exact
        # counts — only that every result is accounted for and consistent.
        assert len(successes) >= 1
        assert len(successes) + len(failures) == process_count
    
        # Successful versions must be unique and sequential starting from 1.0.0
        versions = sorted(result["version"] for result in successes)
        expected_versions = [f"1.0.{i}" for i in range(len(successes))]
>       assert versions == expected_versions
E       AssertionError: assert ['1.0.0', '1....0.4', '1.0.5'] == ['1.0.0', '1....0.3', '1.0.4']
E         
E         At index 1 diff: '1.0.2' != '1.0.1'
E         
E         Full diff:
E           [
E               '1.0.0',
E         -     '1.0.1',
E               '1.0.2',
E               '1.0.3',
E               '1.0.4',
E         +     '1.0.5',
E           ]

/home/runner/work/datachain/datachain/tests/test_atomicity.py:172: AssertionError
```

Note: AI was used to investigate and fix this nasty issue