### PR TITLE
fix: scope created dataset version returns

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -914,6 +914,8 @@ class Catalog:
             )
 
             if version_created:
+                assert len(dataset.versions) == 1
+                assert dataset.versions[0].version == target_version
                 return dataset
 
             # Another writer claimed this version between our check and insert.

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1306,7 +1306,7 @@ class AbstractDBMetastore(AbstractMetastore):
             dataset.name,
             namespace_name=dataset.project.namespace.name,
             project_name=dataset.project.name,
-            versions=None,
+            versions=[version],
             include_incomplete=True,
         )
 

--- a/src/datachain/lib/dc/records.py
+++ b/src/datachain/lib/dc/records.py
@@ -137,7 +137,9 @@ def read_records(
     warehouse = catalog.warehouse
 
     # Create the rows table (create_dataset only creates metadata).
-    table_name = warehouse.dataset_table_name(dsr, dsr.latest_version)
+    assert len(dsr.versions) == 1
+    dataset_version = dsr.versions[0].version
+    table_name = warehouse.dataset_table_name(dsr, dataset_version)
     warehouse.create_dataset_rows_table(table_name, columns=columns)
 
     dr = warehouse.dataset_rows(dsr)
@@ -158,6 +160,6 @@ def read_records(
     warehouse.insert_rows_done(table)
 
     # Finalize warehouse-derived metadata before marking the version COMPLETE.
-    catalog.complete_dataset_version(dsr, dsr.latest_version)
+    catalog.complete_dataset_version(dsr, dataset_version)
 
     return read_dataset(name=dsr.full_name, session=session, settings=settings)

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -3387,7 +3387,11 @@ class DatasetQuery:
                 **kwargs,
             )
 
-            version = version or dataset.latest_version
+            assert len(dataset.versions) == 1
+            dataset_version = (
+                dataset.get_version(version) if version else dataset.versions[0]
+            )
+            version = dataset_version.version
 
             # Phase 3: Rename staging table to the final dataset table name.
             final_table_name = self.catalog.warehouse.dataset_table_name(

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -3458,19 +3458,25 @@ class DatasetQuery:
         """
         from datachain.lib.listing import calc_fingerprint
 
-        prev_version = dataset.latest_complete_version
+        full_dataset = self.catalog.get_dataset(
+            name,
+            namespace_name=project.namespace.name,
+            project_name=project.name,
+            versions=None,
+        )
+        prev_version = full_dataset.latest_complete_version
         if not prev_version:
             return None
 
-        old_fp = calc_fingerprint(self.session, dataset, prev_version)
-        new_fp = calc_fingerprint(self.session, dataset, version)
+        old_fp = calc_fingerprint(self.session, full_dataset, prev_version)
+        new_fp = calc_fingerprint(self.session, full_dataset, version)
         if old_fp != new_fp:
             return None
 
-        self.catalog.remove_dataset_version(dataset, version)
+        self.catalog.remove_dataset_version(full_dataset, version)
         # updating TTL of a bucket listing
         self.catalog.metastore.update_dataset_version(
-            dataset, prev_version, finished_at=datetime.now(timezone.utc)
+            full_dataset, prev_version, finished_at=datetime.now(timezone.utc)
         )
         return self.__class__(
             name=name,

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -92,6 +92,8 @@ def test_create_dataset_with_explicit_version(test_session, project):
         columns=[sa.Column("similarity", Float32)],
     )
 
+    assert [v.version for v in dataset.versions] == ["1.0.0"]
+
     dataset_version = dataset.get_version("1.0.0")
 
     assert dataset.name == name
@@ -146,7 +148,10 @@ def test_create_dataset_already_exist(test_session, saved_dataset):
         columns=[sa.Column("similarity", Float32)],
     )
 
-    assert sorted([v.version for v in dataset.versions]) == sorted(["1.0.0", "1.0.1"])
+    assert [v.version for v in dataset.versions] == ["1.0.1"]
+
+    full_dataset = catalog.get_dataset(saved_dataset.name, versions=None)
+    assert sorted(v.version for v in full_dataset.versions) == ["1.0.0", "1.0.1"]
 
     dataset_version = dataset.get_version("1.0.1")
 
@@ -379,6 +384,7 @@ def test_remove_dataset_with_multiple_versions(test_session, saved_dataset):
     updated_dataset, _ = catalog.create_dataset_version(
         saved_dataset, "2.0.0", columns=columns
     )
+    updated_dataset = catalog.get_dataset(saved_dataset.name, versions=None)
     assert updated_dataset.has_version("2.0.0")
     assert updated_dataset.has_version("1.0.0")
 

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -197,14 +197,17 @@ def test_create_dataset_version_finished_at(metastore):
         status=DatasetStatus.COMPLETE,
         finished_at=now.isoformat(),
     )
-    assert len(ds.versions) == 2
-    assert ds.versions[1].finished_at == now
+    assert len(ds.versions) == 1
+    assert ds.versions[0].finished_at == now
 
     ds, _ = metastore.create_dataset_version(
         dataset=ds, version="1.2.5", status=DatasetStatus.FAILED
     )
-    assert len(ds.versions) == 3
-    assert ds.versions[2].finished_at is not None
+    assert len(ds.versions) == 1
+    assert ds.versions[0].finished_at is not None
+
+    full_ds = metastore.get_dataset("test_dataset", versions=None)
+    assert len(full_ds.versions) == 3
 
 
 @pytest.mark.parametrize("ignore_if_exists", [True, False])
@@ -699,6 +702,7 @@ def test_remove_dataset_version(metastore):
     ds, _ = metastore.create_dataset_version(
         dataset=ds, version="2.0.0", status=DatasetStatus.COMPLETE
     )
+    ds = metastore.get_dataset("ds", versions=None)
     assert len(ds.versions) == 2
 
     # Removing non-existent version should raise an exception
@@ -729,6 +733,7 @@ def test_remove_dataset_version_cleans_dependencies(metastore):
     ds1, _ = metastore.create_dataset_version(
         dataset=ds1, version="2.0.0", status=DatasetStatus.COMPLETE
     )
+    ds1 = metastore.get_dataset("ds1", versions=None)
 
     ds2 = metastore.create_dataset(name="ds2")
     ds2, _ = metastore.create_dataset_version(
@@ -826,6 +831,7 @@ def test_update_dataset_dependency_source_default_new_source(metastore):
     src, _ = metastore.create_dataset_version(
         dataset=src, version="2.0.0", status=DatasetStatus.COMPLETE
     )
+    src = metastore.get_dataset("src", versions=None)
     tgt = metastore.create_dataset(name="tgt")
     tgt, _ = metastore.create_dataset_version(
         dataset=tgt, version="1.0.0", status=DatasetStatus.COMPLETE


### PR DESCRIPTION
Should fix a potential race condition in `save()`. It is leading to some tests failing from time to time - https://github.com/datachain-ai/datachain/pull/1759#issuecomment-4414656054 