### PR TITLE
fix(read_storage): always attach listing_fn so refresh paths can re-list

### DIFF
--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -170,7 +170,7 @@ def read_storage(
             updated_uris.add(list_uri_to_use)
             update_single_uri = True
 
-        list_ds_name, list_uri, list_path, list_ds_exists = get_listing(
+        list_ds_name, list_uri, list_path, _ = get_listing(
             list_uri_to_use, session, update=update_single_uri
         )
 
@@ -198,35 +198,39 @@ def read_storage(
         dc._query.update = update
         dc.signals_schema = dc.signals_schema.mutate({f"{column}": file_type})
 
-        if update or not list_ds_exists:
-
-            def lst_fn(ds_name, lst_uri):
-                # Start with a single dummy record so gen() has one row to iterate over.
-                # Disable prefetch=0 to prevent downloading files during listing.
-                (
-                    read_records(
-                        [{"seed": 0}],
-                        schema={"seed": int},
-                        session=session,
-                        settings=settings,
-                        in_memory=in_memory,
-                    )
-                    .settings(
-                        prefetch=0,
-                        namespace=listing_namespace_name,
-                        project=listing_project_name,
-                    )
-                    .gen(
-                        list_bucket(lst_uri, cache, client_config=client_config),
-                        output={f"{column}": file_type},
-                    )
-                    # for internal listing datasets, we always bump major version
-                    .save(ds_name, listing=True, update_version="major")
+        def lst_fn(ds_name, lst_uri):
+            # Start with a single dummy record so gen() has one row to iterate over.
+            # Disable prefetch=0 to prevent downloading files during listing.
+            (
+                read_records(
+                    [{"seed": 0}],
+                    schema={"seed": int},
+                    session=session,
+                    settings=settings,
+                    in_memory=in_memory,
                 )
-
-            dc._query.set_listing_fn(
-                lambda ds_name=list_ds_name, lst_uri=list_uri: lst_fn(ds_name, lst_uri)
+                .settings(
+                    prefetch=0,
+                    namespace=listing_namespace_name,
+                    project=listing_project_name,
+                )
+                .gen(
+                    list_bucket(lst_uri, cache, client_config=client_config),
+                    output={f"{column}": file_type},
+                )
+                # for internal listing datasets, we always bump major version
+                .save(ds_name, listing=True, update_version="major")
             )
+
+        # Always attach the listing function. `resolve_listing` may need to call
+        # it later not only when ``update`` is set or the dataset is missing at
+        # construction time, but also when the listing dataset is detected as
+        # expired (or has been cleaned up between construction and execution,
+        # e.g. for ephemeral listings). Attaching it unconditionally avoids an
+        # `AssertionError: self.listing_fn` in those refresh paths.
+        dc._query.set_listing_fn(
+            lambda ds_name=list_ds_name, lst_uri=list_uri: lst_fn(ds_name, lst_uri)
+        )
 
         # If a glob pattern was detected, use it for filtering
         # Otherwise, use the original list_path from get_listing

--- a/src/datachain/lib/dc/storage.py
+++ b/src/datachain/lib/dc/storage.py
@@ -200,7 +200,7 @@ def read_storage(
         def lst_fn(ds_name, lst_uri):
             # Seed for .gen() iteration. content_hash=None because hash_callable
             # doesn't capture list_func's closure (which holds `lst_uri`, `cache`,
-            # `client_config`) — auto-hashing the seed would let the UDF
+            # `client_config`) -- auto-hashing the seed would let the UDF
             # checkpoint cache return a stale listing across URIs/runs.
             (
                 create_records_dataset(

--- a/tests/func/test_listing.py
+++ b/tests/func/test_listing.py
@@ -143,6 +143,26 @@ def test_listing_update_unchanged_keeps_old_version(test_session, tmp_dir):
     assert ds.get_version("1.0.0").finished_at > original_finished_at
 
 
+def test_listing_refresh_when_expired_after_construction(
+    test_session, tmp_dir, monkeypatch
+):
+    """Regression test for ``AssertionError: self.listing_fn`` raised from
+    ``DatasetQuery.resolve_listing`` when the listing dataset exists at chain
+    construction time but is detected as expired at execution time. The
+    listing function must be attached unconditionally so the refresh path can
+    invoke it.
+    """
+    (tmp_dir / "a.txt").write_text("hello")
+    uri = tmp_dir.as_uri()
+
+    dc.read_storage(uri, session=test_session).exec()
+
+    chain = dc.read_storage(uri, session=test_session)
+    monkeypatch.setattr("datachain.lib.listing.LISTING_TTL", -1)
+
+    assert chain.count() == 1
+
+
 def test_listing_update_changed_creates_new_version(test_session, tmp_dir):
     """update=True with changed files should create a new listing version."""
     (tmp_dir / "a.txt").write_text("hello")


### PR DESCRIPTION
The listing function was only attached when `update=True` or the listing dataset did not exist at chain construction time. However, `DatasetQuery.resolve_listing` also invokes `listing_fn` when the listing is detected as expired at execution time (or has been cleaned up between construction and execution, e.g. for ephemeral listings introduced in #1718). In those cases `listing_fn` was `None` and the assertion `assert self.listing_fn` failed.

Attach the listing function unconditionally - the gating logic in `resolve_listing` is unchanged, so this only affects the refresh paths that were previously broken. The placeholder `lambda: True` already used in `read_listing_dataset` confirms the project convention of always having a listing function available.