### PR TITLE
Added check for anon on File read methods

### DIFF
--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -30,6 +30,7 @@ class AzureClient(Client):
             "tenant_id",
         }
     )
+    _ANON_FALLBACK = True
 
     @classmethod
     def bucket_status(cls, name: str, **kwargs) -> BucketStatus:

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -176,7 +176,7 @@ class Client(ABC):
     # True  = anon retry succeeded, use anon from the start.
     # False = anon retry also failed, don't bother retrying again.
     # Missing key = no decision yet.
-    _ANON_BUCKETS: ClassVar[dict[tuple[str, str], bool]] = {}
+    _anon_buckets: ClassVar[dict[tuple[str, str], bool]] = {}
 
     @classmethod
     def has_explicit_credentials(cls, client_config: dict | None) -> bool:
@@ -187,11 +187,11 @@ class Client(ABC):
 
     @classmethod
     def _bucket_needs_anon(cls, name: str) -> bool | None:
-        return cls._ANON_BUCKETS.get((cls.protocol, name))
+        return cls._anon_buckets.get((cls.protocol, name))
 
     @classmethod
     def _mark_bucket_anon(cls, name: str, anon: bool) -> None:
-        cls._ANON_BUCKETS[(cls.protocol, name)] = anon
+        cls._anon_buckets[(cls.protocol, name)] = anon
 
     def __init__(self, name: str, fs_kwargs: dict[str, Any], cache: Cache) -> None:
         self.name = name

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -63,36 +63,87 @@ class BucketStatus(NamedTuple):
     error: str | None = None
 
 
-def _anon_fallback(method):
-    """Retry a Client method once with anonymous access on PermissionError.
+class AnonFallbackFS:
+    """Proxy for an fsspec ``AbstractFileSystem`` that retries any method on
+    ``PermissionError`` with ``anon=True``, and caches the decision per
+    ``(protocol, bucket)`` so future calls go straight to the right mode.
 
-    Only marks the bucket as anon-needed if the retry actually succeeds, so
-    genuinely inaccessible buckets keep raising clean errors instead of
-    being silently cached as anon.
+    Wrapping at this layer (rather than on individual ``Client`` methods)
+    means every code path that goes through ``self.fs`` is covered - both
+    sync paths (``get_file_info``, ``open_object``) and async ones
+    (``get_current_etag``, ``get_file``, ``get_size``).
     """
 
-    @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
-        try:
-            return method(self, *args, **kwargs)
-        except PermissionError:
-            if (
-                self.fs_kwargs.get("anon")
-                or self._bucket_needs_anon(self.name) is not None
-            ):
-                raise
-            saved_fs = self._fs
-            self._fs = type(self).create_fs(**{**self.fs_kwargs, "anon": True})
-            try:
-                result = method(self, *args, **kwargs)
-            except PermissionError:
-                self._fs = saved_fs
-                self._mark_bucket_anon(self.name, False)
-                raise
-            self._mark_bucket_anon(self.name, True)
-            return result
+    def __init__(self, client: "Client") -> None:
+        self._client = client
+        kwargs = dict(client.fs_kwargs)
+        if client._bucket_needs_anon(client.name) is True:
+            kwargs["anon"] = True
+        self._inner_fs = type(client).create_fs(**kwargs)
 
-    return wrapper
+    @property  # type: ignore[misc]
+    def __class__(self):
+        # Pretend to be the underlying fsspec class so isinstance checks
+        # (e.g. pyarrow's ``isinstance(fs, AbstractFileSystem)``) pass.
+        return type(self._inner_fs)
+
+    def __getattr__(self, name: str):
+        attr = getattr(self._inner_fs, name)
+        if not callable(attr):
+            return attr
+        if asyncio.iscoroutinefunction(attr):
+            return self._wrap_async(name, attr)
+        return self._wrap_sync(name, attr)
+
+    def _can_retry(self) -> bool:
+        if self._client.fs_kwargs.get("anon"):
+            return False
+        return self._client._bucket_needs_anon(self._client.name) is None
+
+    def _swap_to_anon(self) -> None:
+        self._inner_fs = type(self._client).create_fs(
+            **{**self._client.fs_kwargs, "anon": True}
+        )
+
+    def _wrap_sync(self, name, attr):
+        def call(*args, **kwargs):
+            try:
+                return attr(*args, **kwargs)
+            except PermissionError:
+                if not self._can_retry():
+                    raise
+                saved = self._inner_fs
+                self._swap_to_anon()
+                try:
+                    result = getattr(self._inner_fs, name)(*args, **kwargs)
+                except PermissionError:
+                    self._inner_fs = saved
+                    self._client._mark_bucket_anon(self._client.name, False)
+                    raise
+                self._client._mark_bucket_anon(self._client.name, True)
+                return result
+
+        return call
+
+    def _wrap_async(self, name, attr):
+        async def call(*args, **kwargs):
+            try:
+                return await attr(*args, **kwargs)
+            except PermissionError:
+                if not self._can_retry():
+                    raise
+                saved = self._inner_fs
+                self._swap_to_anon()
+                try:
+                    result = await getattr(self._inner_fs, name)(*args, **kwargs)
+                except PermissionError:
+                    self._inner_fs = saved
+                    self._client._mark_bucket_anon(self._client.name, False)
+                    raise
+                self._client._mark_bucket_anon(self._client.name, True)
+                return result
+
+        return call
 
 
 class Client(ABC):
@@ -102,6 +153,10 @@ class Client(ABC):
     protocol: ClassVar[str]
     # client_config keys this backend treats as credentials.
     CREDENTIAL_KEYS: ClassVar[frozenset[str]] = frozenset()
+    # Whether ``anon=True`` is a meaningful fsspec kwarg for this backend.
+    # Subclasses for S3/GCS/Azure flip this to True so ``Client.fs`` returns
+    # an ``AnonFallbackFS`` proxy.
+    _ANON_FALLBACK: ClassVar[bool] = False
     # Process-local cache of (protocol, bucket) anon decisions.
     # True  = anon retry succeeded, use anon from the start.
     # False = anon retry also failed, don't bother retrying again.
@@ -277,10 +332,10 @@ class Client(ABC):
     @property
     def fs(self) -> "AbstractFileSystem":
         if not self._fs:
-            kwargs = dict(self.fs_kwargs)
-            if self._bucket_needs_anon(self.name) is True:
-                kwargs["anon"] = True
-            self._fs = self.create_fs(**kwargs)
+            if type(self)._ANON_FALLBACK:
+                self._fs = AnonFallbackFS(self)  # type: ignore[assignment]
+            else:
+                self._fs = self.create_fs(**self.fs_kwargs)
         return self._fs
 
     def url(
@@ -299,7 +354,6 @@ class Client(ABC):
         info = await self.fs._info(full_path, **self._file_info_kwargs(file.version))
         return self.info_to_file(info, file.path).etag
 
-    @_anon_fallback
     def get_file_info(self, path: str, version_id: str | None = None) -> "File":
         self.validate_file_path(path)
         full_path = self.get_uri(path)
@@ -484,7 +538,6 @@ class Client(ABC):
             # Default to copy if reflinks are not supported
             shutil.copy2(src, dst)
 
-    @_anon_fallback
     def open_object(
         self, file: "File", use_cache: bool = True, cb: Callback = DEFAULT_CALLBACK
     ) -> BinaryIO:

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -77,7 +77,10 @@ class AnonFallbackFS:
     def __init__(self, client: "Client") -> None:
         self._client = client
         kwargs = dict(client.fs_kwargs)
-        if client._bucket_needs_anon(client.name) is True:
+        if (
+            self._should_use_anon_cache()
+            and client._bucket_needs_anon(client.name) is True
+        ):
             kwargs["anon"] = True
         self._inner_fs = type(client).create_fs(**kwargs)
 
@@ -95,9 +98,17 @@ class AnonFallbackFS:
             return self._wrap_async(name, attr)
         return self._wrap_sync(name, attr)
 
+    def _should_use_anon_cache(self) -> bool:
+        # Clients with explicit creds skip the shared anon cache - reading
+        # could lock them out of paths their creds cover, writing could
+        # mis-flag a bucket as anon-needed for future no-creds callers.
+        return not type(self._client).has_explicit_credentials(self._client.fs_kwargs)
+
     def _can_retry(self) -> bool:
         if self._client.fs_kwargs.get("anon"):
             return False
+        if not self._should_use_anon_cache():
+            return True
         return self._client._bucket_needs_anon(self._client.name) is None
 
     def _swap_to_anon(self) -> None:
@@ -118,9 +129,11 @@ class AnonFallbackFS:
                     result = getattr(self._inner_fs, name)(*args, **kwargs)
                 except PermissionError:
                     self._inner_fs = saved
-                    self._client._mark_bucket_anon(self._client.name, False)
+                    if self._should_use_anon_cache():
+                        self._client._mark_bucket_anon(self._client.name, False)
                     raise
-                self._client._mark_bucket_anon(self._client.name, True)
+                if self._should_use_anon_cache():
+                    self._client._mark_bucket_anon(self._client.name, True)
                 return result
 
         return call
@@ -138,9 +151,11 @@ class AnonFallbackFS:
                     result = await getattr(self._inner_fs, name)(*args, **kwargs)
                 except PermissionError:
                     self._inner_fs = saved
-                    self._client._mark_bucket_anon(self._client.name, False)
+                    if self._should_use_anon_cache():
+                        self._client._mark_bucket_anon(self._client.name, False)
                     raise
-                self._client._mark_bucket_anon(self._client.name, True)
+                if self._should_use_anon_cache():
+                    self._client._mark_bucket_anon(self._client.name, True)
                 return result
 
         return call

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -76,7 +76,10 @@ def _anon_fallback(method):
         try:
             return method(self, *args, **kwargs)
         except PermissionError:
-            if self.fs_kwargs.get("anon") or self._bucket_needs_anon(self.name):
+            if (
+                self.fs_kwargs.get("anon")
+                or self._bucket_needs_anon(self.name) is not None
+            ):
                 raise
             saved_fs = self._fs
             self._fs = type(self).create_fs(**{**self.fs_kwargs, "anon": True})
@@ -84,8 +87,9 @@ def _anon_fallback(method):
                 result = method(self, *args, **kwargs)
             except PermissionError:
                 self._fs = saved_fs
+                self._mark_bucket_anon(self.name, False)
                 raise
-            self._mark_bucket_anon(self.name)
+            self._mark_bucket_anon(self.name, True)
             return result
 
     return wrapper
@@ -98,10 +102,11 @@ class Client(ABC):
     protocol: ClassVar[str]
     # client_config keys this backend treats as credentials.
     CREDENTIAL_KEYS: ClassVar[frozenset[str]] = frozenset()
-    # Process-local cache of (protocol, bucket) pairs that have been
-    # resolved as needing anonymous access. Populated only after an anon
-    # retry actually succeeds.
-    _ANON_BUCKETS: ClassVar[set[tuple[str, str]]] = set()
+    # Process-local cache of (protocol, bucket) anon decisions.
+    # True  = anon retry succeeded, use anon from the start.
+    # False = anon retry also failed, don't bother retrying again.
+    # Missing key = no decision yet.
+    _ANON_BUCKETS: ClassVar[dict[tuple[str, str], bool]] = {}
 
     @classmethod
     def has_explicit_credentials(cls, client_config: dict | None) -> bool:
@@ -111,12 +116,12 @@ class Client(ABC):
         return any(k in client_config for k in cls.CREDENTIAL_KEYS)
 
     @classmethod
-    def _bucket_needs_anon(cls, name: str) -> bool:
-        return (cls.protocol, name) in cls._ANON_BUCKETS
+    def _bucket_needs_anon(cls, name: str) -> bool | None:
+        return cls._ANON_BUCKETS.get((cls.protocol, name))
 
     @classmethod
-    def _mark_bucket_anon(cls, name: str) -> None:
-        cls._ANON_BUCKETS.add((cls.protocol, name))
+    def _mark_bucket_anon(cls, name: str, anon: bool) -> None:
+        cls._ANON_BUCKETS[(cls.protocol, name)] = anon
 
     def __init__(self, name: str, fs_kwargs: dict[str, Any], cache: Cache) -> None:
         self.name = name
@@ -273,7 +278,7 @@ class Client(ABC):
     def fs(self) -> "AbstractFileSystem":
         if not self._fs:
             kwargs = dict(self.fs_kwargs)
-            if self._bucket_needs_anon(self.name):
+            if self._bucket_needs_anon(self.name) is True:
                 kwargs["anon"] = True
             self._fs = self.create_fs(**kwargs)
         return self._fs

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -63,6 +63,34 @@ class BucketStatus(NamedTuple):
     error: str | None = None
 
 
+def _anon_fallback(method):
+    """Retry a Client method once with anonymous access on PermissionError.
+
+    Only marks the bucket as anon-needed if the retry actually succeeds, so
+    genuinely inaccessible buckets keep raising clean errors instead of
+    being silently cached as anon.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except PermissionError:
+            if self.fs_kwargs.get("anon") or self._bucket_needs_anon(self.name):
+                raise
+            saved_fs = self._fs
+            self._fs = type(self).create_fs(**{**self.fs_kwargs, "anon": True})
+            try:
+                result = method(self, *args, **kwargs)
+            except PermissionError:
+                self._fs = saved_fs
+                raise
+            self._mark_bucket_anon(self.name)
+            return result
+
+    return wrapper
+
+
 class Client(ABC):
     MAX_THREADS = multiprocessing.cpu_count()
     FS_CLASS: ClassVar[type["AbstractFileSystem"]]
@@ -70,6 +98,10 @@ class Client(ABC):
     protocol: ClassVar[str]
     # client_config keys this backend treats as credentials.
     CREDENTIAL_KEYS: ClassVar[frozenset[str]] = frozenset()
+    # Process-local cache of (protocol, bucket) pairs that have been
+    # resolved as needing anonymous access. Populated only after an anon
+    # retry actually succeeds.
+    _ANON_BUCKETS: ClassVar[set[tuple[str, str]]] = set()
 
     @classmethod
     def has_explicit_credentials(cls, client_config: dict | None) -> bool:
@@ -77,6 +109,14 @@ class Client(ABC):
         if not client_config:
             return False
         return any(k in client_config for k in cls.CREDENTIAL_KEYS)
+
+    @classmethod
+    def _bucket_needs_anon(cls, name: str) -> bool:
+        return (cls.protocol, name) in cls._ANON_BUCKETS
+
+    @classmethod
+    def _mark_bucket_anon(cls, name: str) -> None:
+        cls._ANON_BUCKETS.add((cls.protocol, name))
 
     def __init__(self, name: str, fs_kwargs: dict[str, Any], cache: Cache) -> None:
         self.name = name
@@ -232,7 +272,10 @@ class Client(ABC):
     @property
     def fs(self) -> "AbstractFileSystem":
         if not self._fs:
-            self._fs = self.create_fs(**self.fs_kwargs)
+            kwargs = dict(self.fs_kwargs)
+            if self._bucket_needs_anon(self.name):
+                kwargs["anon"] = True
+            self._fs = self.create_fs(**kwargs)
         return self._fs
 
     def url(
@@ -251,6 +294,7 @@ class Client(ABC):
         info = await self.fs._info(full_path, **self._file_info_kwargs(file.version))
         return self.info_to_file(info, file.path).etag
 
+    @_anon_fallback
     def get_file_info(self, path: str, version_id: str | None = None) -> "File":
         self.validate_file_path(path)
         full_path = self.get_uri(path)
@@ -435,6 +479,7 @@ class Client(ABC):
             # Default to copy if reflinks are not supported
             shutil.copy2(src, dst)
 
+    @_anon_fallback
     def open_object(
         self, file: "File", use_cache: bool = True, cb: Callback = DEFAULT_CALLBACK
     ) -> BinaryIO:

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -64,15 +64,37 @@ class BucketStatus(NamedTuple):
 
 
 class AnonFallbackFS:
-    """Proxy for an fsspec ``AbstractFileSystem`` that retries any method on
-    ``PermissionError`` with ``anon=True``, and caches the decision per
+    """Proxy for an fsspec ``AbstractFileSystem`` that retries read methods
+    on ``PermissionError`` with ``anon=True``, and caches the decision per
     ``(protocol, bucket)`` so future calls go straight to the right mode.
 
-    Wrapping at this layer (rather than on individual ``Client`` methods)
-    means every code path that goes through ``self.fs`` is covered - both
-    sync paths (``get_file_info``, ``open_object``) and async ones
-    (``get_current_etag``, ``get_file``, ``get_size``).
+    Only read methods are wrapped - anon is read-only on every cloud
+    backend, so retrying writes would always fail and would mis-mark the
+    bucket as anon-impossible, defeating the feature for later reads.
     """
+
+    # fsspec read-side methods we wrap. ``open`` / ``_open`` are also here
+    # but the wrapper checks ``mode`` and skips retry for write modes.
+    READ_METHODS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "_info",
+            "_open",
+            "open",
+            "_cat_file",
+            "_ls",
+            "_get_file",
+            "_glob",
+            "_walk",
+            "_find",
+            "_du",
+            "_size",
+            "_exists",
+            "_isdir",
+            "_isfile",
+            "_modified",
+            "sign",
+        }
+    )
 
     def __init__(self, client: "Client") -> None:
         self._client = client
@@ -92,11 +114,17 @@ class AnonFallbackFS:
 
     def __getattr__(self, name: str):
         attr = getattr(self._inner_fs, name)
-        if not callable(attr):
+        if not callable(attr) or name not in self.READ_METHODS:
             return attr
         if asyncio.iscoroutinefunction(attr):
             return self._wrap_async(name, attr)
         return self._wrap_sync(name, attr)
+
+    @staticmethod
+    def _is_write_open(args, kwargs) -> bool:
+        """``open`` / ``_open`` mode arg indicates write/append/exclusive."""
+        mode = args[1] if len(args) >= 2 else kwargs.get("mode", "rb")
+        return any(c in mode for c in "wax+")
 
     def _should_use_anon_cache(self) -> bool:
         # Clients with explicit creds skip the shared anon cache - reading
@@ -118,6 +146,8 @@ class AnonFallbackFS:
 
     def _wrap_sync(self, name, attr):
         def call(*args, **kwargs):
+            if name in ("open", "_open") and self._is_write_open(args, kwargs):
+                return attr(*args, **kwargs)
             try:
                 return attr(*args, **kwargs)
             except PermissionError:
@@ -144,6 +174,8 @@ class AnonFallbackFS:
 
     def _wrap_async(self, name, attr):
         async def call(*args, **kwargs):
+            if name in ("open", "_open") and self._is_write_open(args, kwargs):
+                return await attr(*args, **kwargs)
             try:
                 return await attr(*args, **kwargs)
             except PermissionError:

--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -125,16 +125,20 @@ class AnonFallbackFS:
                     raise
                 saved = self._inner_fs
                 self._swap_to_anon()
+                keep_anon = False
                 try:
                     result = getattr(self._inner_fs, name)(*args, **kwargs)
+                    keep_anon = True
+                    if self._should_use_anon_cache():
+                        self._client._mark_bucket_anon(self._client.name, True)
+                    return result
                 except PermissionError:
-                    self._inner_fs = saved
                     if self._should_use_anon_cache():
                         self._client._mark_bucket_anon(self._client.name, False)
                     raise
-                if self._should_use_anon_cache():
-                    self._client._mark_bucket_anon(self._client.name, True)
-                return result
+                finally:
+                    if not keep_anon:
+                        self._inner_fs = saved
 
         return call
 
@@ -147,16 +151,20 @@ class AnonFallbackFS:
                     raise
                 saved = self._inner_fs
                 self._swap_to_anon()
+                keep_anon = False
                 try:
                     result = await getattr(self._inner_fs, name)(*args, **kwargs)
+                    keep_anon = True
+                    if self._should_use_anon_cache():
+                        self._client._mark_bucket_anon(self._client.name, True)
+                    return result
                 except PermissionError:
-                    self._inner_fs = saved
                     if self._should_use_anon_cache():
                         self._client._mark_bucket_anon(self._client.name, False)
                     raise
-                if self._should_use_anon_cache():
-                    self._client._mark_bucket_anon(self._client.name, True)
-                return result
+                finally:
+                    if not keep_anon:
+                        self._inner_fs = saved
 
         return call
 

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -16,7 +16,7 @@ from datachain.client.fileslice import FileWrapper
 from datachain.lib.file import File
 from datachain.progress import tqdm
 
-from .fsspec import DELIMITER, BucketStatus, Client, ResultQueue
+from .fsspec import DELIMITER, BucketStatus, Client, ResultQueue, _anon_fallback
 
 # Patch gcsfs for consistency with s3fs
 GCSFileSystem.set_session = GCSFileSystem._set_session
@@ -154,6 +154,7 @@ class GCSClient(Client):
         info = await self.fs._info(path)
         return self.info_to_file(info, file.path).etag
 
+    @_anon_fallback
     def get_file_info(self, path: str, version_id: str | None = None) -> File:
         self.validate_file_path(path)
         fs_path = self._path_with_generation(self.get_uri(path), version_id)
@@ -168,6 +169,7 @@ class GCSClient(Client):
             raise FileNotFoundError(file.get_fs_path())
         return int(size)
 
+    @_anon_fallback
     def open_object(
         self,
         file: File,

--- a/src/datachain/client/gcs.py
+++ b/src/datachain/client/gcs.py
@@ -16,7 +16,7 @@ from datachain.client.fileslice import FileWrapper
 from datachain.lib.file import File
 from datachain.progress import tqdm
 
-from .fsspec import DELIMITER, BucketStatus, Client, ResultQueue, _anon_fallback
+from .fsspec import DELIMITER, BucketStatus, Client, ResultQueue
 
 # Patch gcsfs for consistency with s3fs
 GCSFileSystem.set_session = GCSFileSystem._set_session
@@ -30,6 +30,7 @@ class GCSClient(Client):
     PREFIX = "gs://"
     protocol = "gs"
     CREDENTIAL_KEYS = frozenset({"token"})
+    _ANON_FALLBACK = True
 
     @classmethod
     def create_fs(cls, **kwargs) -> GCSFileSystem:
@@ -154,7 +155,6 @@ class GCSClient(Client):
         info = await self.fs._info(path)
         return self.info_to_file(info, file.path).etag
 
-    @_anon_fallback
     def get_file_info(self, path: str, version_id: str | None = None) -> File:
         self.validate_file_path(path)
         fs_path = self._path_with_generation(self.get_uri(path), version_id)
@@ -169,7 +169,6 @@ class GCSClient(Client):
             raise FileNotFoundError(file.get_fs_path())
         return int(size)
 
-    @_anon_fallback
     def open_object(
         self,
         file: File,

--- a/src/datachain/client/s3.py
+++ b/src/datachain/client/s3.py
@@ -21,6 +21,7 @@ class ClientS3(Client):
     CREDENTIAL_KEYS = frozenset(
         {"key", "secret", "token", "aws_key", "aws_secret", "aws_token"}
     )
+    _ANON_FALLBACK = True
 
     @staticmethod
     def _normalize_s3_kwargs(kwargs: dict) -> dict:

--- a/tests/func/test_storage_auto_anon.py
+++ b/tests/func/test_storage_auto_anon.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 import pytest
 
 import datachain as dc
+from datachain.cache import Cache
+from datachain.client import Client
 from datachain.client.azure import AzureClient
+from datachain.client.fsspec import AnonFallbackFS
 from datachain.client.gcs import GCSClient
 from datachain.client.s3 import ClientS3
 
@@ -71,3 +74,22 @@ def test_explicit_anon_skips_auto_detect(probe, explicit, tmp_dir, catalog):
     chain = dc.read_storage(tmp_dir.as_uri(), anon=explicit)
     probe.assert_not_called()
     assert chain.session.catalog.client_config.get("anon") is explicit
+
+
+@pytest.mark.parametrize("cloud_type", ["s3", "gs"], indirect=True)
+def test_anon_fallback_proxy_integration(
+    cloud_server, cloud_server_credentials, tmp_path
+):
+    cache = Cache(str(tmp_path / "cache"), str(tmp_path / "tmp"))
+    client = Client.get_client(
+        cloud_server.src_uri, cache, **cloud_server.client_config
+    )
+
+    # Building fs returns the proxy for cloud clients.
+    _ = client.fs
+    assert isinstance(client._fs, AnonFallbackFS)
+
+    # End-to-end op through proxy → real fsspec → emulator.
+    info = client.get_file_info("description")
+    assert info.path == "description"
+    assert info.size and info.size > 0

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -38,9 +38,9 @@ def test_parse_file_path_ends_with_slash(cloud_type):
 
 @pytest.fixture
 def _clear_anon_cache():
-    Client._ANON_BUCKETS.clear()
+    Client._anon_buckets.clear()
     yield
-    Client._ANON_BUCKETS.clear()
+    Client._anon_buckets.clear()
 
 
 def _gcs_client(bucket: str = "foo", **fs_kwargs) -> GCSClient:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -198,3 +198,25 @@ def test_anon_fallback_explicit_creds_anon_retry_does_not_cache(
 
     # Cache untouched.
     assert GCSClient._bucket_needs_anon("foo") is None
+
+
+def test_anon_fallback_write_open_no_retry_no_cache_poisoning(
+    monkeypatch, _clear_anon_cache
+):
+    # A write-mode open that fails with PermissionError must NOT trigger
+    # an anon retry (anon can never write) and must NOT poison the cache
+    # with False - otherwise future legitimate reads would lose fallback.
+    auth_fs = MagicMock()
+    auth_fs.open = MagicMock(side_effect=PermissionError)
+    create_fs = MagicMock(return_value=auth_fs)
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    client = _gcs_client()
+    with pytest.raises(PermissionError):
+        client.fs.open("gs://foo/x.txt", "wb")
+
+    # No anon fs was built (no retry attempted).
+    create_fs.assert_called_once()
+    assert create_fs.call_args.kwargs.get("anon") is None
+    # Cache is clean - subsequent reads can still fall back.
+    assert GCSClient._bucket_needs_anon("foo") is None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -47,10 +47,8 @@ def _gcs_client(bucket: str = "foo", **fs_kwargs) -> GCSClient:
     return GCSClient(bucket, fs_kwargs, MagicMock())
 
 
-def test_anon_fallback_no_error_no_retry(monkeypatch, _clear_anon_cache):
-    client = _gcs_client()
-    client._fs = MagicMock()
-    client._fs._info = AsyncMock(
+def _info_ok():
+    return AsyncMock(
         return_value={
             "name": "gs://foo/x.txt",
             "size": 1,
@@ -58,107 +56,104 @@ def test_anon_fallback_no_error_no_retry(monkeypatch, _clear_anon_cache):
             "updated": "2024-01-01T00:00:00Z",
         }
     )
-    create_fs = MagicMock()
+
+
+def test_anon_fallback_no_error_no_retry(monkeypatch, _clear_anon_cache):
+    auth_fs = MagicMock()
+    auth_fs._info = _info_ok()
+    create_fs = MagicMock(return_value=auth_fs)
     monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
+    client = _gcs_client()
     client.get_file_info("x.txt")
 
-    create_fs.assert_not_called()
-    assert not GCSClient._bucket_needs_anon("foo")
+    create_fs.assert_called_once()
+    assert create_fs.call_args.kwargs.get("anon") is None
+    assert GCSClient._bucket_needs_anon("foo") is None
 
 
 def test_anon_fallback_retry_succeeds_marks_bucket(monkeypatch, _clear_anon_cache):
-    client = _gcs_client()
     auth_fs = MagicMock()
     auth_fs._info = AsyncMock(side_effect=PermissionError)
-    client._fs = auth_fs
-
     anon_fs = MagicMock()
-    anon_fs._info = AsyncMock(
-        return_value={
-            "name": "gs://foo/x.txt",
-            "size": 1,
-            "etag": "e",
-            "updated": "2024-01-01T00:00:00Z",
-        }
-    )
-    monkeypatch.setattr(GCSClient, "create_fs", MagicMock(return_value=anon_fs))
+    anon_fs._info = _info_ok()
+    create_fs = MagicMock(side_effect=[auth_fs, anon_fs])
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
+    client = _gcs_client()
     client.get_file_info("x.txt")
 
-    assert GCSClient._bucket_needs_anon("foo")
-    assert client._fs is anon_fs
-    assert GCSClient.create_fs.call_args.kwargs.get("anon") is True
+    assert GCSClient._bucket_needs_anon("foo") is True
+    assert create_fs.call_count == 2
+    assert create_fs.call_args_list[1].kwargs.get("anon") is True
 
 
 def test_anon_fallback_retry_also_fails_marks_as_failed(monkeypatch, _clear_anon_cache):
-    client = _gcs_client()
     auth_fs = MagicMock()
     auth_fs._info = AsyncMock(side_effect=PermissionError)
-    client._fs = auth_fs
-
     anon_fs = MagicMock()
     anon_fs._info = AsyncMock(side_effect=PermissionError)
-    monkeypatch.setattr(GCSClient, "create_fs", MagicMock(return_value=anon_fs))
+    create_fs = MagicMock(side_effect=[auth_fs, anon_fs])
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
+    client = _gcs_client()
     with pytest.raises(PermissionError):
         client.get_file_info("x.txt")
 
     assert GCSClient._bucket_needs_anon("foo") is False
-    assert client._fs is auth_fs
+    assert create_fs.call_count == 2
 
 
 def test_anon_fallback_cached_as_failed_skips_retry(monkeypatch, _clear_anon_cache):
     GCSClient._mark_bucket_anon("foo", False)
-    client = _gcs_client()
     auth_fs = MagicMock()
     auth_fs._info = AsyncMock(side_effect=PermissionError)
-    client._fs = auth_fs
-    create_fs = MagicMock()
+    create_fs = MagicMock(return_value=auth_fs)
     monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
+    client = _gcs_client()
     with pytest.raises(PermissionError):
         client.get_file_info("x.txt")
 
-    create_fs.assert_not_called()
+    create_fs.assert_called_once()
+    assert create_fs.call_args.kwargs.get("anon") is None
 
 
 def test_anon_fallback_cached_bucket_uses_anon_directly(monkeypatch, _clear_anon_cache):
     GCSClient._mark_bucket_anon("foo", True)
-    create_fs = MagicMock()
+    create_fs = MagicMock(return_value=MagicMock())
     monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
-    _ = _gcs_client().fs
+    _ = _gcs_client().fs._info
 
     create_fs.assert_called_once()
     assert create_fs.call_args.kwargs.get("anon") is True
 
 
 def test_anon_fallback_explicit_anon_no_retry(monkeypatch, _clear_anon_cache):
-    client = _gcs_client(anon=True)
-    client._fs = MagicMock()
-    client._fs._info = AsyncMock(side_effect=PermissionError)
-    create_fs = MagicMock()
+    auth_fs = MagicMock()
+    auth_fs._info = AsyncMock(side_effect=PermissionError)
+    create_fs = MagicMock(return_value=auth_fs)
     monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
+    client = _gcs_client(anon=True)
     with pytest.raises(PermissionError):
         client.get_file_info("x.txt")
 
-    create_fs.assert_not_called()
-    assert not GCSClient._bucket_needs_anon("foo")
+    create_fs.assert_called_once()
+    assert GCSClient._bucket_needs_anon("foo") is None
 
 
 def test_anon_fallback_open_object_retry_succeeds(monkeypatch, _clear_anon_cache):
-    client = _gcs_client()
     auth_fs = MagicMock()
     auth_fs.open = MagicMock(side_effect=PermissionError)
-    client._fs = auth_fs
-    client.cache.get_path = MagicMock(return_value=None)
-
     anon_fs = MagicMock()
     anon_fs.open = MagicMock(return_value=MagicMock())
-    monkeypatch.setattr(GCSClient, "create_fs", MagicMock(return_value=anon_fs))
+    create_fs = MagicMock(side_effect=[auth_fs, anon_fs])
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 
+    client = _gcs_client()
+    client.cache.get_path = MagicMock(return_value=None)
     client.open_object(File(source="gs://foo", path="x.txt"))
 
-    assert GCSClient._bucket_needs_anon("foo")
+    assert GCSClient._bucket_needs_anon("foo") is True

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -157,3 +157,44 @@ def test_anon_fallback_open_object_retry_succeeds(monkeypatch, _clear_anon_cache
     client.open_object(File(source="gs://foo", path="x.txt"))
 
     assert GCSClient._bucket_needs_anon("foo") is True
+
+
+def test_anon_fallback_explicit_creds_ignore_cache(monkeypatch, _clear_anon_cache):
+    # A previous no-creds caller cached the bucket as anon-needed.
+    GCSClient._mark_bucket_anon("foo", True)
+
+    # New client with explicit creds: should NOT use anon directly, should
+    # try with creds first, and should NOT overwrite the cache.
+    auth_fs = MagicMock()
+    auth_fs._info = _info_ok()
+    anon_fs = MagicMock()
+    create_fs = MagicMock(side_effect=[auth_fs, anon_fs])
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    client = _gcs_client(token="explicit-token")  # noqa: S106
+    client.get_file_info("x.txt")
+
+    # Only the auth fs was built, anon was never instantiated.
+    create_fs.assert_called_once()
+    assert create_fs.call_args.kwargs.get("anon") is None
+    # Cache was not touched - still True from the earlier no-creds caller.
+    assert GCSClient._bucket_needs_anon("foo") is True
+
+
+def test_anon_fallback_explicit_creds_anon_retry_does_not_cache(
+    monkeypatch, _clear_anon_cache
+):
+    # Client with explicit creds whose creds fail - anon retry succeeds,
+    # but the success must NOT pollute the shared cache.
+    auth_fs = MagicMock()
+    auth_fs._info = AsyncMock(side_effect=PermissionError)
+    anon_fs = MagicMock()
+    anon_fs._info = _info_ok()
+    create_fs = MagicMock(side_effect=[auth_fs, anon_fs])
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    client = _gcs_client(token="explicit-token")  # noqa: S106
+    client.get_file_info("x.txt")
+
+    # Cache untouched.
+    assert GCSClient._bucket_needs_anon("foo") is None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -36,9 +36,6 @@ def test_parse_file_path_ends_with_slash(cloud_type):
     assert rel_part == ""
 
 
-# Anonymous-access fallback (auto-retry on PermissionError) ---------------
-
-
 @pytest.fixture
 def _clear_anon_cache():
     Client._ANON_BUCKETS.clear()
@@ -94,7 +91,7 @@ def test_anon_fallback_retry_succeeds_marks_bucket(monkeypatch, _clear_anon_cach
     assert GCSClient.create_fs.call_args.kwargs.get("anon") is True
 
 
-def test_anon_fallback_retry_also_fails_does_not_mark(monkeypatch, _clear_anon_cache):
+def test_anon_fallback_retry_also_fails_marks_as_failed(monkeypatch, _clear_anon_cache):
     client = _gcs_client()
     auth_fs = MagicMock()
     auth_fs._info = AsyncMock(side_effect=PermissionError)
@@ -107,12 +104,27 @@ def test_anon_fallback_retry_also_fails_does_not_mark(monkeypatch, _clear_anon_c
     with pytest.raises(PermissionError):
         client.get_file_info("x.txt")
 
-    assert not GCSClient._bucket_needs_anon("foo")
+    assert GCSClient._bucket_needs_anon("foo") is False
     assert client._fs is auth_fs
 
 
+def test_anon_fallback_cached_as_failed_skips_retry(monkeypatch, _clear_anon_cache):
+    GCSClient._mark_bucket_anon("foo", False)
+    client = _gcs_client()
+    auth_fs = MagicMock()
+    auth_fs._info = AsyncMock(side_effect=PermissionError)
+    client._fs = auth_fs
+    create_fs = MagicMock()
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    with pytest.raises(PermissionError):
+        client.get_file_info("x.txt")
+
+    create_fs.assert_not_called()
+
+
 def test_anon_fallback_cached_bucket_uses_anon_directly(monkeypatch, _clear_anon_cache):
-    GCSClient._mark_bucket_anon("foo")
+    GCSClient._mark_bucket_anon("foo", True)
     create_fs = MagicMock()
     monkeypatch.setattr(GCSClient, "create_fs", create_fs)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,11 +1,14 @@
 import os
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from datachain.client import Client
+from datachain.client.gcs import GCSClient
 from datachain.client.local import FileClient
+from datachain.lib.file import File
 
 
 def test_bad_protocol():
@@ -31,3 +34,119 @@ def test_parse_file_path_ends_with_slash(cloud_type):
     uri, rel_part = Client.parse_url("./animals/".replace("/", os.sep))
     assert uri == (Path().absolute() / Path("animals")).as_uri()
     assert rel_part == ""
+
+
+# Anonymous-access fallback (auto-retry on PermissionError) ---------------
+
+
+@pytest.fixture
+def _clear_anon_cache():
+    Client._ANON_BUCKETS.clear()
+    yield
+    Client._ANON_BUCKETS.clear()
+
+
+def _gcs_client(bucket: str = "foo", **fs_kwargs) -> GCSClient:
+    return GCSClient(bucket, fs_kwargs, MagicMock())
+
+
+def test_anon_fallback_no_error_no_retry(monkeypatch, _clear_anon_cache):
+    client = _gcs_client()
+    client._fs = MagicMock()
+    client._fs._info = AsyncMock(
+        return_value={
+            "name": "gs://foo/x.txt",
+            "size": 1,
+            "etag": "e",
+            "updated": "2024-01-01T00:00:00Z",
+        }
+    )
+    create_fs = MagicMock()
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    client.get_file_info("x.txt")
+
+    create_fs.assert_not_called()
+    assert not GCSClient._bucket_needs_anon("foo")
+
+
+def test_anon_fallback_retry_succeeds_marks_bucket(monkeypatch, _clear_anon_cache):
+    client = _gcs_client()
+    auth_fs = MagicMock()
+    auth_fs._info = AsyncMock(side_effect=PermissionError)
+    client._fs = auth_fs
+
+    anon_fs = MagicMock()
+    anon_fs._info = AsyncMock(
+        return_value={
+            "name": "gs://foo/x.txt",
+            "size": 1,
+            "etag": "e",
+            "updated": "2024-01-01T00:00:00Z",
+        }
+    )
+    monkeypatch.setattr(GCSClient, "create_fs", MagicMock(return_value=anon_fs))
+
+    client.get_file_info("x.txt")
+
+    assert GCSClient._bucket_needs_anon("foo")
+    assert client._fs is anon_fs
+    assert GCSClient.create_fs.call_args.kwargs.get("anon") is True
+
+
+def test_anon_fallback_retry_also_fails_does_not_mark(monkeypatch, _clear_anon_cache):
+    client = _gcs_client()
+    auth_fs = MagicMock()
+    auth_fs._info = AsyncMock(side_effect=PermissionError)
+    client._fs = auth_fs
+
+    anon_fs = MagicMock()
+    anon_fs._info = AsyncMock(side_effect=PermissionError)
+    monkeypatch.setattr(GCSClient, "create_fs", MagicMock(return_value=anon_fs))
+
+    with pytest.raises(PermissionError):
+        client.get_file_info("x.txt")
+
+    assert not GCSClient._bucket_needs_anon("foo")
+    assert client._fs is auth_fs
+
+
+def test_anon_fallback_cached_bucket_uses_anon_directly(monkeypatch, _clear_anon_cache):
+    GCSClient._mark_bucket_anon("foo")
+    create_fs = MagicMock()
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    _ = _gcs_client().fs
+
+    create_fs.assert_called_once()
+    assert create_fs.call_args.kwargs.get("anon") is True
+
+
+def test_anon_fallback_explicit_anon_no_retry(monkeypatch, _clear_anon_cache):
+    client = _gcs_client(anon=True)
+    client._fs = MagicMock()
+    client._fs._info = AsyncMock(side_effect=PermissionError)
+    create_fs = MagicMock()
+    monkeypatch.setattr(GCSClient, "create_fs", create_fs)
+
+    with pytest.raises(PermissionError):
+        client.get_file_info("x.txt")
+
+    create_fs.assert_not_called()
+    assert not GCSClient._bucket_needs_anon("foo")
+
+
+def test_anon_fallback_open_object_retry_succeeds(monkeypatch, _clear_anon_cache):
+    client = _gcs_client()
+    auth_fs = MagicMock()
+    auth_fs.open = MagicMock(side_effect=PermissionError)
+    client._fs = auth_fs
+    client.cache.get_path = MagicMock(return_value=None)
+
+    anon_fs = MagicMock()
+    anon_fs.open = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(GCSClient, "create_fs", MagicMock(return_value=anon_fs))
+
+    client.open_object(File(source="gs://foo", path="x.txt"))
+
+    assert GCSClient._bucket_needs_anon("foo")


### PR DESCRIPTION
Closes #1778.

When a `File` read (`open_object` / `get_file_info`) hits `PermissionError` on a cloud client that has credentials but no access to the target bucket, automatically retry with `anon=True` and cache the result per `(protocol, bucket)` so subsequent calls go straight to anonymous mode.

- Adds `_anon_fallback` decorator and `_ANON_BUCKETS` class-level cache on `Client`
- `Client.fs` honors the cache so cached buckets are created anonymously from the start
- Decorates `open_object` and `get_file_info` on the base `Client` and on `GCSClient` (which overrides both)
- Only marks the bucket as anon-needed after the retry actually succeeds; explicit `anon=True` skips the retry