### PR TITLE
Small tweak to skill prompt about JSON input

### DIFF
--- a/src/datachain/skill/knowledge/prompts/enrich.md
+++ b/src/datachain/skill/knowledge/prompts/enrich.md
@@ -4,7 +4,7 @@ Generate a human-readable one short paragraph summary for a DataChain dataset fr
 
 ## Input
 
-Read the JSON file at the path provided. It contains:
+The input is a JSON document with these fields:
 
 - `name`: dataset name
 - `source`: `"local"` or `"studio"`

--- a/src/datachain/skill/knowledge/prompts/enrich_bucket.md
+++ b/src/datachain/skill/knowledge/prompts/enrich_bucket.md
@@ -4,7 +4,7 @@ Generate a human-readable markdown overview for a cloud storage bucket from its 
 
 ## Input
 
-Read the JSON file at the path provided. It contains:
+The input is a JSON document with these fields:
 
 - `uri`: the full storage URI
 - `scheme`: storage scheme (s3, gs, az)


### PR DESCRIPTION
Required for SaaS — rephrase a little bit — no "JSON file" there, but "JSON input". Should works for both CLI and SaaS.