### PR TITLE
Fix numpy JSON serialization at storage boundaries

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -2352,7 +2352,7 @@ class AbstractDBMetastore(AbstractMetastore):
         if finished_at is not None:
             values["finished_at"] = finished_at
         if metrics:
-            values["metrics"] = json.dumps(metrics, serialize_numpy=True)
+            values["metrics"] = json.dumps(metrics)
 
         if values:
             j = self._jobs

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -2352,7 +2352,7 @@ class AbstractDBMetastore(AbstractMetastore):
         if finished_at is not None:
             values["finished_at"] = finished_at
         if metrics:
-            values["metrics"] = json.dumps(metrics)
+            values["metrics"] = json.dumps(metrics, serialize_numpy=True)
 
         if values:
             j = self._jobs

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -107,7 +107,11 @@ class AbstractWarehouse(ABC, Serializable):
             out: dict[str, Any] = {}
             for k, v in obj.items():
                 if not isinstance(k, str):
-                    key_str = json.dumps(self._to_jsonable(k), ensure_ascii=False)
+                    key_str = json.dumps(
+                        self._to_jsonable(k),
+                        ensure_ascii=False,
+                        serialize_numpy=True,
+                    )
                 else:
                     key_str = k
                 out[key_str] = self._to_jsonable(v)
@@ -170,7 +174,7 @@ class AbstractWarehouse(ABC, Serializable):
                 return val
             json_ready = self._to_jsonable(val)
             try:
-                return json.dumps(json_ready, ensure_ascii=False)
+                return json.dumps(json_ready, ensure_ascii=False, serialize_numpy=True)
             except TypeError as e:
                 raise JsonSerializationError(
                     f"JSON serialization error: {e}",

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -104,7 +104,8 @@ def _numpy_to_python(value: Any, numpy_module) -> Any:
     if isinstance(value, numpy_module.generic):
         return value.tolist()
     if isinstance(value, (list, tuple, set)):
-        return [_numpy_to_python(item, numpy_module) for item in value]
+        converted = [_numpy_to_python(item, numpy_module) for item in value]
+        return tuple(converted) if isinstance(value, tuple) else converted
     if isinstance(value, dict):
         return {
             _numpy_to_python(key, numpy_module): _numpy_to_python(item, numpy_module)

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -9,6 +9,7 @@ All code inside DataChain should import this module instead of using
 
 import datetime as _dt
 import json as _json
+import sys as _sys
 import uuid as _uuid
 from collections.abc import Callable
 from typing import Any
@@ -58,35 +59,75 @@ def _format_time(value: _dt.time) -> str:
     return iso
 
 
-def _coerce(value: Any, serialize_bytes: bool) -> Any:
+def _coerce(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
     """Return a JSON-serializable representation for supported extra types."""
 
+    converted = _SENTINEL
     if isinstance(value, _dt.datetime):
-        return _format_datetime(value)
-    if isinstance(value, _dt.date):
-        return value.isoformat()
-    if isinstance(value, _dt.time):
-        return _format_time(value)
-    if isinstance(value, _uuid.UUID):
-        return str(value)
-    if serialize_bytes and isinstance(value, (bytes, bytearray)):
-        return list(bytes(value)[:DEFAULT_PREVIEW_BYTES])
+        converted = _format_datetime(value)
+    elif isinstance(value, _dt.date):
+        converted = value.isoformat()
+    elif isinstance(value, _dt.time):
+        converted = _format_time(value)
+    elif isinstance(value, _uuid.UUID):
+        converted = str(value)
+
+    if converted is _SENTINEL and serialize_numpy:
+        converted = _coerce_numpy(value)
+    if (
+        converted is _SENTINEL
+        and serialize_bytes
+        and isinstance(value, (bytes, bytearray))
+    ):
+        converted = list(bytes(value)[:DEFAULT_PREVIEW_BYTES])
+
+    return converted
+
+
+def _coerce_numpy(value: Any) -> Any:
+    if "numpy" not in _sys.modules:
+        return _SENTINEL
+
+    import numpy as np
+
+    if isinstance(value, (np.ndarray, np.generic)):
+        return _numpy_to_python(value, np)
     return _SENTINEL
 
 
-def _base_default(value: Any, serialize_bytes: bool) -> Any:
-    converted = _coerce(value, serialize_bytes)
+def _numpy_to_python(value: Any, numpy_module) -> Any:
+    if isinstance(value, numpy_module.ndarray):
+        converted = value.tolist()
+        if value.dtype != object:
+            return converted
+        return _numpy_to_python(converted, numpy_module)
+    if isinstance(value, numpy_module.generic):
+        return value.tolist()
+    if isinstance(value, (list, tuple, set)):
+        return [_numpy_to_python(item, numpy_module) for item in value]
+    if isinstance(value, dict):
+        return {
+            _numpy_to_python(key, numpy_module): _numpy_to_python(item, numpy_module)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _base_default(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
+    converted = _coerce(value, serialize_bytes, serialize_numpy)
     if converted is not _SENTINEL:
         return converted
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
-def _build_default(user_default: _Default | None, serialize_bytes: bool) -> _Default:
+def _build_default(
+    user_default: _Default | None, serialize_bytes: bool, serialize_numpy: bool
+) -> _Default:
     if user_default is None:
-        return lambda value: _base_default(value, serialize_bytes)
+        return lambda value: _base_default(value, serialize_bytes, serialize_numpy)
 
     def combined(value: Any) -> Any:
-        converted = _coerce(value, serialize_bytes)
+        converted = _coerce(value, serialize_bytes, serialize_numpy)
         if converted is not _SENTINEL:
             return converted
         return user_default(value)
@@ -99,14 +140,19 @@ def dumps(
     *,
     default: _Default | None = None,
     serialize_bytes: bool = False,
+    serialize_numpy: bool = False,
     **kwargs: Any,
 ) -> str:
     """Serialize *obj* to a JSON-formatted ``str``."""
 
     if serialize_bytes:
-        return _json.dumps(obj, default=_build_default(default, True), **kwargs)
+        return _json.dumps(
+            obj, default=_build_default(default, True, serialize_numpy), **kwargs
+        )
 
-    return _ujson.dumps(obj, default=_build_default(default, False), **kwargs)
+    return _ujson.dumps(
+        obj, default=_build_default(default, False, serialize_numpy), **kwargs
+    )
 
 
 def dump(
@@ -115,15 +161,20 @@ def dump(
     *,
     default: _Default | None = None,
     serialize_bytes: bool = False,
+    serialize_numpy: bool = False,
     **kwargs: Any,
 ) -> None:
     """Serialize *obj* as a JSON formatted stream to *fp*."""
 
     if serialize_bytes:
-        _json.dump(obj, fp, default=_build_default(default, True), **kwargs)
+        _json.dump(
+            obj, fp, default=_build_default(default, True, serialize_numpy), **kwargs
+        )
         return
 
-    _ujson.dump(obj, fp, default=_build_default(default, False), **kwargs)
+    _ujson.dump(
+        obj, fp, default=_build_default(default, False, serialize_numpy), **kwargs
+    )
 
 
 def loads(s: str | bytes | bytearray, **kwargs: Any) -> Any:

--- a/src/datachain/sql/sqlite/types.py
+++ b/src/datachain/sql/sqlite/types.py
@@ -1,5 +1,7 @@
 import sqlite3
 from datetime import timezone
+from importlib import import_module
+from typing import Any
 
 from sqlalchemy import types
 
@@ -7,11 +9,9 @@ from datachain import json
 from datachain.sql.types import TypeConverter, TypeReadConverter
 
 try:
-    import numpy as np
-
-    numpy_imported = True
+    np: Any | None = import_module("numpy")
 except ImportError:
-    numpy_imported = False
+    np = None
 
 
 class Array(types.UserDefinedType):
@@ -29,11 +29,11 @@ class Array(types.UserDefinedType):
 
 
 def adapt_array(arr):
-    return json.dumps(arr, ensure_ascii=False)
+    return json.dumps(arr, ensure_ascii=False, serialize_numpy=True)
 
 
 def adapt_dict(dct):
-    return json.dumps(dct, ensure_ascii=False)
+    return json.dumps(dct, ensure_ascii=False, serialize_numpy=True)
 
 
 def convert_array(arr):
@@ -41,9 +41,9 @@ def convert_array(arr):
 
 
 def adapt_np_array(arr):
-    # Primarily needed for UDF numpy results (e.g. WDS)
-    # tolist() gives nested Python lists + native scalars; ujson.dumps handles NaN/Inf.
-    return json.dumps(arr.tolist(), ensure_ascii=False)
+    # Needed for numpy values produced locally by UDFs and by parquet readers
+    # during remote pulls. datachain.json handles nested object arrays.
+    return json.dumps(arr, ensure_ascii=False, serialize_numpy=True)
 
 
 def adapt_np_generic(val):
@@ -54,7 +54,7 @@ def register_type_converters():
     sqlite3.register_adapter(list, adapt_array)
     sqlite3.register_adapter(dict, adapt_dict)
     sqlite3.register_converter("ARRAY", convert_array)
-    if numpy_imported:
+    if np is not None:
         sqlite3.register_adapter(np.ndarray, adapt_np_array)
         sqlite3.register_adapter(np.int32, adapt_np_generic)
         sqlite3.register_adapter(np.int64, adapt_np_generic)

--- a/src/datachain/sql/sqlite/types.py
+++ b/src/datachain/sql/sqlite/types.py
@@ -1,7 +1,5 @@
 import sqlite3
 from datetime import timezone
-from importlib import import_module
-from typing import Any
 
 from sqlalchemy import types
 
@@ -9,9 +7,11 @@ from datachain import json
 from datachain.sql.types import TypeConverter, TypeReadConverter
 
 try:
-    np: Any | None = import_module("numpy")
+    import numpy as np
+
+    numpy_imported = True
 except ImportError:
-    np = None
+    numpy_imported = False
 
 
 class Array(types.UserDefinedType):
@@ -54,7 +54,7 @@ def register_type_converters():
     sqlite3.register_adapter(list, adapt_array)
     sqlite3.register_adapter(dict, adapt_dict)
     sqlite3.register_converter("ARRAY", convert_array)
-    if np is not None:
+    if numpy_imported:
         sqlite3.register_adapter(np.ndarray, adapt_np_array)
         sqlite3.register_adapter(np.int32, adapt_np_generic)
         sqlite3.register_adapter(np.int64, adapt_np_generic)

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any
 
+import numpy as np
 import pytest
 import ujson as json
 from pydantic import BaseModel, ConfigDict
@@ -146,6 +147,18 @@ def test_convert_type(test_session):
     assert run_convert_type({"ts": dt_value}, JSON()) == '{"ts":"2024-01-02T03:04:05"}'
     # primitives should serialize to valid JSON
     assert run_convert_type(0.5, JSON()) == "0.5"
+
+    out = run_convert_type(
+        {
+            "a": np.array([1, 2], dtype=np.int64),
+            "b": {"score": np.float32(0.5)},
+        },
+        JSON(),
+    )
+    assert json.loads(out) == {"a": [1, 2], "b": {"score": 0.5}}
+
+    out = run_convert_type({np.int64(7): "v"}, JSON())
+    assert json.loads(out) == {"7": "v"}
 
     # JSON with Pydantic models (values and nested)
     class MyFr(BaseModel):

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-import numpy as np
 import pytest
 
 from datachain.data_storage import JobQueryType, JobStatus
@@ -1005,10 +1004,7 @@ def test_update_job(metastore):
         error_message="err",
         error_stack="stack",
         finished_at=datetime.now(timezone.utc),
-        metrics={
-            "acc": np.float32(0.5),
-            "hist": np.array([1, 2], dtype=np.int64),
-        },
+        metrics={"acc": 0.5, "hist": [1, 2]},
     )
     assert updated.status == JobStatus.FAILED
     assert updated.error_message == "err"

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+import numpy as np
 import pytest
 
 from datachain.data_storage import JobQueryType, JobStatus
@@ -1004,13 +1005,16 @@ def test_update_job(metastore):
         error_message="err",
         error_stack="stack",
         finished_at=datetime.now(timezone.utc),
-        metrics={"acc": 0.99},
+        metrics={
+            "acc": np.float32(0.5),
+            "hist": np.array([1, 2], dtype=np.int64),
+        },
     )
     assert updated.status == JobStatus.FAILED
     assert updated.error_message == "err"
     assert updated.error_stack == "stack"
     assert updated.finished_at is not None
-    assert updated.metrics == {"acc": 0.99}
+    assert updated.metrics == {"acc": 0.5, "hist": [1, 2]}
 
 
 def test_set_job_status(metastore):

--- a/tests/unit/sql/sqlite/test_types.py
+++ b/tests/unit/sql/sqlite/test_types.py
@@ -17,8 +17,11 @@ from datachain.sql.sqlite.types import (
     adapt_array,
     adapt_dict,
     adapt_np_array,
+    adapt_np_generic,
+    convert_array,
 )
 from datachain.sql.types import DateTime as DCDateTime
+from datachain.sql.types import Int as DCInt
 
 
 class ValueErrorTZ(tzinfo):
@@ -78,6 +81,20 @@ def test_adapt_np_array_with_nested_object_arrays():
 def test_adapt_array_and_dict_with_nested_numpy_values():
     assert adapt_array([np.array([1, 2], dtype=np.int64)]) == "[[1,2]]"
     assert adapt_dict({"value": np.float32(0.5)}) == '{"value":0.5}'
+
+
+def test_adapt_np_generic():
+    assert adapt_np_generic(np.float32(0.5)) == 0.5
+
+
+def test_convert_array():
+    assert convert_array("[1,2]") == [1, 2]
+
+
+def test_sqlite_type_read_converter_array_decodes_json_string():
+    converter = SQLiteTypeReadConverter()
+
+    assert converter.array("[1,2]", DCInt(), sqlite_base.sqlite_dialect) == [1, 2]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sql/sqlite/test_types.py
+++ b/tests/unit/sql/sqlite/test_types.py
@@ -14,6 +14,8 @@ from datachain.sql.sqlite.base import (
 )
 from datachain.sql.sqlite.types import (
     SQLiteTypeReadConverter,
+    adapt_array,
+    adapt_dict,
     adapt_np_array,
 )
 from datachain.sql.types import DateTime as DCDateTime
@@ -63,6 +65,19 @@ def test_adapt_np_array_nan_inf():
     assert parsed[0][1] == 1.0
     assert parsed[1][0] == 2.0
     assert np.isinf(parsed[1][1])
+
+
+def test_adapt_np_array_with_nested_object_arrays():
+    arr = np.empty(2, dtype=object)
+    arr[0] = np.array([1, 2], dtype=np.int64)
+    arr[1] = np.array([3, 4], dtype=np.int64)
+
+    assert adapt_np_array(arr) == "[[1,2],[3,4]]"
+
+
+def test_adapt_array_and_dict_with_nested_numpy_values():
+    assert adapt_array([np.array([1, 2], dtype=np.int64)]) == "[[1,2]]"
+    assert adapt_dict({"value": np.float32(0.5)}) == '{"value":0.5}'
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import io
+import sys
 
 import numpy as np
 import pytest
@@ -83,3 +84,62 @@ def test_numpy_serialization_handles_nested_values() -> None:
     assert json.loads(
         json.dumps({"payload": payload}, serialize_bytes=True, serialize_numpy=True)
     ) == {"payload": [[1, 2], {"7": 0.5}]}
+
+
+def test_numpy_serialization_does_not_import_numpy_for_other_values(
+    monkeypatch,
+) -> None:
+    monkeypatch.delitem(sys.modules, "numpy", raising=False)
+
+    with pytest.raises(TypeError, match="Unexpected"):
+        json.dumps({"payload": Unexpected()}, serialize_numpy=True)
+
+    assert "numpy" not in sys.modules
+
+
+def test_numpy_serialization_preserves_tuple_dict_keys_for_encoder() -> None:
+    payload = np.empty(1, dtype=object)
+    payload[0] = {(np.int64(1), np.int64(2)): "value"}
+
+    with pytest.raises(TypeError, match="keys must be"):
+        json.dumps({"payload": payload}, serialize_bytes=True, serialize_numpy=True)
+
+
+def test_numpy_serialization_handles_scalars_and_fast_array_path() -> None:
+    encoded = json.loads(
+        json.dumps(
+            {
+                "score": np.float32(0.5),
+                "values": np.array([1, 2], dtype=np.int64),
+            },
+            serialize_numpy=True,
+        )
+    )
+
+    assert encoded == {"score": 0.5, "values": [1, 2]}
+
+
+def test_numpy_serialization_preserves_user_default() -> None:
+    def default(value):
+        if isinstance(value, Unexpected):
+            return "handled"
+        raise TypeError
+
+    encoded = json.loads(
+        json.dumps(
+            {"payload": [np.array([1, 2], dtype=np.int64), Unexpected()]},
+            default=default,
+            serialize_numpy=True,
+        )
+    )
+
+    assert encoded == {"payload": [[1, 2], "handled"]}
+
+
+def test_dump_serialize_numpy_writes_expected_stream() -> None:
+    buffer = io.StringIO()
+    json.dump(
+        {"payload": np.array([1, 2], dtype=np.int64)}, buffer, serialize_numpy=True
+    )
+    buffer.seek(0)
+    assert json.loads(buffer.read()) == {"payload": [1, 2]}

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import io
 
+import numpy as np
 import pytest
 from pydantic import BaseModel
 
@@ -67,3 +68,18 @@ def test_datetime_serialization_matches_pydantic_json_mode() -> None:
         )
         == expected
     )
+
+
+def test_numpy_serialization_is_opt_in() -> None:
+    with pytest.raises(TypeError, match="ndarray"):
+        json.dumps({"payload": np.array([1, 2])})
+
+
+def test_numpy_serialization_handles_nested_values() -> None:
+    payload = np.empty(2, dtype=object)
+    payload[0] = np.array([1, 2], dtype=np.int64)
+    payload[1] = {np.int64(7): np.float32(0.5)}
+
+    assert json.loads(
+        json.dumps({"payload": payload}, serialize_bytes=True, serialize_numpy=True)
+    ) == {"payload": [[1, 2], {"7": 0.5}]}


### PR DESCRIPTION
## Summary
- add opt-in numpy serialization to `datachain.json` without importing numpy during normal `datachain` import
- use the opt-in only where numpy values can cross JSON storage boundaries: SQLite adapters, warehouse JSON conversion, and job metrics
- add regression coverage for nested numpy arrays/scalars in JSON, SQLite adapters, warehouse conversion, and metrics

## Tests
- `tests/unit/test_json.py`, `tests/unit/sql/sqlite/test_types.py`, `tests/func/test_data_storage.py`, `tests/func/test_metastore.py`: 120 passed
- `git diff --check`
