### PR TITLE
Removed concurrency check for checkpoints

### DIFF
--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -846,14 +846,7 @@ class UDFStep(Step, ABC):
                     exec_cmd = get_datachain_executable()
                     cmd = [*exec_cmd, "internal-run-udf"]
                     envs = dict(os.environ)
-                    envs.update(
-                        {
-                            "PYTHONPATH": os.getcwd(),
-                            # Mark as DataChain-controlled subprocess to enable
-                            # checkpoints
-                            "DATACHAIN_SUBPROCESS": "1",
-                        }
-                    )
+                    envs["PYTHONPATH"] = os.getcwd()
                     process_data = filtered_cloudpickle_dumps(udf_info)
 
                     with subprocess.Popen(  # noqa: S603

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -6,7 +6,6 @@ import os.path as osp
 import random
 import re
 import sys
-import threading
 import time
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
@@ -29,15 +28,6 @@ if TYPE_CHECKING:
 DEFAULT_BATCH_SIZE = 2000
 
 logger = logging.getLogger("datachain")
-
-
-class _CheckpointState:
-    """Internal state for checkpoint management."""
-
-    _lock = threading.Lock()
-    disabled = False
-    warning_shown = False
-    owner_thread: int | None = None  # Thread ident of the checkpoint owner
 
 
 NUL = b"\0"
@@ -594,75 +584,14 @@ def uses_glob(path: str) -> bool:
 
 
 def checkpoints_enabled(ephemeral: bool = False) -> bool:
+    """Whether checkpoints are enabled in the current execution context.
+
+    Checkpoints are disabled only in ephemeral mode (no persistent metastore
+    objects). Concurrent execution (user threads/subprocesses) is safe -
+    each chain has its own deterministic hash seeded from its starting
+    dataset, so concurrent saves don't interfere.
     """
-    Check if checkpoints are enabled for the current execution context.
-
-    Checkpoints are automatically disabled when:
-    1. Running in ephemeral mode (no persistent metastore objects)
-    2. A user-created subprocess (detected via DATACHAIN_MAIN_PROCESS_PID mismatch)
-    3. A thread that is not the original checkpoint owner thread
-
-    DataChain-controlled subprocesses can enable checkpoints by setting
-    DATACHAIN_SUBPROCESS=1.
-
-    This is because each checkpoint hash depends on the hash of the previous
-    checkpoint, making the computation order-sensitive. Concurrent execution can
-    cause non-deterministic hash calculations due to unpredictable ordering.
-
-    Returns:
-        bool: True if checkpoints are enabled, False if disabled.
-    """
-    if ephemeral:
-        return False
-    # DataChain-controlled subprocess - explicitly allowed
-    if os.environ.get("DATACHAIN_SUBPROCESS"):
-        return True
-
-    # Track the original main process PID via environment variable
-    # This env var is inherited by all child processes (fork and spawn)
-    current_pid = str(os.getpid())
-    main_pid = os.environ.get("DATACHAIN_MAIN_PROCESS_PID")
-
-    if main_pid is None:
-        # First call ever - we're the main process, set the marker
-        os.environ["DATACHAIN_MAIN_PROCESS_PID"] = current_pid
-        main_pid = current_pid
-
-    if current_pid != main_pid:
-        # We're in a subprocess without DATACHAIN_SUBPROCESS flag
-        # This is a user-created subprocess - disable checkpoints
-        with _CheckpointState._lock:
-            if not _CheckpointState.warning_shown:
-                logger.warning(
-                    "User subprocess detected. "
-                    "Checkpoints will not be created in this subprocess. "
-                    "Previously created checkpoints remain valid and can be reused."
-                )
-                _CheckpointState.warning_shown = True
-        return False
-
-    # Thread ownership tracking - first thread to call becomes the owner
-    # Threads share memory, so all threads see the same _CheckpointState
-    current_thread = threading.current_thread().ident
-    with _CheckpointState._lock:
-        if _CheckpointState.owner_thread is None:
-            _CheckpointState.owner_thread = current_thread
-
-        is_owner = current_thread == _CheckpointState.owner_thread
-
-        if not is_owner and not _CheckpointState.disabled:
-            _CheckpointState.disabled = True
-            if not _CheckpointState.warning_shown:
-                logger.warning(
-                    "Concurrent thread detected. "
-                    "New checkpoints will not be created from this point forward. "
-                    "Previously created checkpoints remain valid and can be reused. "
-                    "To enable checkpoints, ensure your script runs sequentially "
-                    "without user-created threading."
-                )
-                _CheckpointState.warning_shown = True
-
-        return is_owner and not _CheckpointState.disabled
+    return not ephemeral
 
 
 def env2bool(var, undefined=False):

--- a/tests/func/checkpoints/test_checkpoint_concurrency.py
+++ b/tests/func/checkpoints/test_checkpoint_concurrency.py
@@ -1,4 +1,3 @@
-import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -11,18 +10,10 @@ from tests.utils import reset_session_job_state
 
 
 def clone_session(session: Session) -> Session:
-    """
-    Create a new session with cloned metastore and warehouse for thread-safe access.
+    """Create a new session with cloned metastore and warehouse.
 
-    This is needed for tests that run DataChain operations in threads, as SQLite
-    connections cannot be shared across threads. For other databases (PostgreSQL,
-    Clickhouse), cloning ensures each thread has its own connection.
-
-    Args:
-        session: The session to clone catalog from.
-
-    Returns:
-        Session: A new session with cloned catalog components.
+    Needed because SQLite connections aren't shareable across threads;
+    PostgreSQL / ClickHouse also benefit from per-thread connections.
     """
     catalog = session.catalog
     thread_metastore = catalog.metastore.clone(use_new_connection=True)
@@ -33,74 +24,40 @@ def clone_session(session: Session) -> Session:
 
 @pytest.fixture(autouse=True)
 def mock_is_script_run(monkeypatch):
-    """Mock is_script_run to return True for stable job names in tests."""
     monkeypatch.setattr("datachain.query.session.is_script_run", lambda: True)
 
 
-def test_threading_disables_checkpoints(test_session_tmpfile, caplog):
+def test_checkpoints_created_in_thread(test_session_tmpfile):
+    """Per-chain hashing is deterministic, so threads can create checkpoints."""
     test_session = test_session_tmpfile
     metastore = test_session.catalog.metastore
 
     dc.read_values(num=[1, 2, 3, 4, 5, 6], session=test_session).save("nums")
-
-    # -------------- FIRST RUN (main thread) -------------------
     reset_session_job_state()
 
-    dc.read_dataset("nums", session=test_session).save("result1")
-
-    job1 = test_session.get_or_create_job()
-    checkpoints_main = list(metastore.list_checkpoints([job1.id]))
-    assert len(checkpoints_main) > 0, "Checkpoint should be created in main thread"
-
-    # -------------- SECOND RUN (in thread) -------------------
-    reset_session_job_state()
-
-    thread_ran = {"value": False}
-
-    def run_datachain_in_thread():
-        """Run DataChain operation in a thread - checkpoint should NOT be created."""
+    def thread_work():
         thread_session = clone_session(test_session)
         try:
-            thread_ran["value"] = True
-            dc.read_dataset("nums", session=thread_session).save("result2")
+            dc.read_dataset("nums", session=thread_session).save("result")
         finally:
             thread_session.catalog.close()
 
-    thread = threading.Thread(target=run_datachain_in_thread)
+    thread = threading.Thread(target=thread_work)
     thread.start()
     thread.join()
 
-    assert thread_ran["value"] is True
-
-    assert any(
-        "Concurrent thread detected" in record.message for record in caplog.records
-    ), "Warning about concurrent thread should be logged"
-
-    # Verify no checkpoint was created in thread
-    job2 = test_session.get_or_create_job()
-    checkpoints_thread = list(metastore.list_checkpoints([job2.id]))
-    assert len(checkpoints_thread) == 0, "No checkpoints should be created in thread"
+    job = test_session.get_or_create_job()
+    assert len(list(metastore.list_checkpoints([job.id]))) > 0
 
 
-def test_threading_with_executor(test_session_tmpfile, caplog):
+def test_checkpoints_created_in_thread_pool(test_session_tmpfile):
     test_session = test_session_tmpfile
     metastore = test_session.catalog.metastore
 
     dc.read_values(num=[1, 2, 3, 4, 5, 6], session=test_session).save("nums")
-
-    # -------------- FIRST RUN (main thread) -------------------
-    reset_session_job_state()
-    dc.read_dataset("nums", session=test_session).save("before_threading")
-
-    job1 = test_session.get_or_create_job()
-    checkpoints_before = len(list(metastore.list_checkpoints([job1.id])))
-    assert checkpoints_before > 0, "Checkpoint should be created before threading"
-
-    # -------------- SECOND RUN (in thread pool) -------------------
     reset_session_job_state()
 
     def worker(i):
-        """Worker function that runs DataChain operations in thread pool."""
         thread_session = clone_session(test_session)
         try:
             dc.read_dataset("nums", session=thread_session).save(f"result_{i}")
@@ -110,108 +67,5 @@ def test_threading_with_executor(test_session_tmpfile, caplog):
     with ThreadPoolExecutor(max_workers=3) as executor:
         list(executor.map(worker, range(3)))
 
-    assert any(
-        "Concurrent thread detected" in record.message for record in caplog.records
-    ), "Warning should be logged when using thread pool"
-
-    job2 = test_session.get_or_create_job()
-    checkpoints_after = len(list(metastore.list_checkpoints([job2.id])))
-    assert checkpoints_after == 0, "No checkpoints should be created in thread pool"
-
-
-def test_multiprocessing_disables_checkpoints(test_session, monkeypatch):
-    catalog = test_session.catalog
-    metastore = catalog.metastore
-
-    dc.read_values(num=[1, 2, 3, 4, 5, 6], session=test_session).save("nums")
-
-    # -------------- FIRST RUN (main process) -------------------
-    reset_session_job_state()
-    dc.read_dataset("nums", session=test_session).save("main_result")
-
-    job1 = test_session.get_or_create_job()
-    checkpoints_main = list(metastore.list_checkpoints([job1.id]))
-    assert len(checkpoints_main) > 0, "Checkpoint should be created in main process"
-
-    # -------------- SECOND RUN (simulated subprocess) -------------------
-    reset_session_job_state()
-
-    # Simulate being in a subprocess by setting DATACHAIN_MAIN_PROCESS_PID
-    # to a different PID than the current one
-    monkeypatch.setenv("DATACHAIN_MAIN_PROCESS_PID", str(os.getpid() + 1000))
-
-    # Run DataChain operation - checkpoint should NOT be created
-    dc.read_dataset("nums", session=test_session).save("subprocess_result")
-
-    job2 = test_session.get_or_create_job()
-    checkpoints_subprocess = list(metastore.list_checkpoints([job2.id]))
-    assert len(checkpoints_subprocess) == 0, (
-        "No checkpoints should be created in subprocess"
-    )
-
-
-def test_checkpoint_reuse_after_threading(test_session_tmpfile):
-    test_session = test_session_tmpfile
-    metastore = test_session.catalog.metastore
-
-    dc.read_values(num=[1, 2, 3, 4, 5, 6], session=test_session).save("nums")
-
-    # -------------- FIRST RUN (creates checkpoints) -------------------
-    reset_session_job_state()
-    dc.read_dataset("nums", session=test_session).save("result1")
-    dc.read_dataset("nums", session=test_session).save("result2")
-
-    job1 = test_session.get_or_create_job()
-    checkpoints_initial = len(list(metastore.list_checkpoints([job1.id])))
-    assert checkpoints_initial > 0, "Checkpoints should be created initially"
-
-    # Run something in a thread (disables checkpoints globally)
-    def thread_work():
-        thread_session = clone_session(test_session)
-        try:
-            dc.read_dataset("nums", session=thread_session).save("thread_result")
-        finally:
-            thread_session.catalog.close()
-
-    thread = threading.Thread(target=thread_work)
-    thread.start()
-    thread.join()
-
-    # No new checkpoints should have been created in thread
-    assert len(list(metastore.list_checkpoints([job1.id]))) == checkpoints_initial
-
-    # -------------- SECOND RUN (new job, after threading) -------------------
-    reset_session_job_state()
-    dc.read_dataset("nums", session=test_session).save("new_result")
-
-    job2 = test_session.get_or_create_job()
-    checkpoints_new_job = list(metastore.list_checkpoints([job2.id]))
-    assert len(checkpoints_new_job) > 0, "New job should create checkpoints normally"
-
-
-def test_warning_shown_once(test_session_tmpfile, caplog):
-    test_session = test_session_tmpfile
-
-    dc.read_values(num=[1, 2, 3, 4, 5, 6], session=test_session).save("nums")
-    reset_session_job_state()
-
-    def run_multiple_operations():
-        """Run multiple DataChain operations in a thread."""
-        thread_session = clone_session(test_session)
-        try:
-            # Each operation would check checkpoints_enabled()
-            dc.read_dataset("nums", session=thread_session).save("result1")
-            dc.read_dataset("nums", session=thread_session).save("result2")
-            dc.read_dataset("nums", session=thread_session).save("result3")
-        finally:
-            thread_session.catalog.close()
-
-    thread = threading.Thread(target=run_multiple_operations)
-    thread.start()
-    thread.join()
-
-    warning_count = sum(
-        1 for record in caplog.records if "Concurrent thread detected" in record.message
-    )
-
-    assert warning_count == 1, "Warning should be shown only once per process"
+    job = test_session.get_or_create_job()
+    assert len(list(metastore.list_checkpoints([job.id]))) > 0

--- a/tests/test_query_e2e.py
+++ b/tests/test_query_e2e.py
@@ -186,11 +186,7 @@ def run_step(step, catalog):
         popen_args = {"start_new_session": True}
     stdin_path = step.get("stdin_file")
     with open(stdin_path) if stdin_path else nullcontext(None) as stdin_file:
-        # Strip DATACHAIN_MAIN_PROCESS_PID so script starts fresh as its own
-        # main process (with checkpoints enabled).
-        script_env = e2e_subprocess_env(
-            catalog, exclude_keys={"DATACHAIN_MAIN_PROCESS_PID"}
-        )
+        script_env = e2e_subprocess_env(catalog)
 
         process = subprocess.Popen(  # noqa: S603
             command,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,4 @@
 import os
-import threading
 from pathlib import Path
 
 import pytest
@@ -7,7 +6,6 @@ from filelock import FileLock, Timeout
 
 from datachain.fs.utils import is_subpath, path_to_fsspec_uri
 from datachain.utils import (
-    _CheckpointState,
     batched,
     batched_it,
     checkpoints_enabled,
@@ -443,119 +441,12 @@ def test_with_last_flag(input_data, expected):
     assert list(with_last_flag(input_data)) == expected
 
 
-@pytest.fixture(autouse=True)
-def reset_checkpoint_state(monkeypatch):
-    """Reset checkpoint state before each test."""
-    _CheckpointState.disabled = False
-    _CheckpointState.warning_shown = False
-    _CheckpointState.owner_thread = None
-    # Clear any existing env vars
-    monkeypatch.delenv("DATACHAIN_MAIN_PROCESS_PID", raising=False)
-    monkeypatch.delenv("DATACHAIN_SUBPROCESS", raising=False)
-    yield
-    # Reset after test as well
-    _CheckpointState.disabled = False
-    _CheckpointState.warning_shown = False
-    _CheckpointState.owner_thread = None
-
-
-def test_checkpoints_enabled_main_thread():
-    """Test that checkpoints are enabled in main thread and main process."""
+def test_checkpoints_enabled_default():
     assert checkpoints_enabled() is True
-    assert _CheckpointState.disabled is False
-    assert _CheckpointState.warning_shown is False
 
 
-def test_checkpoints_enabled_non_main_thread(monkeypatch):
-    # First call establishes ownership with the real current thread
-    assert checkpoints_enabled() is True
-    owner_ident = _CheckpointState.owner_thread
-    assert owner_ident == threading.current_thread().ident
-
-    # Now simulate a different thread by mocking the ident
-    class MockThread:
-        ident = owner_ident + 1
-        name = "Thread-1"
-
-    monkeypatch.setattr("datachain.utils.threading.current_thread", MockThread)
-
-    assert checkpoints_enabled() is False
-    assert _CheckpointState.disabled is True
-
-
-def test_checkpoints_enabled_non_main_process(monkeypatch):
-    # Simulate a subprocess by setting DATACHAIN_MAIN_PROCESS_PID to a different PID
-    monkeypatch.setenv("DATACHAIN_MAIN_PROCESS_PID", str(os.getpid() + 1000))
-
-    assert checkpoints_enabled() is False
-    # Note: disabled flag is not set for subprocess detection, just returns False
-    assert _CheckpointState.warning_shown is True
-
-
-def test_checkpoints_enabled_warning_shown_once(monkeypatch, caplog):
-    """Test that the warning is only shown once even when called multiple times."""
-    # First call establishes ownership
-    assert checkpoints_enabled() is True
-    owner_ident = _CheckpointState.owner_thread
-
-    class MockThread:
-        ident = owner_ident + 1  # Different thread ident
-        name = "Thread-1"
-
-    monkeypatch.setattr("datachain.utils.threading.current_thread", MockThread)
-
-    # Call multiple times from non-owner thread
-    assert checkpoints_enabled() is False
-    assert checkpoints_enabled() is False
-    assert checkpoints_enabled() is False
-
-    # Verify warning was logged only once
-    warning_count = sum(
-        1 for record in caplog.records if "Concurrent thread detected" in record.message
-    )
-    assert warning_count == 1
-    assert _CheckpointState.warning_shown is True
-
-
-def test_checkpoints_enabled_stays_disabled(monkeypatch):
-    """Test that once disabled, checkpoints stay disabled even in owner thread."""
-    # First call establishes ownership
-    assert checkpoints_enabled() is True
-    owner_ident = _CheckpointState.owner_thread
-
-    class MockThread:
-        ident = owner_ident + 1  # Different thread ident
-        name = "Thread-1"
-
-    class MockOwnerThread:
-        ident = owner_ident  # Same as owner
-        name = "MainThread"
-
-    # Call from non-owner thread disables checkpoints
-    monkeypatch.setattr("datachain.utils.threading.current_thread", MockThread)
-    assert checkpoints_enabled() is False
-    assert _CheckpointState.disabled is True
-
-    # Even if we go back to owner thread, it should stay disabled
-    monkeypatch.setattr("datachain.utils.threading.current_thread", MockOwnerThread)
-    assert checkpoints_enabled() is False
-    assert _CheckpointState.disabled is True
-
-
-def test_checkpoints_enabled_datachain_subprocess(monkeypatch):
-    """Test that DATACHAIN_SUBPROCESS env var enables checkpoints regardless of PID."""
-    # Set the main PID to something different (simulating we're in a subprocess)
-    monkeypatch.setenv("DATACHAIN_MAIN_PROCESS_PID", str(os.getpid() + 1000))
-
-    # Without DATACHAIN_SUBPROCESS, checkpoints should be disabled
-    assert checkpoints_enabled() is False
-
-    # Reset state for next test
-    _CheckpointState.warning_shown = False
-
-    # With DATACHAIN_SUBPROCESS, checkpoints should be enabled
-    monkeypatch.setenv("DATACHAIN_SUBPROCESS", "1")
-    assert checkpoints_enabled() is True
+def test_checkpoints_enabled_ephemeral():
+    assert checkpoints_enabled(ephemeral=True) is False
 
 
 def test_is_subpath_rejects_equal(tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,18 +176,11 @@ def wait_for_condition(
     raise TimeoutError(f"Timeout expired while waiting for: {message}")
 
 
-def e2e_subprocess_env(
-    catalog: Catalog, exclude_keys: set[str] | None = None
-) -> dict[str, str]:
+def e2e_subprocess_env(catalog: Catalog) -> dict[str, str]:
     # Strip AWS_* so the subprocess talks to real public S3 instead of inheriting
     # moto/pytest-servers credentials and region from cloud-emulator fixtures
     # that ran earlier in the same pytest process.
-    exclude = exclude_keys or set()
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if not k.startswith("AWS_") and k not in exclude
-    }
+    env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
     env["DATACHAIN__METASTORE"] = catalog.metastore.serialize()
     env["DATACHAIN__WAREHOUSE"] = catalog.warehouse.serialize()
     return env
@@ -351,12 +344,6 @@ def reset_session_job_state():
     Session._JOB_STATUS = None
     Session._OWNS_JOB = None
     Session._JOB_HOOKS_REGISTERED = False
-
-    # Clear checkpoint state (now in utils module)
-    from datachain.utils import _CheckpointState
-
-    _CheckpointState.disabled = False
-    _CheckpointState.warning_shown = False
 
     # Clear DATACHAIN_JOB_ID env var to allow new job creation on next run
     # This is important for studio/SaaS mode where job_id comes from env var


### PR DESCRIPTION
Closes #1766.

Removes the subprocess/thread auto-disable in `checkpoints_enabled()`. The guards were added when checkpoint hashes formed a global order-sensitive chain across saves. With per-chain hashing (each `apply_steps` starts a fresh sha256 seeded from its own `_starting_step_hash`), concurrent chains and concurrent `.save()` calls produce stable, deterministic hashes regardless of ordering.

- `checkpoints_enabled()` now just returns `not ephemeral`
- Removed `_CheckpointState`, the subprocess-PID check, and the owner-thread tracking
- Dropped the `DATACHAIN_SUBPROCESS` opt-in env var (no auto-disable to opt out of)
- Dropped the `DATACHAIN_MAIN_PROCESS_PID` env var setup in tests
- Rewrote `test_checkpoint_concurrency.py` to verify the opposite - checkpoints DO get created in threads / thread pools
- Replaced the 5 auto-disable tests in `test_utils.py` with 2 small positive ones