### PR TITLE
Add Zarr support: read_zarr, ZarrStore/Array/Selection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,16 +175,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        pyv: ['3.11', '3.14']
+        pyv: ['3.11', '3.13']
         group: ['get_started', 'computer_vision', 'multimodal']
         exclude:
           - {os: ubuntu-latest, pyv: '3.11', group: 'multimodal'}
-          - {os: ubuntu-latest, pyv: '3.14', group: 'multimodal'}
+          - {os: ubuntu-latest, pyv: '3.13', group: 'multimodal'}
         include:
           # HF runs against actual API - thus run it only once
-          - {os: ubuntu-latest, pyv: "3.14", group: llm_and_nlp}
+          - {os: ubuntu-latest, pyv: "3.13", group: llm_and_nlp}
           - {os: ubuntu-latest-4-cores, pyv: "3.11", group: multimodal}
-          - {os: ubuntu-latest-4-cores, pyv: "3.14", group: multimodal}
+          - {os: ubuntu-latest-4-cores, pyv: "3.13", group: multimodal}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,16 +175,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        pyv: ['3.10', '3.13']
+        pyv: ['3.11', '3.14']
         group: ['get_started', 'computer_vision', 'multimodal']
         exclude:
-          - {os: ubuntu-latest, pyv: '3.10', group: 'multimodal'}
-          - {os: ubuntu-latest, pyv: '3.13', group: 'multimodal'}
+          - {os: ubuntu-latest, pyv: '3.11', group: 'multimodal'}
+          - {os: ubuntu-latest, pyv: '3.14', group: 'multimodal'}
         include:
           # HF runs against actual API - thus run it only once
-          - {os: ubuntu-latest, pyv: "3.13", group: llm_and_nlp}
-          - {os: ubuntu-latest-4-cores, pyv: "3.10", group: multimodal}
-          - {os: ubuntu-latest-4-cores, pyv: "3.13", group: multimodal}
+          - {os: ubuntu-latest, pyv: "3.14", group: llm_and_nlp}
+          - {os: ubuntu-latest-4-cores, pyv: "3.11", group: multimodal}
+          - {os: ubuntu-latest-4-cores, pyv: "3.14", group: multimodal}
 
     steps:
       - uses: actions/checkout@v6

--- a/docs/references/data-types/zarrstore.md
+++ b/docs/references/data-types/zarrstore.md
@@ -29,7 +29,8 @@ There are additional models for working with Zarr stores:
   column and is materialized on demand via `read()` or rendered to image bytes
   via `read_bytes()`.
 
-Reading the actual data requires the optional `zarr` dependency:
+Reading the actual data requires the optional `zarr` dependency, which is
+available on Python 3.11 and newer:
 
 ```sh
 pip install 'datachain[zarr]'

--- a/docs/references/data-types/zarrstore.md
+++ b/docs/references/data-types/zarrstore.md
@@ -19,12 +19,15 @@ for (store,) in chain.limit(1).to_iter("zarr"):
 
 There are additional models for working with Zarr stores:
 
-- `ZarrInfo` - summary metadata for a store (format, array paths, attributes).
-- `ZarrArray` - a single array within a store; exposes `shape`, `chunks`,
-  `dtype`, and `attrs`, and reads data via `read()` or `select()`.
-- `ZarrSelection` - a lazy, bounded region inside an array (e.g. one image
-  frame) that can travel through a chain as a column and is materialized on
-  demand via `read()` or rendered to image bytes via `read_bytes()`.
+- [`ZarrInfo`](#datachain.lib.zarr.ZarrInfo) - summary metadata for a store
+  (format, array paths, attributes).
+- [`ZarrArray`](#datachain.lib.zarr.ZarrArray) - a single array within a store;
+  exposes `shape`, `chunks`, `dtype`, and `attrs`, and reads data via `read()`
+  or `select()`.
+- [`ZarrSelection`](#datachain.lib.zarr.ZarrSelection) - a lazy, bounded region
+  inside an array (e.g. one image frame) that can travel through a chain as a
+  column and is materialized on demand via `read()` or rendered to image bytes
+  via `read_bytes()`.
 
 Reading the actual data requires the optional `zarr` dependency:
 

--- a/docs/references/data-types/zarrstore.md
+++ b/docs/references/data-types/zarrstore.md
@@ -29,13 +29,6 @@ There are additional models for working with Zarr stores:
   column and is materialized on demand via `read()` or rendered to image bytes
   via `read_bytes()`.
 
-Reading the actual data requires the optional `zarr` dependency, which is
-available on Python 3.11 and newer:
-
-```sh
-pip install 'datachain[zarr]'
-```
-
 For a complete example of Zarr processing with DataChain, see
 [Embedding Zarr image frames](https://github.com/datachain-ai/datachain/blob/main/examples/multimodal/zarr-robot-frames.py) -
 a pipeline that reads RGB camera frames from a directory of Zarr stores and

--- a/docs/references/data-types/zarrstore.md
+++ b/docs/references/data-types/zarrstore.md
@@ -1,0 +1,46 @@
+# ZarrStore
+
+`ZarrStore` is a [`DataModel`](index.md#datachain.lib.data_model.DataModel) that
+points at a [Zarr](https://zarr.dev) store root and provides methods for
+inspecting and reading its arrays.
+
+Unlike [`File`](file.md), which represents a single byte stream, a Zarr store is
+a *tree* of objects (metadata and chunks). `ZarrStore` rows are created when a
+`DataChain` is initialized [from Zarr stores](../datachain.md#datachain.lib.dc.zarr.read_zarr),
+which collapses every object under a store root into a single row:
+
+```python
+import datachain as dc
+
+chain = dc.read_zarr("s3://bucket-name/data/")
+for (store,) in chain.limit(1).to_iter("zarr"):
+    print(store.get_info())
+```
+
+There are additional models for working with Zarr stores:
+
+- `ZarrInfo` - summary metadata for a store (format, array paths, attributes).
+- `ZarrArray` - a single array within a store; exposes `shape`, `chunks`,
+  `dtype`, and `attrs`, and reads data via `read()` or `select()`.
+- `ZarrSelection` - a lazy, bounded region inside an array (e.g. one image
+  frame) that can travel through a chain as a column and is materialized on
+  demand via `read()` or rendered to image bytes via `read_bytes()`.
+
+Reading the actual data requires the optional `zarr` dependency:
+
+```sh
+pip install 'datachain[zarr]'
+```
+
+For a complete example of Zarr processing with DataChain, see
+[Embedding Zarr image frames](https://github.com/datachain-ai/datachain/blob/main/examples/multimodal/zarr-robot-frames.py) -
+a pipeline that reads RGB camera frames from a directory of Zarr stores and
+encodes them with OpenCLIP.
+
+::: datachain.lib.zarr.ZarrStore
+
+::: datachain.lib.zarr.ZarrArray
+
+::: datachain.lib.zarr.ZarrSelection
+
+::: datachain.lib.zarr.ZarrInfo

--- a/docs/references/datachain.md
+++ b/docs/references/datachain.md
@@ -28,6 +28,8 @@ for examples of how to create a chain.
 
 ::: datachain.lib.dc.storage.read_storage
 
+::: datachain.lib.dc.zarr.read_zarr
+
 ::: datachain.lib.dc.values.read_values
 
 ::: datachain.lib.dc.database.read_database

--- a/examples/multimodal/zarr-robot-frames.py
+++ b/examples/multimodal/zarr-robot-frames.py
@@ -16,6 +16,12 @@ embedding — no raw pixels are carried in the row. The result is saved as a
 DataChain dataset that can be reused for search or clustering.
 """
 
+import sys
+
+if sys.version_info < (3, 11):
+    print("This example requires Python >= 3.11 for Zarr support; skipping.")
+    sys.exit(0)
+
 import numpy as np
 import open_clip
 from PIL import Image

--- a/examples/multimodal/zarr-robot-frames.py
+++ b/examples/multimodal/zarr-robot-frames.py
@@ -1,0 +1,72 @@
+"""
+To run this example, install:
+
+`datachain[examples]`
+
+It demonstrates how to use DataChain's Zarr support to turn a directory of
+Zarr stores into an embedding dataset. Each store is one robot-manipulation
+episode holding a stack of RGB camera frames plus aligned low-dimensional
+state arrays.
+
+`read_zarr` discovers every store under the prefix and yields one row per
+store as a `ZarrStore`. We first attach the per-frame metadata read straight
+from the Zarr stores (frame to embed, resolution, task instruction), then as
+a separate step encode that frame with OpenCLIP and keep only the compact
+embedding — no raw pixels are carried in the row. The result is saved as a
+DataChain dataset that can be reused for search or clustering.
+"""
+
+import numpy as np
+import open_clip
+from PIL import Image
+
+import datachain as dc
+from datachain.lib.zarr import ZarrStore
+
+# Public, anonymous bucket: one ``*.zarr`` store per episode. Each store has:
+#   workspace_rgb        (T, 480, 640, 3) uint8   -- RGB camera frames
+#   joint_pos_lowdim     (T, 6)           float32 -- joint positions
+#   joint_action_lowdim  (T, 6)           float32 -- commanded actions
+#   language_instruction (1,)             str     -- the task description
+SOURCE = "gs://datachain-demo/robot-frames-zarr"
+
+
+class ClipImageEncoder:
+    def __init__(
+        self, model_name: str = "ViT-B-32", pretrained: str = "laion2b_s34b_b79k"
+    ):
+        self.model, _, self.preprocess = open_clip.create_model_and_transforms(
+            model_name, pretrained
+        )
+
+
+def frame_meta(episode: ZarrStore) -> tuple[int, str, str]:
+    # Read straight from the Zarr metadata/small arrays: the frame index we
+    # will embed, the image resolution, and the task instruction.
+    rgb = episode.get_array("workspace_rgb")
+    frame_idx = rgb.shape[0] // 2
+    resolution = f"{rgb.shape[2]}x{rgb.shape[1]}"
+    instruction = bytes(episode.get_array("language_instruction").read()[0]).decode()
+    return frame_idx, resolution, instruction
+
+
+def embed_frame(
+    episode: ZarrStore, frame_idx: int, encoder: ClipImageEncoder
+) -> list[float]:
+    # Read only the selected frame's chunk, then embed it with OpenCLIP. The
+    # heavy pixel data never enters the row — only the float embedding does.
+    frame = np.asarray(episode.get_array("workspace_rgb").select(frame_idx).read())
+    image = encoder.preprocess(Image.fromarray(frame.astype("uint8"))).unsqueeze(0)
+    return encoder.model.encode_image(image)[0].tolist()
+
+
+ds = (
+    dc.read_zarr(SOURCE, column="episode", anon=True)
+    .limit(3)
+    .map(frame_meta, output=("frame_idx", "resolution", "instruction"))
+    .setup(encoder=lambda: ClipImageEncoder())  # noqa: PLW0108
+    .map(embedding=embed_frame)
+    .save("robot_frame_embeddings")
+)
+
+ds.select("frame_idx", "resolution", "instruction").show()

--- a/examples/multimodal/zarr-robot-frames.py
+++ b/examples/multimodal/zarr-robot-frames.py
@@ -1,7 +1,7 @@
 """
-To run this example, install:
+To run this example, install (on Python >= 3.11, which Zarr support requires):
 
-`datachain[examples]`
+`datachain[examples,zarr]`
 
 It demonstrates how to use DataChain's Zarr support to turn a directory of
 Zarr stores into an embedding dataset. Each store is one robot-manipulation

--- a/examples/multimodal/zarr-robot-frames.py
+++ b/examples/multimodal/zarr-robot-frames.py
@@ -16,12 +16,6 @@ embedding — no raw pixels are carried in the row. The result is saved as a
 DataChain dataset that can be reused for search or clustering.
 """
 
-import sys
-
-if sys.version_info < (3, 11):
-    print("This example requires Python >= 3.11 for Zarr support; skipping.")
-    sys.exit(0)
-
 import numpy as np
 import open_clip
 from PIL import Image

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
               - AudioFile: references/data-types/audiofile.md
               - TarVFile: references/data-types/tarvfile.md
               - ArrowRow: references/data-types/arrowrow.md
+              - ZarrStore: references/data-types/zarrstore.md
               - BBox: references/data-types/bbox.md
               - Pose: references/data-types/pose.md
               - Segment: references/data-types/segment.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,14 @@ video = [
   "av>=16.1.0",
   "ffmpeg-python"
 ]
+zarr = [
+  "zarr>=3.0.0"
+]
 postgres = [
   "psycopg2-binary>=2.9.0"
 ]
 tests = [
-  "datachain[torch,audio,remote,vector,hf,video,postgres]",
+  "datachain[torch,audio,remote,vector,hf,video,zarr,postgres]",
   "pytest>=8,<10",
   "pytest-asyncio",
   "pytest-sugar>=0.9.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
   "dvc-studio-client>=0.21,<1",
   "tabulate",
   "websockets",
+  "zarr>=3.0.0 ; python_version >= '3.11'",
   "tomli;python_version<'3.11'"
 ]
 
@@ -94,14 +95,11 @@ video = [
   "av>=16.1.0",
   "ffmpeg-python"
 ]
-zarr = [
-  "zarr>=3.0.0 ; python_version >= '3.11'"
-]
 postgres = [
   "psycopg2-binary>=2.9.0"
 ]
 tests = [
-  "datachain[torch,audio,remote,vector,hf,video,zarr,postgres]",
+  "datachain[torch,audio,remote,vector,hf,video,postgres]",
   "pytest>=8,<10",
   "pytest-asyncio",
   "pytest-sugar>=0.9.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Development Status :: 2 - Pre-Alpha"
 ]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ video = [
   "ffmpeg-python"
 ]
 zarr = [
-  "zarr>=3.0.0 ; python_version >= '3.11'"
+  "zarr>=3.0.0"
 ]
 postgres = [
   "psycopg2-binary>=2.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ video = [
   "ffmpeg-python"
 ]
 zarr = [
-  "zarr>=3.0.0"
+  "zarr>=3.0.0 ; python_version >= '3.11'"
 ]
 postgres = [
   "psycopg2-binary>=2.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
   "dvc-studio-client>=0.21,<1",
   "tabulate",
   "websockets",
-  "zarr>=3.0.0 ; python_version >= '3.11'",
   "tomli;python_version<'3.11'"
 ]
 
@@ -98,8 +97,11 @@ video = [
 postgres = [
   "psycopg2-binary>=2.9.0"
 ]
+zarr = [
+  "zarr>=3.0.0 ; python_version >= '3.11'"
+]
 tests = [
-  "datachain[torch,audio,remote,vector,hf,video,postgres]",
+  "datachain[torch,audio,remote,vector,hf,video,postgres,zarr]",
   "pytest>=8,<10",
   "pytest-asyncio",
   "pytest-sugar>=0.9.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Development Status :: 2 - Pre-Alpha"
 ]
 requires-python = ">=3.10"

--- a/src/datachain/__init__.py
+++ b/src/datachain/__init__.py
@@ -22,6 +22,7 @@ from datachain.lib.dc import (
     read_records,
     read_storage,
     read_values,
+    read_zarr,
 )
 from datachain.lib.file import (
     ArrowRow,
@@ -99,4 +100,5 @@ __all__ = [
     "read_records",
     "read_storage",
     "read_values",
+    "read_zarr",
 ]

--- a/src/datachain/lib/dc/__init__.py
+++ b/src/datachain/lib/dc/__init__.py
@@ -11,6 +11,7 @@ from .records import read_records
 from .storage import read_storage
 from .utils import DatasetMergeError, DatasetPrepareError, Sys, is_local, is_studio
 from .values import read_values
+from .zarr import read_zarr
 
 __all__ = [
     "C",
@@ -36,4 +37,5 @@ __all__ = [
     "read_records",
     "read_storage",
     "read_values",
+    "read_zarr",
 ]

--- a/src/datachain/lib/dc/zarr.py
+++ b/src/datachain/lib/dc/zarr.py
@@ -1,0 +1,75 @@
+import os
+from functools import reduce
+from typing import TYPE_CHECKING
+
+from datachain.query import Session
+
+if TYPE_CHECKING:
+    from .datachain import DataChain
+
+
+def read_zarr(
+    path: str | os.PathLike[str] | list[str] | list[os.PathLike[str]],
+    column: str = "zarr",
+    session: Session | None = None,
+    settings: dict | None = None,
+    in_memory: bool = False,
+    **kwargs,
+) -> "DataChain":
+    """Generate a chain with one row per Zarr store.
+
+    Unlike :func:`read_storage`, which emits one row per physical object, this
+    reader collapses every object under a store root into a single
+    :class:`~datachain.lib.zarr.ZarrStore` row.  Stores are discovered using the
+    standard ``*.zarr`` naming convention.
+
+    Parameters:
+        path: Storage path(s) or URI(s). Can be a local path or start with a
+            storage prefix like `s3://`, `gs://`, `az://` or `file://`.
+            Supports glob patterns.
+        column: Created column name. Defaults to ``"zarr"``.
+        session: Session to use for the chain.
+        settings: Settings to use for the chain.
+        in_memory: If True, use an in-memory database.
+
+    Example:
+        ```py
+        import datachain as dc
+        chain = dc.read_zarr("s3://mybucket/data/")
+        for (store,) in chain.limit(1).to_iter("zarr"):
+            print(store.get_info())
+        ```
+    """
+    from datachain.lib.zarr import (
+        ZARR_ROOT_MARKERS,
+        ZARR_SUFFIX,
+        ZarrStore,
+        file_to_store,
+    )
+
+    from .datachain import C
+    from .storage import read_storage
+
+    # ``read_storage`` lists the whole prefix recursively (markers *and*
+    # chunks); we then keep only the store-root markers. See
+    # ``local/zarr-support-task/followups.md`` for the listing-pushdown
+    # optimization that would avoid descending into chunk objects.
+    chain = read_storage(
+        path,
+        session=session,
+        settings=settings,
+        in_memory=in_memory,
+        **kwargs,
+    )
+
+    # Keep only store-root markers (drop chunks and nested array/group
+    # metadata). A marker sits either directly under a ``*.zarr`` directory
+    # (discovery) or at the listing root when the path itself is a concrete
+    # store directory.
+    conditions = []
+    for marker in sorted(ZARR_ROOT_MARKERS):
+        conditions.append(C("file.path").glob(f"*{ZARR_SUFFIX}/{marker}"))
+        conditions.append(C("file.path") == marker)
+    chain = chain.filter(reduce(lambda a, b: a | b, conditions))
+
+    return chain.map(file_to_store, output={column: ZarrStore})

--- a/src/datachain/lib/dc/zarr.py
+++ b/src/datachain/lib/dc/zarr.py
@@ -51,9 +51,7 @@ def read_zarr(
     from .storage import read_storage
 
     # ``read_storage`` lists the whole prefix recursively (markers *and*
-    # chunks); we then keep only the store-root markers. See
-    # ``local/zarr-support-task/followups.md`` for the listing-pushdown
-    # optimization that would avoid descending into chunk objects.
+    # chunks); we then keep only the store-root markers.
     chain = read_storage(
         path,
         session=session,

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -11,6 +11,7 @@ Reading the actual data requires the optional ``zarr`` dependency:
 """
 
 import posixpath
+import sys
 from collections.abc import Iterator
 from typing import Any, ClassVar, Literal
 
@@ -31,10 +32,13 @@ def _import_zarr() -> Any:
     try:
         import zarr
     except ImportError as exc:
-        raise ImportError(
-            "Missing dependencies for Zarr support.\n"
-            "To install run:\n\n"
+        hint = (
             "  pip install 'datachain[zarr]'\n"
+            if sys.version_info >= (3, 11)
+            else "Zarr support requires Python 3.11 or newer.\n"
+        )
+        raise ImportError(
+            "Missing dependencies for Zarr support.\nTo install run:\n\n" + hint
         ) from exc
     return zarr
 

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -11,11 +11,31 @@ from collections.abc import Iterator
 from typing import Any, ClassVar, Literal
 from urllib.parse import urlsplit, urlunsplit
 
-import zarr
 from pydantic import Field
 
 from datachain.lib.data_model import DataModel
 from datachain.lib.file import File
+
+try:
+    import zarr
+except ImportError:
+    zarr = None  # type: ignore[assignment]
+
+
+def _require_zarr() -> Any:
+    """Return the ``zarr`` module, raising a clear error if it is missing.
+
+    Zarr is an optional dependency, so importing this module must not require
+    it; the hard failure is deferred to the moment Zarr functionality is used.
+    """
+    if zarr is None:
+        raise ImportError(
+            "Missing dependencies for Zarr support.\n"
+            "To install run:\n\n"
+            "  pip install 'datachain[zarr]'\n"
+        )
+    return zarr
+
 
 # Names of the metadata objects that mark a Zarr store/array root.
 #   - ``zarr.json``  : Zarr v3 group or array metadata
@@ -53,6 +73,7 @@ class ZarrStore(DataModel):
         return self.file.path
 
     def _open(self, mode: Literal["r", "r+", "a", "w", "w-"] = "r") -> Any:
+        zarr = _require_zarr()
         f = self.file
         url = f.get_fs_path()
         storage_options = None

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -31,7 +31,7 @@ def _require_zarr() -> Any:
     if zarr is None:
         raise ImportError(
             "Missing dependencies for Zarr support.\n"
-            "To install run:\n\n"
+            "Zarr requires Python >= 3.11.  On a supported Python, run:\n\n"
             "  pip install 'datachain[zarr]'\n"
         )
     return zarr
@@ -213,11 +213,13 @@ class ZarrSelection(DataModel):
                 "To install run:\n\n  pip install pillow\n"
             ) from exc
 
+        from .video import _image_format
+
         arr = np.asarray(self.read())
         if arr.dtype != np.uint8:
             arr = arr.astype("uint8")
         buf = io.BytesIO()
-        Image.fromarray(arr).save(buf, format=format)
+        Image.fromarray(arr).save(buf, format=_image_format(format))
         return buf.getvalue()
 
 

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -9,6 +9,7 @@ multiscale preview, ...) are intentionally *not* handled here.
 import posixpath
 from collections.abc import Iterator
 from typing import Any, ClassVar, Literal
+from urllib.parse import urlsplit, urlunsplit
 
 import zarr
 from pydantic import Field
@@ -27,7 +28,7 @@ ZARR_SUFFIX = ".zarr"
 class ZarrInfo(DataModel):
     """Summary metadata for a Zarr store."""
 
-    zarr_format: int = Field(default=0)
+    zarr_format: int | None = Field(default=None)
     arrays: list[str] = Field(default_factory=list)
     attrs: dict = Field(default_factory=dict)
 
@@ -203,15 +204,22 @@ def _store_root_split(file: File) -> tuple[str, str]:
     """Return ``(source, path)`` for the store root containing ``file``.
 
     ``file`` is a store-root metadata marker.  The store root is the directory
-    that contains it.  When that directory coincides with the listing source
-    (so the marker's relative path has no parent), the source is lifted one
-    level so the root is always addressable as ``source`` + ``path``.
+    that contains it.  When the marker sits directly under the listing source
+    (so its relative path has no parent), the store root *is* the source: the
+    last path segment is peeled off for a clean ``(source, name)`` pair, falling
+    back to the whole source with an empty path when it has no path segment
+    (e.g. a bare bucket like ``s3://bucket``).
     """
     parent = posixpath.dirname(file.path)
     if parent:
         return file.source, parent
-    base, _, name = file.source.rstrip("/").rpartition("/")
-    return base, name
+    parts = urlsplit(file.source)
+    root = parts.path.rstrip("/")
+    if "/" in root:
+        head, _, name = root.rpartition("/")
+        base = urlunsplit((parts.scheme, parts.netloc, head, "", ""))
+        return base, name
+    return file.source.rstrip("/"), ""
 
 
 def file_to_store(file: File) -> ZarrStore:

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -204,22 +204,19 @@ class ZarrSelection(DataModel):
         import io
 
         import numpy as np
+        from PIL import Image
 
-        try:
-            from PIL import Image
-        except ImportError as exc:  # pragma: no cover
-            raise ImportError(
-                "Pillow is required to render Zarr image previews.\n"
-                "To install run:\n\n  pip install pillow\n"
-            ) from exc
-
-        from .video import _image_format
+        # Normalize e.g. "jpg"/".png" to a registered Pillow format name, with a
+        # plain upper-cased fallback (mirrors VideoFrame.read_bytes without the
+        # optional video dependency).
+        ext = format if format.startswith(".") else f".{format}"
+        pil_format = Image.registered_extensions().get(ext.lower(), format.upper())
 
         arr = np.asarray(self.read())
         if arr.dtype != np.uint8:
             arr = arr.astype("uint8")
         buf = io.BytesIO()
-        Image.fromarray(arr).save(buf, format=_image_format(format))
+        Image.fromarray(arr).save(buf, format=pil_format)
         return buf.getvalue()
 
 

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -4,17 +4,13 @@ This module provides the generic Zarr "core": a :class:`ZarrStore` data model
 that points at a Zarr store root and lets you inspect its arrays and read array
 data.  Higher-level conventions (xarray dimensions/coordinates, OME-Zarr
 multiscale preview, ...) are intentionally *not* handled here.
-
-Reading the actual data requires the optional ``zarr`` dependency:
-
-    pip install 'datachain[zarr]'
 """
 
 import posixpath
-import sys
 from collections.abc import Iterator
 from typing import Any, ClassVar, Literal
 
+import zarr
 from pydantic import Field
 
 from datachain.lib.data_model import DataModel
@@ -26,21 +22,6 @@ from datachain.lib.file import File
 #   - ``.zarray``    : Zarr v2 array metadata (array-only store)
 ZARR_ROOT_MARKERS = frozenset({"zarr.json", ".zgroup", ".zarray"})
 ZARR_SUFFIX = ".zarr"
-
-
-def _import_zarr() -> Any:
-    try:
-        import zarr
-    except ImportError as exc:
-        hint = (
-            "  pip install 'datachain[zarr]'\n"
-            if sys.version_info >= (3, 11)
-            else "Zarr support requires Python 3.11 or newer.\n"
-        )
-        raise ImportError(
-            "Missing dependencies for Zarr support.\nTo install run:\n\n" + hint
-        ) from exc
-    return zarr
 
 
 class ZarrInfo(DataModel):
@@ -70,8 +51,7 @@ class ZarrStore(DataModel):
     def path(self) -> str:
         return self.file.path
 
-    def _open(self, mode: str = "r") -> Any:
-        zarr = _import_zarr()
+    def _open(self, mode: Literal["r", "r+", "a", "w", "w-"] = "r") -> Any:
         f = self.file
         url = f.get_fs_path()
         storage_options = None
@@ -96,14 +76,12 @@ class ZarrStore(DataModel):
         yield from self._arrays(self._open())
 
     def _arrays(self, node: Any) -> Iterator["ZarrArray"]:
-        zarr = _import_zarr()
         if isinstance(node, zarr.Array):
             yield self._to_array(node, "")
             return
         yield from self._walk_arrays(node, "")
 
     def _walk_arrays(self, group: Any, prefix: str) -> Iterator["ZarrArray"]:
-        zarr = _import_zarr()
         seen: set[str] = set()
         for name, child in group.members():
             # Some store backends (e.g. ``HfFileSystem``) list each member more
@@ -120,7 +98,6 @@ class ZarrStore(DataModel):
 
     def get_array(self, path: str = "") -> "ZarrArray":
         """Return a single array by its path within the store."""
-        zarr = _import_zarr()
         node = self._open()
         arr = node[path] if path else node
         if not isinstance(arr, zarr.Array):
@@ -208,7 +185,7 @@ class ZarrSelection(DataModel):
 
         try:
             from PIL import Image
-        except ImportError as exc:
+        except ImportError as exc:  # pragma: no cover
             raise ImportError(
                 "Pillow is required to render Zarr image previews.\n"
                 "To install run:\n\n  pip install pillow\n"

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -83,14 +83,16 @@ class ZarrStore(DataModel):
         node = self._open()
         return ZarrInfo(
             zarr_format=int(node.metadata.zarr_format),
-            arrays=[a.path for a in self.get_arrays()],
+            arrays=[a.path for a in self._arrays(node)],
             attrs=dict(node.attrs),
         )
 
     def get_arrays(self) -> Iterator["ZarrArray"]:
         """Yield every array in the store (recursively)."""
+        yield from self._arrays(self._open())
+
+    def _arrays(self, node: Any) -> Iterator["ZarrArray"]:
         zarr = _import_zarr()
-        node = self._open()
         if isinstance(node, zarr.Array):
             yield self._to_array(node, "")
             return

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -1,0 +1,237 @@
+"""Generic Zarr support for DataChain.
+
+This module provides the generic Zarr "core": a :class:`ZarrStore` data model
+that points at a Zarr store root and lets you inspect its arrays and read array
+data.  Higher-level conventions (xarray dimensions/coordinates, OME-Zarr
+multiscale preview, ...) are intentionally *not* handled here.
+
+Reading the actual data requires the optional ``zarr`` dependency:
+
+    pip install 'datachain[zarr]'
+"""
+
+import posixpath
+from collections.abc import Iterator
+from typing import Any, ClassVar, Literal
+
+from pydantic import Field
+
+from datachain.lib.data_model import DataModel
+from datachain.lib.file import File
+
+# Names of the metadata objects that mark a Zarr store/array root.
+#   - ``zarr.json``  : Zarr v3 group or array metadata
+#   - ``.zgroup``    : Zarr v2 group metadata
+#   - ``.zarray``    : Zarr v2 array metadata (array-only store)
+ZARR_ROOT_MARKERS = frozenset({"zarr.json", ".zgroup", ".zarray"})
+ZARR_SUFFIX = ".zarr"
+
+
+def _import_zarr() -> Any:
+    try:
+        import zarr
+    except ImportError as exc:
+        raise ImportError(
+            "Missing dependencies for Zarr support.\n"
+            "To install run:\n\n"
+            "  pip install 'datachain[zarr]'\n"
+        ) from exc
+    return zarr
+
+
+class ZarrInfo(DataModel):
+    """Summary metadata for a Zarr store."""
+
+    zarr_format: int = Field(default=0)
+    arrays: list[str] = Field(default_factory=list)
+    attrs: dict = Field(default_factory=dict)
+
+
+class ZarrStore(DataModel):
+    """A Zarr store root.
+
+    Unlike :class:`~datachain.lib.file.File`, a store is a *tree* of objects
+    (metadata and chunks) rather than a single byte stream, so it is modeled as
+    a plain ``DataModel``.  The nested ``file`` points at the store root prefix
+    and carries the storage credentials/catalog needed to read the store.
+    """
+
+    file: File
+
+    @property
+    def source(self) -> str:
+        return self.file.source
+
+    @property
+    def path(self) -> str:
+        return self.file.path
+
+    def _open(self, mode: str = "r") -> Any:
+        zarr = _import_zarr()
+        f = self.file
+        url = f.get_fs_path()
+        storage_options = None
+        if f.source and not f.source.startswith("file://"):
+            catalog = getattr(f, "_catalog", None)
+            storage_options = getattr(catalog, "client_config", None) or None
+        if storage_options:
+            return zarr.open(url, mode=mode, storage_options=storage_options)
+        return zarr.open(url, mode=mode)
+
+    def get_info(self) -> ZarrInfo:
+        """Return summary metadata for the store."""
+        node = self._open()
+        return ZarrInfo(
+            zarr_format=int(node.metadata.zarr_format),
+            arrays=[a.path for a in self.get_arrays()],
+            attrs=dict(node.attrs),
+        )
+
+    def get_arrays(self) -> Iterator["ZarrArray"]:
+        """Yield every array in the store (recursively)."""
+        zarr = _import_zarr()
+        node = self._open()
+        if isinstance(node, zarr.Array):
+            yield self._to_array(node, "")
+            return
+        yield from self._walk_arrays(node, "")
+
+    def _walk_arrays(self, group: Any, prefix: str) -> Iterator["ZarrArray"]:
+        zarr = _import_zarr()
+        seen: set[str] = set()
+        for name, child in group.members():
+            # Some store backends (e.g. ``HfFileSystem``) list each member more
+            # than once; dedup by name so an array is yielded only once and we
+            # don't re-descend into the same subgroup repeatedly.
+            if name in seen:
+                continue
+            seen.add(name)
+            child_path = f"{prefix}/{name}".lstrip("/")
+            if isinstance(child, zarr.Array):
+                yield self._to_array(child, child_path)
+            else:
+                yield from self._walk_arrays(child, child_path)
+
+    def get_array(self, path: str = "") -> "ZarrArray":
+        """Return a single array by its path within the store."""
+        zarr = _import_zarr()
+        node = self._open()
+        arr = node[path] if path else node
+        if not isinstance(arr, zarr.Array):
+            raise ValueError(  # noqa: TRY004
+                f"'{path}' is not a Zarr array in store {self.path!r}"
+            )
+        return self._to_array(arr, path)
+
+    def _to_array(self, arr: Any, path: str) -> "ZarrArray":
+        chunks = list(arr.chunks) if arr.chunks is not None else None
+        return ZarrArray(
+            store=self,
+            path=path,
+            shape=list(arr.shape),
+            chunks=chunks,
+            dtype=str(arr.dtype),
+            attrs=dict(arr.attrs),
+        )
+
+
+class ZarrArray(DataModel):
+    """A single array within a :class:`ZarrStore`."""
+
+    store: ZarrStore
+    path: str = Field(default="")
+    shape: list[int] = Field(default_factory=list)
+    chunks: list[int] | None = Field(default=None)
+    dtype: str = Field(default="")
+    attrs: dict = Field(default_factory=dict)
+
+    _hidden_fields: ClassVar[list[str]] = ["attrs"]
+
+    def read(self, selection: Any = None) -> Any:
+        """Read array data, optionally restricted to a NumPy-style selection."""
+        node = self.store._open()
+        arr = node[self.path] if self.path else node
+        if selection is None:
+            return arr[...]
+        return arr[selection]
+
+    def select(
+        self,
+        index: "int | list[int]",
+        media: "Literal['image', 'audio', 'video'] | None" = None,
+    ) -> "ZarrSelection":
+        """Return a lazy :class:`ZarrSelection` pointing at an item in this array.
+
+        ``index`` addresses the leading axes (e.g. ``i`` or ``[i]`` for one
+        frame of an ``(N, H, W, C)`` array).  The region is read on demand via
+        :meth:`ZarrSelection.read`, so the item can travel through a DataChain
+        as a column without materializing its bytes.
+        """
+        idx = [index] if isinstance(index, int) else list(index)
+        return ZarrSelection(array=self, index=idx, media=media)
+
+
+class ZarrSelection(DataModel):
+    """A lazy, bounded region inside a :class:`ZarrArray`.
+
+    Points at a single item (or block) inside an array without reading it,
+    analogous to how :class:`~datachain.lib.file.File` points at a byte stream.
+    ``index`` addresses the leading axes; :meth:`read` materializes the region.
+    """
+
+    array: ZarrArray
+    index: list[int] = Field(default_factory=list)
+    media: Literal["image", "audio", "video"] | None = Field(default=None)
+
+    def read(self) -> Any:
+        """Read and return the selected region."""
+        return self.array.read(tuple(self.index))
+
+    def read_bytes(self, format: str = "PNG") -> bytes:
+        """Render the selected region to encoded media bytes.
+
+        Only ``media="image"`` is supported for now: the region is read and
+        encoded with Pillow (e.g. PNG), so callers such as Studio can stream a
+        preview without materializing the image into the row.
+        """
+        if self.media not in (None, "image"):
+            raise ValueError(f"read_bytes() supports image media, not {self.media!r}")
+        import io
+
+        import numpy as np
+
+        try:
+            from PIL import Image
+        except ImportError as exc:
+            raise ImportError(
+                "Pillow is required to render Zarr image previews.\n"
+                "To install run:\n\n  pip install pillow\n"
+            ) from exc
+
+        arr = np.asarray(self.read())
+        if arr.dtype != np.uint8:
+            arr = arr.astype("uint8")
+        buf = io.BytesIO()
+        Image.fromarray(arr).save(buf, format=format)
+        return buf.getvalue()
+
+
+def _store_root_split(file: File) -> tuple[str, str]:
+    """Return ``(source, path)`` for the store root containing ``file``.
+
+    ``file`` is a store-root metadata marker.  The store root is the directory
+    that contains it.  When that directory coincides with the listing source
+    (so the marker's relative path has no parent), the source is lifted one
+    level so the root is always addressable as ``source`` + ``path``.
+    """
+    parent = posixpath.dirname(file.path)
+    if parent:
+        return file.source, parent
+    base, _, name = file.source.rstrip("/").rpartition("/")
+    return base, name
+
+
+def file_to_store(file: File) -> ZarrStore:
+    """Build a :class:`ZarrStore` from a matched store-root metadata file."""
+    source, path = _store_root_split(file)
+    return ZarrStore(file=File(source=source, path=path))

--- a/src/datachain/lib/zarr.py
+++ b/src/datachain/lib/zarr.py
@@ -236,4 +236,13 @@ def _store_root_split(file: File) -> tuple[str, str]:
 def file_to_store(file: File) -> ZarrStore:
     """Build a :class:`ZarrStore` from a matched store-root metadata file."""
     source, path = _store_root_split(file)
-    return ZarrStore(file=File(source=source, path=path))
+    root = File(source=source, path=path)
+    # Carry over the stream so a store built in-process keeps its credentials
+    # (DataChain otherwise re-injects the catalog when materializing rows).
+    if file._catalog is not None:
+        root._set_stream(
+            file._catalog,
+            caching_enabled=file._caching_enabled,
+            download_cb=file._download_cb,
+        )
+    return ZarrStore(file=root)

--- a/tests/unit/lib/test_zarr.py
+++ b/tests/unit/lib/test_zarr.py
@@ -1,0 +1,93 @@
+import numpy as np
+import pytest
+
+import datachain as dc
+
+zarr = pytest.importorskip("zarr")
+
+
+def _make_store(root, who, n=4):
+    g = zarr.open_group(str(root), mode="w")
+    g.attrs["who"] = who
+    g.create_array("images", shape=(n, 8, 8), chunks=(1, 8, 8), dtype="uint8")
+    g["images"][:] = np.arange(n * 8 * 8).reshape(n, 8, 8).astype("uint8")
+    labels = g.create_group("labels")
+    labels.create_array("y", shape=(n,), dtype="int64")
+    labels["y"][:] = np.arange(n)
+    return g
+
+
+def _single_store(tmp_dir, test_session, name="s"):
+    _make_store(tmp_dir / f"{name}.zarr", name)
+    chain = dc.read_zarr((tmp_dir / f"{name}.zarr").as_uri(), session=test_session)
+    (store,) = next(iter(chain.to_iter("zarr")))
+    return store
+
+
+def test_read_zarr_one_row_per_store(tmp_dir, test_session):
+    for name in ("scan001", "scan002", "scan003"):
+        _make_store(tmp_dir / f"{name}.zarr", name)
+
+    chain = dc.read_zarr(tmp_dir.as_uri(), session=test_session)
+    stores = [s for (s,) in chain.order_by("zarr.file.path").to_iter("zarr")]
+
+    assert [s.path for s in stores] == ["scan001.zarr", "scan002.zarr", "scan003.zarr"]
+
+
+def test_read_zarr_discovers_stores_at_any_depth(tmp_dir, test_session):
+    _make_store(tmp_dir / "top.zarr", "top")
+    _make_store(tmp_dir / "a" / "b" / "deep.zarr", "deep")
+
+    chain = dc.read_zarr(tmp_dir.as_uri(), session=test_session)
+    paths = sorted(s.path for (s,) in chain.to_iter("zarr"))
+
+    # Both the top-level and the nested store are found, and nested array
+    # metadata (e.g. ".../images/zarr.json") is never reported as a store.
+    assert paths == ["a/b/deep.zarr", "top.zarr"]
+
+
+def test_read_zarr_directory(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session, name="only")
+
+    assert store.path == "only.zarr"
+
+
+def test_zarr_store_get_info(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+    info = store.get_info()
+
+    assert info.zarr_format == 3
+    assert sorted(info.arrays) == ["images", "labels/y"]
+    assert info.attrs == {"who": "s"}
+
+
+def test_zarr_store_get_arrays(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+    arrays = {a.path: a for a in store.get_arrays()}
+
+    assert sorted(arrays) == ["images", "labels/y"]
+    assert arrays["images"].shape == [4, 8, 8]
+    assert arrays["images"].chunks == [1, 8, 8]
+    assert arrays["images"].dtype == "uint8"
+    assert arrays["labels/y"].shape == [4]
+
+
+def test_zarr_array_read(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+
+    data = store.get_array("images").read()
+    assert data.shape == (4, 8, 8)
+    assert int(data.flat[0]) == 0
+
+    one = store.get_array("images").read(np.s_[0])
+    assert one.shape == (8, 8)
+
+    labels = store.get_array("labels/y").read()
+    assert labels.tolist() == [0, 1, 2, 3]
+
+
+def test_zarr_store_get_array_not_an_array(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+
+    with pytest.raises(ValueError, match="not a Zarr array"):
+        store.get_array("labels")

--- a/tests/unit/lib/test_zarr.py
+++ b/tests/unit/lib/test_zarr.py
@@ -182,3 +182,25 @@ def test_zarr_store_open_passes_remote_storage_options(
 
     assert captured["storage_options"] == {"key": "secret"}
     assert info.attrs == {"who": "s"}
+
+
+@pytest.mark.parametrize(
+    "source,path,expected_source,expected_path",
+    [
+        # Discovered marker nested under the listing root.
+        ("gs://bucket", "data/scan.zarr/zarr.json", "gs://bucket", "data/scan.zarr"),
+        # Concrete store path: the store root is the source itself.
+        ("gs://bucket/scan.zarr", "zarr.json", "gs://bucket", "scan.zarr"),
+        # Whole bucket is a single store (no path segment to split off).
+        ("s3://bucket", ".zgroup", "s3://bucket", ""),
+        ("s3://bucket/", ".zgroup", "s3://bucket", ""),
+    ],
+)
+def test_file_to_store_root_split(source, path, expected_source, expected_path):
+    from datachain.lib.file import File
+    from datachain.lib.zarr import file_to_store
+
+    store = file_to_store(File(source=source, path=path))
+
+    assert store.source == expected_source
+    assert store.path == expected_path

--- a/tests/unit/lib/test_zarr.py
+++ b/tests/unit/lib/test_zarr.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
-import zarr
 
 import datachain as dc
+
+zarr = pytest.importorskip("zarr")
 
 
 def _make_store(root, who, n=4):

--- a/tests/unit/lib/test_zarr.py
+++ b/tests/unit/lib/test_zarr.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -50,6 +52,7 @@ def test_read_zarr_directory(tmp_dir, test_session):
     store = _single_store(tmp_dir, test_session, name="only")
 
     assert store.path == "only.zarr"
+    assert store.source.startswith("file://")
 
 
 def test_zarr_store_get_info(tmp_dir, test_session):
@@ -142,3 +145,40 @@ def test_zarr_selection_read_bytes_rejects_non_image(tmp_dir, test_session):
 
     with pytest.raises(ValueError, match="supports image media"):
         selection.read_bytes()
+
+
+def test_zarr_selection_read_bytes_converts_non_uint8(tmp_dir, test_session):
+    g = zarr.open_group(str(tmp_dir / "f.zarr"), mode="w")
+    g.create_array("img", shape=(2, 4, 4), chunks=(1, 4, 4), dtype="float32")
+    g["img"][:] = np.zeros((2, 4, 4), dtype="float32")
+
+    chain = dc.read_zarr((tmp_dir / "f.zarr").as_uri(), session=test_session)
+    (store,) = next(iter(chain.to_iter("zarr")))
+    content = store.get_array("img").select(0, media="image").read_bytes()
+
+    assert content[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_zarr_store_open_passes_remote_storage_options(
+    tmp_dir, test_session, monkeypatch
+):
+    from datachain.lib.file import File
+    from datachain.lib.zarr import ZarrStore
+
+    _make_store(tmp_dir / "s.zarr", "s")
+    captured = {}
+    real_open = zarr.open
+
+    def fake_open(url, mode="r", storage_options=None):
+        captured["url"] = url
+        captured["storage_options"] = storage_options
+        return real_open(str(tmp_dir / "s.zarr"), mode=mode)
+
+    monkeypatch.setattr("datachain.lib.zarr.zarr.open", fake_open)
+
+    file = File(source="s3://bucket", path="s.zarr")
+    file._catalog = SimpleNamespace(client_config={"key": "secret"})
+    info = ZarrStore(file=file).get_info()
+
+    assert captured["storage_options"] == {"key": "secret"}
+    assert info.attrs == {"who": "s"}

--- a/tests/unit/lib/test_zarr.py
+++ b/tests/unit/lib/test_zarr.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
+import zarr
 
 import datachain as dc
-
-zarr = pytest.importorskip("zarr")
 
 
 def _make_store(root, who, n=4):
@@ -91,3 +90,54 @@ def test_zarr_store_get_array_not_an_array(tmp_dir, test_session):
 
     with pytest.raises(ValueError, match="not a Zarr array"):
         store.get_array("labels")
+
+
+def test_read_zarr_custom_column(tmp_dir, test_session):
+    _make_store(tmp_dir / "s.zarr", "s")
+
+    chain = dc.read_zarr(
+        (tmp_dir / "s.zarr").as_uri(), column="store", session=test_session
+    )
+    (store,) = next(iter(chain.to_iter("store")))
+
+    assert store.path == "s.zarr"
+
+
+def test_zarr_array_only_store(tmp_dir, test_session):
+    zarr.open_array(str(tmp_dir / "arr.zarr"), mode="w", shape=(2, 3), dtype="uint8")
+
+    chain = dc.read_zarr((tmp_dir / "arr.zarr").as_uri(), session=test_session)
+    (store,) = next(iter(chain.to_iter("zarr")))
+    arrays = store.get_arrays()
+
+    assert [a.path for a in arrays] == [""]
+    assert store.get_array().shape == [2, 3]
+
+
+def test_zarr_selection_read(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+
+    selection = store.get_array("images").select(0)
+    assert selection.index == [0]
+    assert selection.read().shape == (8, 8)
+
+    block = store.get_array("images").select([1])
+    assert block.read().shape == (8, 8)
+
+
+def test_zarr_selection_read_bytes_image(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+
+    selection = store.get_array("images").select(0, media="image")
+    content = selection.read_bytes()
+
+    assert content[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_zarr_selection_read_bytes_rejects_non_image(tmp_dir, test_session):
+    store = _single_store(tmp_dir, test_session)
+
+    selection = store.get_array("images").select(0, media="audio")
+
+    with pytest.raises(ValueError, match="supports image media"):
+        selection.read_bytes()


### PR DESCRIPTION
## Summary

Adds a generic Zarr core to the DataChain library.

- **`read_zarr(path, ...)`** — discovers `*.zarr` stores under a path and yields one row per store.
- **`ZarrStore` / `ZarrArray`** — data models for inspecting a store's arrays and reading array data (using the `zarr` package).
- **`ZarrSelection`** — a lazy, bounded region inside an array that travels through a chain as a column without materializing its bytes. Provides `read()` and an image `read_bytes()` encoder used for streamed previews.

Zarr is an **optional** dependency, kept out of the core install so the
project keeps supporting Python >= 3.10 (the `zarr` 3.x package itself
requires Python >= 3.11). Install it with the `zarr` extra:

```
pip install 'datachain[zarr]'
```

Importing `datachain.lib.zarr` works without the extra; the Zarr ops
raise a clear `ImportError` pointing at `datachain[zarr]` (and the
Python >= 3.11 requirement) only when actually used.

## Test plan

- `tests/unit/lib/test_zarr.py` covers store discovery (one row per store, any depth), single-store reads, array access, and error cases.