### PR TITLE
ci: fix flaky example/e2e jobs (Python 3.10 FutureWarning + HF 429 rate limits)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,7 +228,10 @@ jobs:
 
       - name: Run examples
         env:
-          HF_TOKEN: ${{ matrix.group == 'llm_and_nlp' && secrets.HF_TOKEN || '' }}
+          # Pass HF_TOKEN to all example groups: several groups download public
+          # models/datasets from the HF Hub anonymously (transformers, open_clip),
+          # which now hits HTTP 429 rate limits. Authenticating raises the limit.
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           ANTHROPIC_API_KEY: ${{ matrix.group == 'llm_and_nlp' && secrets.ANTHROPIC_API_KEY || '' }}
           OPENAI_API_KEY: ${{ matrix.group == 'multimodal' && secrets.OPENAI_API_KEY || '' }}
         run: nox -s examples -p ${{ matrix.pyv }} -- -m "${{ matrix.group }}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -183,6 +183,13 @@ def e2e_subprocess_env(catalog: Catalog) -> dict[str, str]:
     env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
     env["DATACHAIN__METASTORE"] = catalog.metastore.serialize()
     env["DATACHAIN__WAREHOUSE"] = catalog.warehouse.serialize()
+    # Silence google-api-core's Python-version-deprecation FutureWarning so it does
+    # not pollute subprocess stderr (it only appears on older Python versions and
+    # would otherwise trip e2e assertions that check stderr for warnings).
+    python_warnings = "ignore::FutureWarning:google.api_core._python_version_support"
+    if existing := env.get("PYTHONWARNINGS"):
+        python_warnings = f"{existing},{python_warnings}"
+    env["PYTHONWARNINGS"] = python_warnings
     return env
 
 


### PR DESCRIPTION
Fixes two unrelated CI failures.

## 1. E2E tests fail on Python 3.10 (FutureWarning in stderr)

The `Tests` workflow's **E2E tests** job fails only on Python 3.10 (3.12/3.13 pass).

The e2e step that interrupts `tests/scripts/name_len_slow.py` asserts:
```python
"expected_not_in_stderr": "Warning"
```

On Python 3.10, `google.api_core._python_version_support` emits a `FutureWarning` into the subprocess stderr stating Google will stop supporting Python 3.10 (EOL 2026-10-04). The substring `Warning` (from `FutureWarning`) trips the assertion. Newer Python versions are not flagged, so they pass.

**Fix:** `e2e_subprocess_env` in `tests/utils.py` sets `PYTHONWARNINGS` to ignore that one external warning:
```
ignore::FutureWarning:google.api_core._python_version_support
```
Any pre-existing `PYTHONWARNINGS` value is preserved, and real warnings during interrupt/cleanup are still surfaced.

## 2. Example jobs hit HuggingFace 429 rate limits

Several example groups (`computer_vision`, `multimodal`, `get_started`) download public models/datasets from the HuggingFace Hub anonymously via `transformers` and `open_clip`. Anonymous HF traffic is now aggressively rate-limited (HTTP 429). `HF_TOKEN` was previously injected only for the `llm_and_nlp` group, so the other groups ran unauthenticated and hit 429s.

**Fix:** Pass `HF_TOKEN` to every example group in `.github/workflows/tests.yml` to raise the rate limit.

## Validation

- Verified locally that the `PYTHONWARNINGS` filter suppresses a `FutureWarning` originating from the target module while leaving it visible without the filter.
- `HF_TOKEN` is already configured as a repo secret; CI change is config-only.