### PR TITLE
fix(metastore): store job params/metrics as JSON objects, not encoded strings

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -2288,8 +2288,8 @@ class AbstractDBMetastore(AbstractMetastore):
                 python_version=python_version,
                 error_message="",
                 error_stack="",
-                params=json.dumps(params or {}),
-                metrics=json.dumps({}),
+                params=params or {},
+                metrics={},
                 parent_job_id=parent_job_id,
                 rerun_from_job_id=rerun_from_job_id,
                 run_group_id=run_group_id,
@@ -2352,7 +2352,7 @@ class AbstractDBMetastore(AbstractMetastore):
         if finished_at is not None:
             values["finished_at"] = finished_at
         if metrics:
-            values["metrics"] = json.dumps(metrics)
+            values["metrics"] = metrics
 
         if values:
             j = self._jobs

--- a/src/datachain/job.py
+++ b/src/datachain/job.py
@@ -8,6 +8,27 @@ from datachain import json
 J = TypeVar("J", bound="Job")
 
 
+def _as_dict(value: "str | dict | None") -> dict:
+    """Normalize a JSON column value to a dict.
+
+    A JSON column can hand back either a ``str`` or an already-decoded
+    ``dict`` depending on the backend and how the row was written:
+
+    - SQLite always returns the raw string.
+    - PostgreSQL/JSONB returns a ``dict`` for rows stored as a JSON object,
+      but a ``str`` for legacy rows that were double-encoded into a JSON
+      string scalar (e.g. ``"{}"``) by a previous ``json.dumps``-on-write.
+
+    Decoding only when we still have a string keeps both the current and the
+    legacy on-disk formats readable, so no data migration is required.
+    """
+    if value is None or value == "":
+        return {}
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
 @dataclass
 class Job:
     id: str
@@ -42,8 +63,8 @@ class Job:
         python_version: str | None,
         error_message: str,
         error_stack: str,
-        params: str,
-        metrics: str,
+        params: "str | dict[str, str] | None",
+        metrics: "str | dict[str, Any] | None",
         parent_job_id: str | None,
         rerun_from_job_id: str | None,
         run_group_id: str | None,
@@ -57,8 +78,8 @@ class Job:
             query,
             query_type,
             workers,
-            json.loads(params),
-            json.loads(metrics),
+            _as_dict(params),
+            _as_dict(metrics),
             finished_at,
             python_version,
             error_message,

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -1013,6 +1013,52 @@ def test_update_job(metastore):
     assert updated.metrics == {"acc": 0.5, "hist": [1, 2]}
 
 
+def test_job_params_metrics_stored_as_json_object(metastore):
+    """params/metrics must be stored as JSON objects, not pre-serialized strings.
+
+    create_job/update_job pass dicts straight to the JSON columns so each
+    backend serializes once. Pre-``json.dumps``-ing the value double-encodes it
+    on JSONB backends (PostgreSQL stores a ``"{}"`` string scalar instead of an
+    object), which breaks consumers that read the column as a dict. The stored
+    text must decode to the original mapping in a single pass.
+    """
+    job_id = metastore.create_job(
+        name="json_shape_job",
+        query="SELECT 1",
+        query_type=JobQueryType.PYTHON,
+        status=JobStatus.CREATED,
+        workers=1,
+        params={"foo": "bar"},
+    )
+    metastore.update_job(job_id, metrics={"acc": 0.5, "nested": {"x": 1}})
+
+    def stored(job_id, *columns):
+        # Read the raw stored JSON, bypassing Job.parse's dict normalization.
+        jobs = metastore._jobs
+        query = metastore._jobs_select(*columns).where(jobs.c.id == job_id)
+        return next(metastore.db.execute(query))
+
+    raw_params, raw_metrics = stored(
+        job_id, metastore._jobs.c.params, metastore._jobs.c.metrics
+    )
+
+    # A single decode yields the mapping (not a string that needs decoding again).
+    assert json.loads(raw_params) == {"foo": "bar"}
+    assert json.loads(raw_metrics) == {"acc": 0.5, "nested": {"x": 1}}
+
+    # And an empty-metrics job stores an empty object, not a quoted scalar.
+    empty_id = metastore.create_job(
+        name="empty_metrics_job",
+        query="SELECT 1",
+        query_type=JobQueryType.PYTHON,
+        status=JobStatus.CREATED,
+        workers=1,
+    )
+    (raw_empty,) = stored(empty_id, metastore._jobs.c.metrics)
+    assert json.loads(raw_empty) == {}
+    assert metastore.get_job(empty_id).metrics == {}
+
+
 def test_set_job_status(metastore):
     job_id = metastore.create_job(
         name="status_job",

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -1,3 +1,5 @@
+import pytest
+
 from datachain.job import Job
 
 
@@ -26,3 +28,45 @@ def test_parse():
     assert job.name == "test-job"
     assert job.run_group_id == "group-1"
     assert job.rerun_from_job_id is None
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # SQLite returns JSON columns as raw strings.
+        ('{"a": "b"}', {"a": "b"}),
+        # PostgreSQL/JSONB deserializes JSON columns to Python objects.
+        ({"a": "b"}, {"a": "b"}),
+        # Legacy double-encoded rows decode to a string scalar like '{}'.
+        ("{}", {}),
+        # None / empty-string edge cases (empty JSON in some backends).
+        (None, {}),
+        ("", {}),
+    ],
+)
+def test_parse_params_metrics_accepts_str_and_dict(value, expected):
+    """params/metrics may arrive as a str (SQLite) or a dict (PostgreSQL/JSONB).
+
+    Job.parse must normalize both to a dict without re-decoding a dict.
+    """
+    job = Job.parse(
+        id="test-id",
+        name="test-job",
+        status=1,
+        created_at="2024-01-01T00:00:00",
+        finished_at=None,
+        query="SELECT 1",
+        query_type=1,
+        workers=1,
+        python_version=None,
+        error_message="",
+        error_stack="",
+        params=value,
+        metrics=value,
+        parent_job_id=None,
+        rerun_from_job_id=None,
+        run_group_id=None,
+    )
+
+    assert job.params == expected
+    assert job.metrics == expected


### PR DESCRIPTION
## Problem

`create_job`/`update_job` pre-`json.dumps`'d `params` and `metrics` before binding them to the SQLAlchemy `JSON` columns:

```python
params=json.dumps(params or {}),
metrics=json.dumps({}),
...
values["metrics"] = json.dumps(metrics)
```

The `JSON` column type serializes *again*, so on **JSONB backends** (the Studio Postgres metastore, which inherits this same `AbstractDBMetastore`) a dict gets **double-encoded** into a JSON **string scalar** — `{}` is stored as `"{}"` rather than `{}`. Consumers that read the column as a dict (e.g. Studio's Django `JSONField`) then see a `str` and reject it (HTTP 400). The fingerprint is rows whose `metrics` is exactly the string `"{}"` — jobs whose metrics were only ever set to empty.

### Why it was invisible locally

On the OSS **SQLite** metastore the `JSON` columns are a **read passthrough**: a typed select returns the raw stored string, not a deserialized dict. So the write-side `json.dumps` and the read-side `json.loads` in `Job.parse` cancel out and SQLite stores correct JSON either way. The bug only manifests on JSONB, which is why existing tests passed and the symptom only showed up in Studio.

## Fix

- **Write** — bind dicts straight to the JSON columns (`params=params or {}`, `metrics={}`, `values["metrics"] = metrics`) so each backend serializes exactly once.
- **Read** — `Job.parse` now normalizes via a small `_as_dict` helper that accepts both `str` (SQLite, and legacy double-encoded Postgres scalars) and `dict` (correct JSONB), plus `None`/`""`.

This is **backward-compatible**: existing double-encoded `"{}"` rows still decode to `{}`, so no data migration is required. New rows are stored as proper JSON objects.

## Tests

- `tests/unit/test_job.py` — parametrized `Job.parse` coverage for `str` / `dict` / `None` / `""`. This is the catchable regression guard: the old `json.loads(dict)` raised `TypeError`, which is exactly what the fixed JSONB write path now returns on read.
- `tests/func/test_metastore.py` — asserts `params`/`metrics` are stored as JSON **objects** (single decode yields the mapping), including the empty-metrics case.

Verified locally: 192 related tests pass, `mypy` and `ruff` clean.

## Notes / follow-ups (not in this PR)

Surfaced while tracing this, worth separate PRs:
- Studio's job-metrics ingest validator should defensively reject non-dict `metrics` (defense in depth).
- `JobOutput` / usage scripts could expose existing telemetry already on the record (`compute_cluster`, `metrics`).
- Studio's `tasks/job.py` receives `workers_stats` but drops it (`pass  # TODO`) — per-worker resource/cost data is currently not persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
