### PR TITLE
fix(metastore): store job params/metrics as JSON objects, not encoded strings

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -2288,8 +2288,8 @@ class AbstractDBMetastore(AbstractMetastore):
                 python_version=python_version,
                 error_message="",
                 error_stack="",
-                params=json.dumps(params or {}),
-                metrics=json.dumps({}),
+                params=params or {},
+                metrics={},
                 parent_job_id=parent_job_id,
                 rerun_from_job_id=rerun_from_job_id,
                 run_group_id=run_group_id,
@@ -2352,7 +2352,7 @@ class AbstractDBMetastore(AbstractMetastore):
         if finished_at is not None:
             values["finished_at"] = finished_at
         if metrics:
-            values["metrics"] = json.dumps(metrics)
+            values["metrics"] = metrics
 
         if values:
             j = self._jobs

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -1013,6 +1013,55 @@ def test_update_job(metastore):
     assert updated.metrics == {"acc": 0.5, "hist": [1, 2]}
 
 
+def test_job_params_metrics_stored_as_json_object(metastore):
+    """params/metrics round-trip through the JSON columns as objects.
+
+    create_job/update_job pass dicts straight to the JSON columns so each
+    backend serializes once. Pre-``json.dumps``-ing the value double-encodes it
+    on a native-JSON backend (PostgreSQL stores a ``"{}"`` string scalar
+    instead of an object), which breaks consumers that read the column as a
+    dict. That failure mode is PostgreSQL-only and cannot be reproduced here --
+    SQLite stores the serialized text verbatim either way -- so this is a
+    round-trip/regression *guard for the SQLite path* plus documentation of the
+    contract; the stored text must decode to the original mapping in one pass.
+    """
+    job_id = metastore.create_job(
+        name="json_shape_job",
+        query="SELECT 1",
+        query_type=JobQueryType.PYTHON,
+        status=JobStatus.CREATED,
+        workers=1,
+        params={"foo": "bar"},
+    )
+    metastore.update_job(job_id, metrics={"acc": 0.5, "nested": {"x": 1}})
+
+    def stored(job_id, *columns):
+        # Read the raw stored value, bypassing Job.parse's json.loads.
+        jobs = metastore._jobs
+        query = metastore._jobs_select(*columns).where(jobs.c.id == job_id)
+        return next(metastore.db.execute(query))
+
+    raw_params, raw_metrics = stored(
+        job_id, metastore._jobs.c.params, metastore._jobs.c.metrics
+    )
+
+    # A single decode yields the mapping (not a string that needs decoding again).
+    assert json.loads(raw_params) == {"foo": "bar"}
+    assert json.loads(raw_metrics) == {"acc": 0.5, "nested": {"x": 1}}
+
+    # And an empty-metrics job stores an empty object, not a quoted scalar.
+    empty_id = metastore.create_job(
+        name="empty_metrics_job",
+        query="SELECT 1",
+        query_type=JobQueryType.PYTHON,
+        status=JobStatus.CREATED,
+        workers=1,
+    )
+    (raw_empty,) = stored(empty_id, metastore._jobs.c.metrics)
+    assert json.loads(raw_empty) == {}
+    assert metastore.get_job(empty_id).metrics == {}
+
+
 def test_set_job_status(metastore):
     job_id = metastore.create_job(
         name="status_job",


### PR DESCRIPTION
## Problem

`create_job`/`update_job` pre-`json.dumps`'d `params`/`metrics` before binding them to the `sqlalchemy.JSON` columns. On a native-JSON backend the column serializes **again**, so a dict double-encodes into a JSON **string scalar** — `{}` is stored as `"{}"`. Verified on real Postgres 16 (generic `JSON` and `JSONB`, identical):

```
bind json.dumps({}) (str)  ->  stored '"{}"'  (scalar)  ->  read back as str   ❌
bind {} (dict)             ->  stored '{}'    (object)  ->  read back as dict  ✅
```

The SaaS Postgres metastore (`PostgreSQLMetastore`, which inherits `AbstractDBMetastore` and writes to `dqlapp_job`) hits this. Anything reading the column as native JSON — Studio's Django `JSONField` on `dqlapp_job.metrics` — then gets a `str` and rejects it.

It's invisible locally because the SQLite metastore reads through the **raw `sqlite3` cursor** (`SQLiteDatabaseEngine.execute`), which bypasses SQLAlchemy's JSON result processor: values are stored and returned as text either way. **SQLite stores correct JSON regardless, so no SQLite migration is needed.**

## Fix

Bind dicts directly so each backend serializes exactly once:

```python
params=params or {}      # was json.dumps(params or {})
metrics={}               # was json.dumps({})
values["metrics"] = metrics   # was json.dumps(metrics)
```

**No read-side change is needed** — and that's deliberate, not an omission:
- **OSS** ships only `SQLiteMetastore`, where reads always return a `str`, so the existing `Job.parse` `json.loads` is correct.
- **The SaaS** reads via `SaaSJob.parse` (`PostgreSQLMetastore.job_class = SaaSJob`), which is already `str`-or-`dict` tolerant (`_dict_param`). It handles both new native objects and legacy `"{}"` scalars.

So the bug is purely the write-side double-encode, and this is the minimal fix for it. (An earlier revision also made OSS `Job.parse` tolerant via an `_as_dict` helper; that was dropped as unnecessary, since no current code path feeds a `dict` into the OSS `Job.parse`.)

## Backward compatibility

Legacy `"{}"` rows already in `dqlapp_job` keep their string value; the SaaS read paths (`SaaSJob._dict_param`, and the HTTP `JobOutput._coerce_metrics`) already coerce them. Cleaning them up so *direct* readers (admin, `data.py`, analytics) also see dicts is a one-shot backfill on the Studio side — out of scope here.

## Tests

`tests/func/test_metastore.py` — round-trips `params`/`metrics` (incl. nested + empty) and asserts the stored text decodes to the mapping in a single pass. Note: the double-encode itself is PostgreSQL-only and can't be reproduced on the SQLite test fixture, so this guards the SQLite round-trip and documents the contract; the real fix is validated against Postgres in the PR discussion.

`mypy` + `ruff` clean.

## Follow-ups (separate, not in this PR)

- **datachain_server:** version bump to consume this fix (no code change — `PostgreSQLMetastore` inherits the write methods).
- **Studio:** one-shot backfill of legacy string-scalar rows (`WHERE jsonb_typeof(metrics) = 'string'`).
- **Dataset columns** (`attrs`, `schema`, `feature_schema`, `preview`) double-encode the same way, but `preview` holds `bytes` and needs the custom (`serialize_bytes`) encoder — so those are better declared `TEXT` (honest typing for manually-serialized data) rather than bound as native objects. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
