### PR TITLE
feat: built-in per-dataset statistics

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1058,10 +1058,64 @@ class Catalog:
                 preview_rows,
             )
 
+        # Compute distribution stats eagerly on backends where it is cheap
+        # (e.g. ClickHouse).  Slow backends (SQLite) leave this for lazy
+        # computation on first access via ``get_dataset_stats``.
+        if self.warehouse.stats_compute_is_cheap() and dataset_version.stats is None:
+            try:
+                values["stats"] = self.warehouse.compute_dataset_stats(dataset, version)
+            except Exception:
+                # Stats are best-effort and must never break dataset creation.
+                logger.warning(
+                    "Failed to compute stats for %s@%s",
+                    dataset.name,
+                    version,
+                    exc_info=True,
+                )
+
         if not values:
             return
 
         self.metastore.update_dataset_version(dataset, version, **values)
+
+    def get_dataset_stats(
+        self,
+        name: str,
+        version: str | None = None,
+        *,
+        namespace_name: str | None = None,
+        project_name: str | None = None,
+        force: bool = False,
+        **compute_kwargs,
+    ) -> dict:
+        """Return per-column distribution statistics for a dataset version.
+
+        Stats are cached on the dataset version: a previously computed value is
+        returned as-is unless ``force=True``.  Otherwise they are computed via
+        the warehouse and persisted for next time.
+        """
+        namespace_name, project_name, name = self.get_full_dataset_name(
+            name, project_name=project_name, namespace_name=namespace_name
+        )
+        dataset = self.get_dataset(
+            name,
+            namespace_name=namespace_name,
+            project_name=project_name,
+            versions=None,
+            include_incomplete=False,
+        )
+        version = version or dataset.latest_version
+        dataset_version = dataset.get_version(version)
+
+        if dataset_version.stats is not None and not force and not compute_kwargs:
+            return dataset_version.stats
+
+        stats = self.warehouse.compute_dataset_stats(dataset, version, **compute_kwargs)
+        # Persist only the default (un-parameterized) computation so the cache
+        # stays consistent with what callers get back by default.
+        if not compute_kwargs:
+            self.metastore.update_dataset_version(dataset, version, stats=stats)
+        return stats
 
     def complete_dataset_version(
         self,

--- a/src/datachain/cli/__init__.py
+++ b/src/datachain/cli/__init__.py
@@ -11,6 +11,7 @@ from .commands import (
     bucket_status_cmd,
     clear_cache,
     completion,
+    dataset_stats,
     du,
     edit_dataset,
     garbage_collect,
@@ -206,6 +207,13 @@ def handle_dataset_command(args, catalog):
             force=args.force,
             studio=args.studio,
             team=args.team,
+        ),
+        "stats": lambda: dataset_stats(
+            catalog,
+            args.name,
+            version=args.version,
+            force=args.force,
+            as_json=args.as_json,
         ),
     }
 

--- a/src/datachain/cli/commands/__init__.py
+++ b/src/datachain/cli/commands/__init__.py
@@ -1,5 +1,11 @@
 from .bucket import bucket_status_cmd
-from .datasets import edit_dataset, list_datasets, list_datasets_local, rm_dataset
+from .datasets import (
+    dataset_stats,
+    edit_dataset,
+    list_datasets,
+    list_datasets_local,
+    rm_dataset,
+)
 from .du import du
 from .index import index
 from .ls import ls
@@ -11,6 +17,7 @@ __all__ = [
     "bucket_status_cmd",
     "clear_cache",
     "completion",
+    "dataset_stats",
     "du",
     "edit_dataset",
     "garbage_collect",

--- a/src/datachain/cli/commands/datasets.py
+++ b/src/datachain/cli/commands/datasets.py
@@ -213,3 +213,73 @@ def edit_dataset(
             raise DataChainError(
                 "Not logged in to Studio. Log in with 'datachain auth login'."
             )
+
+
+def _format_stats_value(kind: str, info: dict) -> str:
+    if kind == "numeric":
+        mn, mx, avg = info.get("min"), info.get("max"), info.get("avg")
+        avg_str = f"{avg:.4g}" if isinstance(avg, (int, float)) else "—"
+        return f"min={mn}  max={mx}  avg={avg_str}"
+    if kind == "boolean":
+        return f"true={info.get('true_count', 0)}  false={info.get('false_count', 0)}"
+    if kind == "temporal":
+        return f"min={info.get('min')}  max={info.get('max')}"
+    if kind == "categorical":
+        distinct = info.get("distinct_count")
+        prefix = "~" if info.get("distinct_approx") else ""
+        top = info.get("top_k") or []
+        top_str = ", ".join(f"{t['value']}({t['count']})" for t in top[:3])
+        return f"distinct={prefix}{distinct}  top: {top_str}"
+    return ""
+
+
+def dataset_stats(
+    catalog: "Catalog",
+    name: str,
+    version: str | None = None,
+    force: bool = False,
+    as_json: bool = False,
+) -> None:
+    from datachain.dataset import parse_dataset_with_version
+
+    name, name_version = parse_dataset_with_version(name)
+    version = version or name_version
+
+    try:
+        stats = catalog.get_dataset_stats(name, version, force=force)
+    except DatasetNotFoundError:
+        print("Dataset not found in local", file=sys.stderr)
+        return
+
+    if as_json:
+        from datachain import json
+
+        print(json.dumps(stats, indent=2))
+        return
+
+    sampled = stats.get("sampled")
+    sample_note = f" (sampled {sampled['rows']} rows)" if sampled else ""
+    print(f"rows: {stats['row_count']}{sample_note}")
+
+    rows = [
+        [
+            col,
+            info.get("type", ""),
+            info.get("null_count", 0),
+            _format_stats_value(info.get("kind", ""), info),
+        ]
+        for col, info in stats.get("columns", {}).items()
+    ]
+    if rows:
+        print(
+            tabulate(
+                rows,
+                headers=["column", "type", "nulls", "distribution"],
+                disable_numparse=True,
+            )
+        )
+
+    skipped = stats.get("skipped_columns") or {}
+    if skipped:
+        skipped_str = ", ".join(f"{c} ({reason})" for c, reason in skipped.items())
+        print(f"\nskipped: {skipped_str}")

--- a/src/datachain/cli/commands/datasets.py
+++ b/src/datachain/cli/commands/datasets.py
@@ -8,7 +8,11 @@ from datachain import semver
 from datachain.catalog import is_namespace_local
 from datachain.cli.utils import determine_flavors
 from datachain.config import Config
-from datachain.error import DataChainError, DatasetNotFoundError
+from datachain.error import (
+    DataChainError,
+    DatasetNotFoundError,
+    DatasetVersionNotFoundError,
+)
 from datachain.studio import list_datasets as list_datasets_studio
 
 if TYPE_CHECKING:
@@ -247,8 +251,8 @@ def dataset_stats(
 
     try:
         stats = catalog.get_dataset_stats(name, version, force=force)
-    except DatasetNotFoundError:
-        print("Dataset not found in local", file=sys.stderr)
+    except (DatasetNotFoundError, DatasetVersionNotFoundError) as e:
+        print(str(e) or "Dataset not found in local", file=sys.stderr)
         return
 
     if as_json:

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -306,6 +306,34 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         help="The team to delete a dataset. By default, it will use team from config",
     )
 
+    stats_dataset_parser = datasets_subparser.add_parser(
+        "stats",
+        parents=[parent_parser],
+        description="Show per-column distribution statistics for a dataset.",
+        formatter_class=CustomHelpFormatter,
+    )
+    stats_dataset_parser.add_argument("name", type=str, help="Dataset name")
+    stats_dataset_parser.add_argument(
+        "--version",
+        action="store",
+        default=None,
+        type=str,
+        help="Dataset version (defaults to the latest version)",
+    )
+    stats_dataset_parser.add_argument(
+        "--force",
+        default=False,
+        action="store_true",
+        help="Recompute stats even if a cached value exists",
+    )
+    stats_dataset_parser.add_argument(
+        "--json",
+        dest="as_json",
+        default=False,
+        action="store_true",
+        help="Output raw stats as JSON instead of a formatted table",
+    )
+
     parse_ls = subp.add_parser(
         "ls",
         parents=[parent_parser],

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -300,6 +300,7 @@ class AbstractMetastore(ABC, Serializable):
         job_id: str | None = None,
         uuid: str | None = None,
         content_hash: str | None = None,
+        stats: dict | None = None,
     ) -> tuple[DatasetRecord, bool]:
         """Creates new dataset version.
 
@@ -848,6 +849,11 @@ class AbstractDBMetastore(AbstractMetastore):
             Column("schema", JSON, nullable=True),
             Column("job_id", Text, nullable=True),
             Column("content_hash", Text, nullable=True),
+            # Per-column distribution statistics (row counts, numeric ranges /
+            # histograms, top-K categorical values, ...).  ``None`` means stats
+            # have not been computed yet; they are filled lazily or eagerly
+            # depending on the warehouse backend.
+            Column("stats", JSON, nullable=True),
             UniqueConstraint("dataset_id", "version"),
         ]
 
@@ -1278,6 +1284,7 @@ class AbstractDBMetastore(AbstractMetastore):
         job_id: str | None = None,
         uuid: str | None = None,
         content_hash: str | None = None,
+        stats: dict | None = None,
     ) -> tuple[DatasetRecord, bool]:
         """Creates new dataset version.
 
@@ -1312,6 +1319,7 @@ class AbstractDBMetastore(AbstractMetastore):
             preview=json.dumps(preview or []),
             job_id=job_id or os.getenv("DATACHAIN_JOB_ID"),
             content_hash=content_hash,
+            stats=json.dumps(stats) if stats is not None else None,
         )
         if ignore_if_exists:
             query = query.on_conflict_do_nothing(  # type: ignore[attr-defined]
@@ -1449,6 +1457,9 @@ class AbstractDBMetastore(AbstractMetastore):
                     values[field] = json.dumps(value, serialize_bytes=True)
                 version_values["_preview_data"] = value
                 version_values["_preview_loaded"] = True
+            elif field == "stats":
+                values[field] = json.dumps(value) if value is not None else None
+                version_values[field] = value
             else:
                 values[field] = value
                 version_values[field] = value

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -86,6 +86,20 @@ def _stats_stringify(value: Any) -> str | None:
     return text
 
 
+def _stats_isoformat(value: Any) -> str | None:
+    """Coerce a temporal aggregate result into a JSON-friendly string.
+
+    Backends may return ``datetime`` objects (which aren't stdlib-JSON
+    serializable) or already-formatted strings; normalize both so the
+    freshly computed dict and the value reloaded from the DB match.
+    """
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
 class AbstractWarehouse(ABC, Serializable):
     """
     Abstract Warehouse class, to be implemented by any Database Adapters
@@ -590,7 +604,6 @@ class AbstractWarehouse(ABC, Serializable):
         top_k: int | None = None,
         bins: int | None = None,
         max_columns: int | None = None,
-        sample: int | None = None,
     ) -> dict[str, Any]:
         """Compute per-column distribution statistics for a dataset version.
 
@@ -600,7 +613,7 @@ class AbstractWarehouse(ABC, Serializable):
               "stats_version": 1,
               "computed_at": "<iso8601>",
               "row_count": <int>,
-              "sampled": false | {"rows": <int>, "fraction": <float>},
+              "sampled": false,   # reserved for future sampling support
               "columns": {
                 "<dotted.name>": {
                   "type": "<python type>", "kind": "numeric|categorical|...",
@@ -621,9 +634,11 @@ class AbstractWarehouse(ABC, Serializable):
         """
         from datachain.data_storage.schema import DEFAULT_DELIMITER
 
-        top_k = self.STATS_TOP_K if top_k is None else top_k
-        bins = self.STATS_HISTOGRAM_BINS if bins is None else bins
-        max_columns = self.STATS_MAX_COLUMNS if max_columns is None else max_columns
+        top_k = max(1, self.STATS_TOP_K if top_k is None else top_k)
+        bins = max(1, self.STATS_HISTOGRAM_BINS if bins is None else bins)
+        max_columns = max(
+            1, self.STATS_MAX_COLUMNS if max_columns is None else max_columns
+        )
 
         table_name = self.dataset_table_name(dataset, version)
         if not self.db.has_table(table_name):
@@ -632,16 +647,7 @@ class AbstractWarehouse(ABC, Serializable):
             )
 
         table = self.dataset_rows(dataset, version).get_table()
-
-        # Optional random sample (mostly useful on slow backends).
-        if sample is not None:
-            sub = sa.select(table)
-            rand_col = table.c.get("sys__rand")
-            if rand_col is not None:
-                sub = sub.order_by(rand_col)
-            base: Any = sub.limit(sample).subquery()
-        else:
-            base = table
+        base = table
 
         # Classify leaf columns from the real table types.
         analyzed: list[tuple[str, str, str, Any]] = []  # display, db, kind, sqltype
@@ -664,23 +670,11 @@ class AbstractWarehouse(ABC, Serializable):
                 skipped[display] = "max_columns_exceeded"
             analyzed = analyzed[:max_columns]
 
-        row_count = self.table_rows_count(base if sample is not None else table)
-        if sample is not None:
-            full_count = self.table_rows_count(table)
-            n_rows = row_count
-            sampled: Any = {
-                "rows": n_rows,
-                "fraction": (n_rows / full_count) if full_count else 0.0,
-            }
-            row_count = full_count
-        else:
-            n_rows = row_count
-            sampled = False
+        row_count = self.table_rows_count(table)
+        n_rows = row_count
 
         # Scalar aggregate passes (batched to keep each SELECT narrow).
         columns_out: dict[str, dict[str, Any]] = {}
-        numeric_cols: list[tuple[str, str]] = []
-        categorical_cols: list[tuple[str, str]] = []
 
         for start in range(0, len(analyzed), self.STATS_AGG_BATCH):
             batch = analyzed[start : start + self.STATS_AGG_BATCH]
@@ -708,7 +702,7 @@ class AbstractWarehouse(ABC, Serializable):
 
             row = list(next(iter(self.db.execute(sa.select(*exprs).select_from(base)))))
             idx = 0
-            for display, name, kind, keys in specs:
+            for display, _name, kind, keys in specs:
                 agg = {}
                 for key in keys:
                     agg[key] = row[idx]
@@ -731,16 +725,13 @@ class AbstractWarehouse(ABC, Serializable):
                         entry["stddev"] = math.sqrt(var) if var > 0 else 0.0
                     else:
                         entry["stddev"] = None
-                    numeric_cols.append((display, name))
                 elif kind == "temporal":
-                    entry["min"] = agg["min"]
-                    entry["max"] = agg["max"]
+                    entry["min"] = _stats_isoformat(agg["min"])
+                    entry["max"] = _stats_isoformat(agg["max"])
                 elif kind == "boolean":
                     true_count = int(agg["true"] or 0)
                     entry["true_count"] = true_count
                     entry["false_count"] = max(0, non_null - true_count)
-                elif kind == "categorical":
-                    categorical_cols.append((display, name))
                 columns_out[display] = entry
 
         # Attach the python type name for each analyzed column.
@@ -752,7 +743,9 @@ class AbstractWarehouse(ABC, Serializable):
                 columns_out[display]["type"] = type(sqltype).__name__
 
         # Numeric histograms (per column, reusing the min/max computed above).
-        for display, name in numeric_cols:
+        for display, name, kind, _t in analyzed:
+            if kind != "numeric":
+                continue
             entry = columns_out[display]
             if entry["non_null_count"] == 0 or entry["min"] is None:
                 entry["histogram"] = None
@@ -763,7 +756,9 @@ class AbstractWarehouse(ABC, Serializable):
             entry["histogram"] = {"edges": edges, "counts": counts} if edges else None
 
         # Categorical distinct count + top-K (per column).
-        for display, name in categorical_cols:
+        for display, name, kind, _t in analyzed:
+            if kind != "categorical":
+                continue
             entry = columns_out[display]
             distinct, approx = self._stats_distinct_count(base, base.c[name])
             entry["distinct_count"] = distinct
@@ -774,7 +769,7 @@ class AbstractWarehouse(ABC, Serializable):
             "stats_version": self.STATS_VERSION,
             "computed_at": datetime.now(timezone.utc).isoformat(),
             "row_count": int(row_count),
-            "sampled": sampled,
+            "sampled": False,
             "columns": columns_out,
             "skipped_columns": skipped,
         }

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -1,12 +1,16 @@
 import glob
+import inspect
 import itertools
 import logging
+import math
 import posixpath
 import secrets
 import string
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Union, cast
 from urllib.parse import urlparse
 
@@ -25,7 +29,7 @@ from datachain.client import Client
 from datachain.data_storage.schema import convert_rows_custom_column_types
 from datachain.data_storage.serializer import Serializable
 from datachain.dataset import DatasetRecord, StorageURI
-from datachain.error import TableRenameError
+from datachain.error import TableMissingError, TableRenameError
 from datachain.lib.file import File
 from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
@@ -56,6 +60,31 @@ logger = logging.getLogger("datachain")
 
 SELECT_BATCH_SIZE = 100_000  # number of rows to fetch at a time
 
+# Max characters kept for a single categorical value in stats top-K lists,
+# to keep the stored stats blob bounded.
+STATS_VALUE_MAX_LEN = 256
+
+
+def _stats_number(value: Any) -> Any:
+    """Coerce a numeric aggregate result into a JSON-friendly number."""
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, bool):
+        return int(value)
+    return value
+
+
+def _stats_stringify(value: Any) -> str | None:
+    """Render a categorical value as a bounded-length string for stats."""
+    if value is None:
+        return None
+    text = value if isinstance(value, str) else str(value)
+    if len(text) > STATS_VALUE_MAX_LEN:
+        return text[:STATS_VALUE_MAX_LEN] + "…"
+    return text
+
 
 class AbstractWarehouse(ABC, Serializable):
     """
@@ -73,6 +102,13 @@ class AbstractWarehouse(ABC, Serializable):
     DATASET_SOURCE_TABLE_PREFIX = "src_"
     UDF_TABLE_NAME_PREFIX = "udf_"
     TMP_TABLE_NAME_PREFIX = "tmp_"
+
+    # Per-dataset statistics (see ``compute_dataset_stats``).
+    STATS_VERSION = 1
+    STATS_TOP_K = 20  # categorical: number of most-frequent values to keep
+    STATS_HISTOGRAM_BINS = 20  # numeric: number of equal-width histogram buckets
+    STATS_MAX_COLUMNS = 200  # cap analyzed leaf columns; the rest are skipped
+    STATS_AGG_BATCH = 40  # scalar columns aggregated per SELECT pass
     INSERT_BATCH_SIZE: int = 10_000
     INSERT_FLUSH_INTERVAL: float = 60.0
 
@@ -509,6 +545,307 @@ class AbstractWarehouse(ABC, Serializable):
         query = sa.select(*expressions)
         ((nrows, *rest),) = self.db.execute(query)
         return nrows, rest[0] if rest else 0
+
+    #
+    # Per-column distribution statistics
+    #
+
+    def stats_compute_is_cheap(self) -> bool:
+        """Whether per-dataset stats are cheap enough to compute eagerly on save.
+
+        Backends with native approximate aggregates (e.g. ClickHouse ``uniq`` /
+        ``topK`` / ``quantile``) override this to return ``True`` so stats are
+        filled in when a dataset version is finalized.  Row-by-row backends such
+        as SQLite keep it ``False`` and compute stats lazily on first access.
+        """
+        return False
+
+    @staticmethod
+    def _stats_column_kind(col_type: Any) -> str | None:
+        """Classify a column's SQL type into a stats kind, or ``None`` to skip.
+
+        ``None`` is returned for complex/opaque columns (arrays, JSON, binary,
+        embeddings, ...) that don't have a meaningful scalar distribution.
+        """
+        from datachain.sql.types import Boolean, DateTime, Float, Int, String
+
+        col_type = col_type() if inspect.isclass(col_type) else col_type
+        # ``bool`` is a subclass of ``int`` in Python, so check Boolean first.
+        if isinstance(col_type, Boolean):
+            return "boolean"
+        if isinstance(col_type, (Int, Float)):
+            return "numeric"
+        if isinstance(col_type, DateTime):
+            return "temporal"
+        if isinstance(col_type, String):
+            return "categorical"
+        return None
+
+    def compute_dataset_stats(  # noqa: PLR0912, PLR0915, C901
+        self,
+        dataset: DatasetRecord,
+        version: str,
+        *,
+        columns: list[str] | None = None,
+        top_k: int | None = None,
+        bins: int | None = None,
+        max_columns: int | None = None,
+        sample: int | None = None,
+    ) -> dict[str, Any]:
+        """Compute per-column distribution statistics for a dataset version.
+
+        Returns a JSON-serializable dict with this shape (``stats_version=1``)::
+
+            {
+              "stats_version": 1,
+              "computed_at": "<iso8601>",
+              "row_count": <int>,
+              "sampled": false | {"rows": <int>, "fraction": <float>},
+              "columns": {
+                "<dotted.name>": {
+                  "type": "<python type>", "kind": "numeric|categorical|...",
+                  "null_count": <int>, "non_null_count": <int>,
+                  # numeric: min, max, avg, stddev, histogram{edges, counts}
+                  # categorical: distinct_count, distinct_approx, top_k[{value,count}]
+                  # boolean: true_count, false_count
+                  # temporal: min, max
+                },
+                ...
+              },
+              "skipped_columns": {"<name>": "<reason>"},
+            }
+
+        Aggregations use portable SQLAlchemy so both backends inherit this.
+        Backends override the small ``_stats_*`` hooks below to use native,
+        more efficient primitives.
+        """
+        from datachain.data_storage.schema import DEFAULT_DELIMITER
+
+        top_k = self.STATS_TOP_K if top_k is None else top_k
+        bins = self.STATS_HISTOGRAM_BINS if bins is None else bins
+        max_columns = self.STATS_MAX_COLUMNS if max_columns is None else max_columns
+
+        table_name = self.dataset_table_name(dataset, version)
+        if not self.db.has_table(table_name):
+            raise TableMissingError(
+                f"Table {table_name} for dataset {dataset.name}@{version} not found"
+            )
+
+        table = self.dataset_rows(dataset, version).get_table()
+
+        # Optional random sample (mostly useful on slow backends).
+        if sample is not None:
+            sub = sa.select(table)
+            rand_col = table.c.get("sys__rand")
+            if rand_col is not None:
+                sub = sub.order_by(rand_col)
+            base: Any = sub.limit(sample).subquery()
+        else:
+            base = table
+
+        # Classify leaf columns from the real table types.
+        analyzed: list[tuple[str, str, str, Any]] = []  # display, db, kind, sqltype
+        skipped: dict[str, str] = {}
+        for c in table.columns:
+            name = c.name
+            if name.startswith("sys__"):
+                continue
+            display = name.replace(DEFAULT_DELIMITER, ".")
+            if columns is not None and name not in columns and display not in columns:
+                continue
+            kind = self._stats_column_kind(c.type)
+            if kind is None:
+                skipped[display] = type(c.type).__name__
+                continue
+            analyzed.append((display, name, kind, c.type))
+
+        if len(analyzed) > max_columns:
+            for display, _name, _kind, _t in analyzed[max_columns:]:
+                skipped[display] = "max_columns_exceeded"
+            analyzed = analyzed[:max_columns]
+
+        row_count = self.table_rows_count(base if sample is not None else table)
+        if sample is not None:
+            full_count = self.table_rows_count(table)
+            n_rows = row_count
+            sampled: Any = {
+                "rows": n_rows,
+                "fraction": (n_rows / full_count) if full_count else 0.0,
+            }
+            row_count = full_count
+        else:
+            n_rows = row_count
+            sampled = False
+
+        # Scalar aggregate passes (batched to keep each SELECT narrow).
+        columns_out: dict[str, dict[str, Any]] = {}
+        numeric_cols: list[tuple[str, str]] = []
+        categorical_cols: list[tuple[str, str]] = []
+
+        for start in range(0, len(analyzed), self.STATS_AGG_BATCH):
+            batch = analyzed[start : start + self.STATS_AGG_BATCH]
+            exprs: list[Any] = []
+            specs: list[tuple[str, str, str, list[str]]] = []
+            for display, name, kind, _t in batch:
+                col = base.c[name]
+                keys = ["nn"]
+                exprs.append(sa.func.count(col))
+                if kind == "numeric":
+                    keys += ["min", "max", "avg", "avgsq"]
+                    exprs += [
+                        sa.func.min(col),
+                        sa.func.max(col),
+                        sa.func.avg(col),
+                        sa.func.avg(col * col),
+                    ]
+                elif kind == "temporal":
+                    keys += ["min", "max"]
+                    exprs += [sa.func.min(col), sa.func.max(col)]
+                elif kind == "boolean":
+                    keys += ["true"]
+                    exprs.append(sa.func.sum(sa.cast(col, sa.Integer)))
+                specs.append((display, name, kind, keys))
+
+            row = list(next(iter(self.db.execute(sa.select(*exprs).select_from(base)))))
+            idx = 0
+            for display, name, kind, keys in specs:
+                agg = {}
+                for key in keys:
+                    agg[key] = row[idx]
+                    idx += 1
+                non_null = int(agg["nn"] or 0)
+                entry: dict[str, Any] = {
+                    "type": None,  # filled in after the aggregate passes
+                    "kind": kind,
+                    "non_null_count": non_null,
+                    "null_count": max(0, n_rows - non_null),
+                }
+                if kind == "numeric":
+                    entry["min"] = _stats_number(agg["min"])
+                    entry["max"] = _stats_number(agg["max"])
+                    avg = agg["avg"]
+                    entry["avg"] = float(avg) if avg is not None else None
+                    avgsq = agg["avgsq"]
+                    if avg is not None and avgsq is not None:
+                        var = float(avgsq) - float(avg) ** 2
+                        entry["stddev"] = math.sqrt(var) if var > 0 else 0.0
+                    else:
+                        entry["stddev"] = None
+                    numeric_cols.append((display, name))
+                elif kind == "temporal":
+                    entry["min"] = agg["min"]
+                    entry["max"] = agg["max"]
+                elif kind == "boolean":
+                    true_count = int(agg["true"] or 0)
+                    entry["true_count"] = true_count
+                    entry["false_count"] = max(0, non_null - true_count)
+                elif kind == "categorical":
+                    categorical_cols.append((display, name))
+                columns_out[display] = entry
+
+        # Attach the python type name for each analyzed column.
+        for display, _name, _kind, sqltype in analyzed:
+            try:
+                py = sqltype.python_type
+                columns_out[display]["type"] = getattr(py, "__name__", str(py))
+            except (NotImplementedError, AttributeError):
+                columns_out[display]["type"] = type(sqltype).__name__
+
+        # Numeric histograms (per column, reusing the min/max computed above).
+        for display, name in numeric_cols:
+            entry = columns_out[display]
+            if entry["non_null_count"] == 0 or entry["min"] is None:
+                entry["histogram"] = None
+                continue
+            edges, counts = self._stats_numeric_histogram(
+                base, base.c[name], entry["min"], entry["max"], bins
+            )
+            entry["histogram"] = {"edges": edges, "counts": counts} if edges else None
+
+        # Categorical distinct count + top-K (per column).
+        for display, name in categorical_cols:
+            entry = columns_out[display]
+            distinct, approx = self._stats_distinct_count(base, base.c[name])
+            entry["distinct_count"] = distinct
+            entry["distinct_approx"] = approx
+            entry["top_k"] = self._stats_top_k(base, base.c[name], top_k)
+
+        return {
+            "stats_version": self.STATS_VERSION,
+            "computed_at": datetime.now(timezone.utc).isoformat(),
+            "row_count": int(row_count),
+            "sampled": sampled,
+            "columns": columns_out,
+            "skipped_columns": skipped,
+        }
+
+    def _stats_distinct_count(self, base: Any, col: Any) -> tuple[int, bool]:
+        """Return ``(distinct_count, is_approximate)`` for a column.
+
+        Default is an exact ``COUNT(DISTINCT)``; backends with cheap approximate
+        cardinality (ClickHouse ``uniq``) override this and return ``True``.
+        """
+        query = sa.select(sa.func.count(col.distinct())).select_from(base)
+        return int(next(iter(self.db.execute(query)))[0]), False
+
+    def _stats_top_k(self, base: Any, col: Any, k: int) -> list[dict[str, Any]]:
+        """Return the ``k`` most frequent non-null values as ``{value, count}``."""
+        cnt = sa.func.count().label("n")
+        query = (
+            sa.select(col, cnt)
+            .select_from(base)
+            .where(col.isnot(None))
+            .group_by(col)
+            .order_by(cnt.desc())
+            .limit(k)
+        )
+        out: list[dict[str, Any]] = []
+        for value, n in self.db.execute(query):
+            out.append({"value": _stats_stringify(value), "count": int(n)})
+        return out
+
+    def _stats_numeric_histogram(
+        self,
+        base: Any,
+        col: Any,
+        min_val: float | None,
+        max_val: float | None,
+        bins: int,
+    ) -> tuple[list[float], list[int]]:
+        """Equal-width histogram over ``[min_val, max_val]`` with ``bins`` buckets."""
+        if min_val is None or max_val is None:
+            return [], []
+        min_f, max_f = float(min_val), float(max_val)
+        if max_f <= min_f:
+            count = int(
+                next(
+                    iter(
+                        self.db.execute(
+                            sa.select(sa.func.count(col))
+                            .select_from(base)
+                            .where(col.isnot(None))
+                        )
+                    )
+                )[0]
+            )
+            return [min_f, max_f], [count]
+
+        width = (max_f - min_f) / bins
+        raw = sa.cast((col - min_f) / sa.literal(width), sa.Integer)
+        bucket = sa.case((raw >= bins, bins - 1), else_=raw)
+        query = (
+            sa.select(bucket.label("b"), sa.func.count().label("n"))
+            .select_from(base)
+            .where(col.isnot(None))
+            .group_by(bucket)
+        )
+        counts = [0] * bins
+        for b, n in self.db.execute(query):
+            bi = max(0, min(bins - 1, int(b)))
+            counts[bi] = int(n)
+        edges = [min_f + i * width for i in range(bins + 1)]
+        edges[-1] = max_f
+        return edges, counts
 
     @abstractmethod
     def prepare_entries(self, entries: "Iterable[File]") -> Iterable[dict[str, Any]]:

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -26,7 +26,10 @@ from sqlalchemy.sql.selectable import GenerativeSelect
 
 from datachain import json
 from datachain.client import Client
-from datachain.data_storage.schema import convert_rows_custom_column_types
+from datachain.data_storage.schema import (
+    DEFAULT_DELIMITER,
+    convert_rows_custom_column_types,
+)
 from datachain.data_storage.serializer import Serializable
 from datachain.dataset import DatasetRecord, StorageURI
 from datachain.error import TableMissingError, TableRenameError
@@ -98,6 +101,14 @@ def _stats_isoformat(value: Any) -> str | None:
     if hasattr(value, "isoformat"):
         return value.isoformat()
     return str(value)
+
+
+def _stats_stddev(avg: Any, avg_sq: Any) -> float | None:
+    """Population stddev from E[x] and E[x²], or ``None`` if either is missing."""
+    if avg is None or avg_sq is None:
+        return None
+    variance = float(avg_sq) - float(avg) ** 2
+    return math.sqrt(variance) if variance > 0 else 0.0
 
 
 class AbstractWarehouse(ABC, Serializable):
@@ -560,10 +571,6 @@ class AbstractWarehouse(ABC, Serializable):
         ((nrows, *rest),) = self.db.execute(query)
         return nrows, rest[0] if rest else 0
 
-    #
-    # Per-column distribution statistics
-    #
-
     def stats_compute_is_cheap(self) -> bool:
         """Whether per-dataset stats are cheap enough to compute eagerly on save.
 
@@ -595,7 +602,7 @@ class AbstractWarehouse(ABC, Serializable):
             return "categorical"
         return None
 
-    def compute_dataset_stats(  # noqa: PLR0912, PLR0915, C901
+    def compute_dataset_stats(
         self,
         dataset: DatasetRecord,
         version: str,
@@ -632,8 +639,6 @@ class AbstractWarehouse(ABC, Serializable):
         Backends override the small ``_stats_*`` hooks below to use native,
         more efficient primitives.
         """
-        from datachain.data_storage.schema import DEFAULT_DELIMITER
-
         top_k = max(1, self.STATS_TOP_K if top_k is None else top_k)
         bins = max(1, self.STATS_HISTOGRAM_BINS if bins is None else bins)
         max_columns = max(
@@ -645,12 +650,34 @@ class AbstractWarehouse(ABC, Serializable):
             raise TableMissingError(
                 f"Table {table_name} for dataset {dataset.name}@{version} not found"
             )
-
         table = self.dataset_rows(dataset, version).get_table()
-        base = table
 
-        # Classify leaf columns from the real table types.
-        analyzed: list[tuple[str, str, str, Any]] = []  # display, db, kind, sqltype
+        analyzed, skipped = self._stats_classify_columns(table, columns, max_columns)
+        row_count = self.table_rows_count(table)
+
+        columns_out = self._stats_scalar_aggregates(table, analyzed, row_count)
+        self._stats_attach_histograms(table, analyzed, columns_out, bins)
+        self._stats_attach_categorical(table, analyzed, columns_out, top_k)
+
+        return {
+            "stats_version": self.STATS_VERSION,
+            "computed_at": datetime.now(timezone.utc).isoformat(),
+            "row_count": int(row_count),
+            "sampled": False,
+            "columns": columns_out,
+            "skipped_columns": skipped,
+        }
+
+    def _stats_classify_columns(
+        self, table: Any, columns: list[str] | None, max_columns: int
+    ) -> tuple[list[tuple[str, str, str, Any]], dict[str, str]]:
+        """Pick the leaf columns worth profiling.
+
+        Returns ``(analyzed, skipped)``: ``analyzed`` is a list of
+        ``(display_name, db_name, kind, sql_type)``; ``skipped`` maps a column
+        to why it was left out (unsupported type, or the ``max_columns`` cap).
+        """
+        analyzed: list[tuple[str, str, str, Any]] = []
         skipped: dict[str, str] = {}
         for c in table.columns:
             name = c.name
@@ -662,87 +689,95 @@ class AbstractWarehouse(ABC, Serializable):
             kind = self._stats_column_kind(c.type)
             if kind is None:
                 skipped[display] = type(c.type).__name__
-                continue
-            analyzed.append((display, name, kind, c.type))
+            else:
+                analyzed.append((display, name, kind, c.type))
 
-        if len(analyzed) > max_columns:
-            for display, _name, _kind, _t in analyzed[max_columns:]:
-                skipped[display] = "max_columns_exceeded"
-            analyzed = analyzed[:max_columns]
+        for display, *_ in analyzed[max_columns:]:
+            skipped[display] = "max_columns_exceeded"
+        return analyzed[:max_columns], skipped
 
-        row_count = self.table_rows_count(table)
-        n_rows = row_count
-
-        # Scalar aggregate passes (batched to keep each SELECT narrow).
+    def _stats_scalar_aggregates(
+        self, table: Any, analyzed: list[tuple[str, str, str, Any]], row_count: int
+    ) -> dict[str, dict[str, Any]]:
+        """Build each column's entry from batched single-row aggregate SELECTs."""
         columns_out: dict[str, dict[str, Any]] = {}
-
         for start in range(0, len(analyzed), self.STATS_AGG_BATCH):
             batch = analyzed[start : start + self.STATS_AGG_BATCH]
             exprs: list[Any] = []
-            specs: list[tuple[str, str, str, list[str]]] = []
-            for display, name, kind, _t in batch:
-                col = base.c[name]
-                keys = ["nn"]
-                exprs.append(sa.func.count(col))
-                if kind == "numeric":
-                    keys += ["min", "max", "avg", "avgsq"]
-                    exprs += [
-                        sa.func.min(col),
-                        sa.func.max(col),
-                        sa.func.avg(col),
-                        sa.func.avg(col * col),
-                    ]
-                elif kind == "temporal":
-                    keys += ["min", "max"]
-                    exprs += [sa.func.min(col), sa.func.max(col)]
-                elif kind == "boolean":
-                    keys += ["true"]
-                    exprs.append(sa.func.sum(sa.cast(col, sa.Integer)))
-                specs.append((display, name, kind, keys))
+            specs: list[tuple[str, str, Any, list[str]]] = []
+            for display, name, kind, sqltype in batch:
+                pairs = self._stats_aggregate_exprs(table.c[name], kind)
+                specs.append((display, kind, sqltype, [key for key, _ in pairs]))
+                exprs += [expr for _, expr in pairs]
 
-            row = list(next(iter(self.db.execute(sa.select(*exprs).select_from(base)))))
+            stmt = sa.select(*exprs).select_from(table)
+            row = list(next(iter(self.db.execute(stmt))))
             idx = 0
-            for display, _name, kind, keys in specs:
-                agg = {}
-                for key in keys:
-                    agg[key] = row[idx]
-                    idx += 1
-                non_null = int(agg["nn"] or 0)
-                entry: dict[str, Any] = {
-                    "type": None,  # filled in after the aggregate passes
-                    "kind": kind,
-                    "non_null_count": non_null,
-                    "null_count": max(0, n_rows - non_null),
-                }
-                if kind == "numeric":
-                    entry["min"] = _stats_number(agg["min"])
-                    entry["max"] = _stats_number(agg["max"])
-                    avg = agg["avg"]
-                    entry["avg"] = float(avg) if avg is not None else None
-                    avgsq = agg["avgsq"]
-                    if avg is not None and avgsq is not None:
-                        var = float(avgsq) - float(avg) ** 2
-                        entry["stddev"] = math.sqrt(var) if var > 0 else 0.0
-                    else:
-                        entry["stddev"] = None
-                elif kind == "temporal":
-                    entry["min"] = _stats_isoformat(agg["min"])
-                    entry["max"] = _stats_isoformat(agg["max"])
-                elif kind == "boolean":
-                    true_count = int(agg["true"] or 0)
-                    entry["true_count"] = true_count
-                    entry["false_count"] = max(0, non_null - true_count)
+            for display, kind, sqltype, keys in specs:
+                agg = {key: row[idx + i] for i, key in enumerate(keys)}
+                idx += len(keys)
+                entry = self._stats_entry(kind, agg, row_count)
+                entry["type"] = self._stats_type_name(sqltype)
                 columns_out[display] = entry
+        return columns_out
 
-        # Attach the python type name for each analyzed column.
-        for display, _name, _kind, sqltype in analyzed:
-            try:
-                py = sqltype.python_type
-                columns_out[display]["type"] = getattr(py, "__name__", str(py))
-            except (NotImplementedError, AttributeError):
-                columns_out[display]["type"] = type(sqltype).__name__
+    @staticmethod
+    def _stats_aggregate_exprs(col: Any, kind: str) -> list[tuple[str, Any]]:
+        """Scalar aggregates for a column, as ``(key, sql_expr)`` pairs."""
+        exprs: list[tuple[str, Any]] = [("non_null", sa.func.count(col))]
+        if kind == "numeric":
+            exprs += [
+                ("min", sa.func.min(col)),
+                ("max", sa.func.max(col)),
+                ("avg", sa.func.avg(col)),
+                ("avg_sq", sa.func.avg(col * col)),
+            ]
+        elif kind == "temporal":
+            exprs += [("min", sa.func.min(col)), ("max", sa.func.max(col))]
+        elif kind == "boolean":
+            exprs.append(("true", sa.func.sum(sa.cast(col, sa.Integer))))
+        return exprs
 
-        # Numeric histograms (per column, reusing the min/max computed above).
+    @staticmethod
+    def _stats_entry(kind: str, agg: dict[str, Any], row_count: int) -> dict[str, Any]:
+        """Assemble a column's entry from its scalar aggregate values."""
+        non_null = int(agg["non_null"] or 0)
+        entry: dict[str, Any] = {
+            "kind": kind,
+            "non_null_count": non_null,
+            "null_count": max(0, row_count - non_null),
+        }
+        if kind == "numeric":
+            entry["min"] = _stats_number(agg["min"])
+            entry["max"] = _stats_number(agg["max"])
+            entry["avg"] = float(agg["avg"]) if agg["avg"] is not None else None
+            entry["stddev"] = _stats_stddev(agg["avg"], agg["avg_sq"])
+        elif kind == "temporal":
+            entry["min"] = _stats_isoformat(agg["min"])
+            entry["max"] = _stats_isoformat(agg["max"])
+        elif kind == "boolean":
+            true_count = int(agg["true"] or 0)
+            entry["true_count"] = true_count
+            entry["false_count"] = max(0, non_null - true_count)
+        return entry
+
+    @staticmethod
+    def _stats_type_name(sqltype: Any) -> str:
+        """Best-effort Python type name for a column's SQL type."""
+        try:
+            py = sqltype.python_type
+            return getattr(py, "__name__", str(py))
+        except (NotImplementedError, AttributeError):
+            return type(sqltype).__name__
+
+    def _stats_attach_histograms(
+        self,
+        table: Any,
+        analyzed: list[tuple[str, str, str, Any]],
+        columns_out: dict[str, dict[str, Any]],
+        bins: int,
+    ) -> None:
+        """Add an equal-width ``histogram`` to each numeric column entry."""
         for display, name, kind, _t in analyzed:
             if kind != "numeric":
                 continue
@@ -751,28 +786,26 @@ class AbstractWarehouse(ABC, Serializable):
                 entry["histogram"] = None
                 continue
             edges, counts = self._stats_numeric_histogram(
-                base, base.c[name], entry["min"], entry["max"], bins
+                table, table.c[name], entry["min"], entry["max"], bins
             )
             entry["histogram"] = {"edges": edges, "counts": counts} if edges else None
 
-        # Categorical distinct count + top-K (per column).
+    def _stats_attach_categorical(
+        self,
+        table: Any,
+        analyzed: list[tuple[str, str, str, Any]],
+        columns_out: dict[str, dict[str, Any]],
+        top_k: int,
+    ) -> None:
+        """Add ``distinct_count`` and ``top_k`` to each categorical column entry."""
         for display, name, kind, _t in analyzed:
             if kind != "categorical":
                 continue
             entry = columns_out[display]
-            distinct, approx = self._stats_distinct_count(base, base.c[name])
+            distinct, approx = self._stats_distinct_count(table, table.c[name])
             entry["distinct_count"] = distinct
             entry["distinct_approx"] = approx
-            entry["top_k"] = self._stats_top_k(base, base.c[name], top_k)
-
-        return {
-            "stats_version": self.STATS_VERSION,
-            "computed_at": datetime.now(timezone.utc).isoformat(),
-            "row_count": int(row_count),
-            "sampled": False,
-            "columns": columns_out,
-            "skipped_columns": skipped,
-        }
+            entry["top_k"] = self._stats_top_k(table, table.c[name], top_k)
 
     def _stats_distinct_count(self, base: Any, col: Any) -> tuple[int, bool]:
         """Return ``(distinct_count, is_approximate)`` for a column.

--- a/src/datachain/dataset.py
+++ b/src/datachain/dataset.py
@@ -296,6 +296,8 @@ class DatasetVersion:
     query_script: str = ""
     job_id: str | None = None
     content_hash: str | None = None
+    # Per-column distribution statistics, or ``None`` when not computed yet.
+    stats: dict | None = None
 
     @classmethod
     def parse(  # noqa: PLR0913
@@ -319,6 +321,7 @@ class DatasetVersion:
         query_script: str = "",
         job_id: str | None = None,
         content_hash: str | None = None,
+        stats: str | dict | None = None,
         *,
         preview_loaded: bool = True,
     ):
@@ -326,6 +329,8 @@ class DatasetVersion:
             schema_parsed = parse_schema(json.loads(schema) if schema else {})
         else:
             schema_parsed = schema
+
+        stats_parsed = json.loads(stats) if isinstance(stats, str) else stats
 
         return cls(
             id=id,
@@ -347,6 +352,7 @@ class DatasetVersion:
             query_script=query_script,
             job_id=job_id,
             content_hash=content_hash,
+            stats=stats_parsed,
             _preview_loaded=preview_loaded,
         )
 
@@ -577,6 +583,7 @@ class DatasetRecord:
         version_schema: str | None = None,
         version_job_id: str | None = None,
         version_content_hash: str | None = None,
+        version_stats: str | dict | None = None,
         *,
         versions_loaded: bool = True,
         preview_loaded: bool = True,
@@ -635,6 +642,7 @@ class DatasetRecord:
                 version_query_script or "",
                 version_job_id,
                 version_content_hash,
+                version_stats,
                 preview_loaded=preview_loaded,
             )
             versions_list = [dataset_version]

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -125,6 +125,70 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound="DataChain")
 
+# Schema of the describe-style chain returned by ``DataChain.stats()`` —
+# one row per leaf column. ``min``/``max`` are stringified so a single column
+# can hold both numeric and temporal ranges; richer numbers live in ``avg`` /
+# ``stddev`` and the JSON ``top_k`` / ``histogram`` columns.
+_STATS_CHAIN_SCHEMA: dict[str, Any] = {
+    "column_name": str,
+    "kind": str,
+    "type": str | None,
+    "row_count": int,
+    "null_count": int | None,
+    "non_null_count": int | None,
+    "distinct_count": int | None,
+    "min": str | None,
+    "max": str | None,
+    "avg": float | None,
+    "stddev": float | None,
+    "true_count": int | None,
+    "false_count": int | None,
+    "top_k": list[dict] | None,
+    "histogram": dict | None,
+    "skipped_reason": str | None,
+}
+
+
+def _stats_to_chain(stats: dict[str, Any], session: Any) -> "DataChain":
+    """Build the describe-style stats chain (one row per column) from a dict."""
+    from datachain.lib.dc.values import read_values
+
+    data: dict[str, Any] = {key: [] for key in _STATS_CHAIN_SCHEMA}
+    row_count = stats.get("row_count", 0)
+
+    def add(**values: Any) -> None:
+        for key in _STATS_CHAIN_SCHEMA:
+            data[key].append(values.get(key))
+
+    for name, info in stats.get("columns", {}).items():
+        mn, mx = info.get("min"), info.get("max")
+        add(
+            column_name=name,
+            kind=info.get("kind"),
+            type=info.get("type"),
+            row_count=row_count,
+            null_count=info.get("null_count"),
+            non_null_count=info.get("non_null_count"),
+            distinct_count=info.get("distinct_count"),
+            min=None if mn is None else str(mn),
+            max=None if mx is None else str(mx),
+            avg=info.get("avg"),
+            stddev=info.get("stddev"),
+            true_count=info.get("true_count"),
+            false_count=info.get("false_count"),
+            top_k=info.get("top_k"),
+            histogram=info.get("histogram"),
+        )
+    for name, reason in stats.get("skipped_columns", {}).items():
+        add(
+            column_name=name,
+            kind="skipped",
+            row_count=row_count,
+            skipped_reason=reason,
+        )
+
+    return read_values(**data, output=_STATS_CHAIN_SCHEMA, session=session)
+
 
 class DataChainSchema(dict[str, DataType]):
     """Dict-like public view of a DataChain schema.
@@ -398,30 +462,46 @@ class DataChain:
             include_incomplete=False,
         )
 
-    def stats(self, *, force: bool = False, **kwargs) -> dict:
-        """Per-column distribution statistics for the underlying dataset.
+    def stats(self, *, force: bool = False, **kwargs) -> "DataChain":
+        """Per-column distribution statistics, as a new chain (one row per column).
 
-        Returns a dict with the dataset row count and, per leaf column, value
-        distribution info (numeric min/max/avg/histogram, categorical top
-        values, boolean counts, ...).  Results are cached on the dataset
-        version; pass ``force=True`` to recompute.
+        Each row describes a leaf column: ``kind``/``type``, null and non-null
+        counts, and kind-specific stats — numeric ``min``/``max``/``avg``/
+        ``stddev``/``histogram``, categorical ``distinct_count``/``top_k``, and
+        boolean ``true_count``/``false_count``. Use ``.to_pandas()`` /
+        ``.to_records()`` / ``.show()`` to view them.
+
+        Works on any chain. For a plain saved dataset the result is computed
+        once and cached on the dataset version (``force=True`` recomputes); a
+        transformed chain (filters, maps, ...) is materialized and profiled
+        without caching.
 
         Example:
             ```py
-            stats = dc.read_dataset("cats").stats()
-            print(stats["row_count"], stats["columns"]["label"]["top_k"])
+            dc.read_dataset("cats").stats().to_pandas()
+            dc.read_dataset("cats").filter(C("size") > 0).stats().show()
             ```
         """
-        if not self.name:
-            raise ValueError("Cannot compute stats for a chain without a saved dataset")
-        return self.session.catalog.get_dataset_stats(
-            self.name,
-            self.version,
-            namespace_name=self._query.project.namespace.name,
-            project_name=self._query.project.name,
-            force=force,
-            **kwargs,
-        )
+        catalog = self.session.catalog
+        if self.name and not self._query.steps:
+            stats = catalog.get_dataset_stats(
+                self.name,
+                self.version,
+                namespace_name=self._query.project.namespace.name,
+                project_name=self._query.project.name,
+                force=force,
+                **kwargs,
+            )
+        else:
+            # Transformed or unsaved chain: materialize and profile uncached.
+            materialized = self.persist()
+            dataset = materialized.dataset
+            if dataset is None or materialized.version is None:
+                raise ValueError("Cannot compute stats: chain has no rows table")
+            stats = catalog.warehouse.compute_dataset_stats(
+                dataset, materialized.version, **kwargs
+            )
+        return _stats_to_chain(stats, self.session)
 
     def __or__(self, other: "Self") -> "Self":
         """Return `self.union(other)`."""

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -398,6 +398,31 @@ class DataChain:
             include_incomplete=False,
         )
 
+    def stats(self, *, force: bool = False, **kwargs) -> dict:
+        """Per-column distribution statistics for the underlying dataset.
+
+        Returns a dict with the dataset row count and, per leaf column, value
+        distribution info (numeric min/max/avg/histogram, categorical top
+        values, boolean counts, ...).  Results are cached on the dataset
+        version; pass ``force=True`` to recompute.
+
+        Example:
+            ```py
+            stats = dc.read_dataset("cats").stats()
+            print(stats["row_count"], stats["columns"]["label"]["top_k"])
+            ```
+        """
+        if not self.name:
+            raise ValueError("Cannot compute stats for a chain without a saved dataset")
+        return self.session.catalog.get_dataset_stats(
+            self.name,
+            self.version,
+            namespace_name=self._query.project.namespace.name,
+            project_name=self._query.project.name,
+            force=force,
+            **kwargs,
+        )
+
     def __or__(self, other: "Self") -> "Self":
         """Return `self.union(other)`."""
         return self.union(other)

--- a/tests/func/test_dataset_stats.py
+++ b/tests/func/test_dataset_stats.py
@@ -124,18 +124,31 @@ def test_stats_computed_eagerly_when_backend_is_cheap(test_session, monkeypatch)
     assert version.stats["columns"]["num"]["max"] == 3
 
 
-def test_python_accessor_computes_and_caches(test_session):
+def test_python_accessor_returns_chain_and_caches(test_session):
     chain = _save(test_session, num=[1, 2, 3], label=["x", "y", "x"])
     catalog = test_session.catalog
 
-    stats = chain.stats()
-    assert stats["row_count"] == 3
-    assert stats["columns"]["label"]["distinct_count"] == 2
+    stats_chain = chain.stats()
+    assert isinstance(stats_chain, dc.DataChain)
+    recs = {r["column_name"]: r for r in stats_chain.to_records()}
+    assert recs["label"]["kind"] == "categorical"
+    assert recs["label"]["distinct_count"] == 2
+    assert recs["num"]["row_count"] == 3
 
     # The result was persisted on the version and is loaded on a fresh read.
     _, version = _dataset_version(catalog, chain)
     assert version.stats is not None
     assert version.stats["columns"]["num"]["max"] == 3
+
+
+def test_stats_on_transformed_chain(test_session):
+    name = _save(test_session, num=[1, 2, 3, 4, 100]).name
+    filtered = dc.read_dataset(name, session=test_session).filter(dc.C("num") < 50)
+
+    recs = {r["column_name"]: r for r in filtered.stats().to_records()}
+    # Stats reflect the filtered result (1,2,3,4), not the full dataset.
+    assert recs["num"]["non_null_count"] == 4
+    assert recs["num"]["row_count"] == 4
 
 
 def test_get_dataset_stats_uses_cache(test_session):

--- a/tests/func/test_dataset_stats.py
+++ b/tests/func/test_dataset_stats.py
@@ -1,0 +1,180 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+import datachain as dc
+
+
+def _save(test_session, **columns):
+    name = uuid.uuid4().hex
+    return dc.read_values(session=test_session, **columns).save(name)
+
+
+def _dataset_version(catalog, chain):
+    dataset = catalog.get_dataset(chain.name, versions=[chain.version])
+    return dataset, dataset.get_version(chain.version)
+
+
+def test_compute_dataset_stats_numeric(test_session):
+    chain = _save(test_session, num=[1, 2, 3, 4, 100, 7])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+
+    assert stats["stats_version"] == 1
+    assert stats["row_count"] == 6
+    assert stats["sampled"] is False
+    col = stats["columns"]["num"]
+    assert col["kind"] == "numeric"
+    assert col["type"] == "int"
+    assert col["min"] == 1
+    assert col["max"] == 100
+    assert col["non_null_count"] == 6
+    assert col["null_count"] == 0
+    assert col["avg"] == pytest.approx(19.5)
+    assert col["stddev"] > 0
+    # histogram buckets must cover exactly the non-null rows
+    assert sum(col["histogram"]["counts"]) == 6
+    assert len(col["histogram"]["edges"]) == len(col["histogram"]["counts"]) + 1
+
+
+def test_compute_dataset_stats_categorical(test_session):
+    chain = _save(test_session, label=["a", "a", "b", "c", "a", "a"])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+    col = stats["columns"]["label"]
+
+    assert col["kind"] == "categorical"
+    assert col["distinct_count"] == 3
+    assert col["distinct_approx"] is False
+    # top_k is ordered by descending frequency
+    assert col["top_k"][0] == {"value": "a", "count": 4}
+    assert {t["value"] for t in col["top_k"]} == {"a", "b", "c"}
+
+
+def test_compute_dataset_stats_boolean_and_nulls(test_session):
+    chain = _save(test_session, flag=[True, False, True, None, True])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+    col = stats["columns"]["flag"]
+
+    assert col["kind"] == "boolean"
+    assert col["true_count"] == 3
+    assert col["false_count"] == 1
+    assert col["null_count"] == 1
+    assert col["non_null_count"] == 4
+
+
+def test_compute_dataset_stats_temporal(test_session):
+    a = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    b = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    chain = _save(test_session, ts=[a, b, a])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+    col = stats["columns"]["ts"]
+
+    assert col["kind"] == "temporal"
+    assert str(a.year) in str(col["min"])
+    assert str(b.year) in str(col["max"])
+
+
+def test_compute_dataset_stats_skips_complex_columns(test_session):
+    chain = _save(
+        test_session,
+        num=[1, 2, 3],
+        emb=[[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+    )
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+
+    assert "num" in stats["columns"]
+    assert "emb" not in stats["columns"]
+    assert "emb" in stats["skipped_columns"]
+
+
+def test_stats_not_computed_eagerly_on_sqlite(test_session):
+    """SQLite is a 'slow' backend: stats stay None after save (lazy)."""
+    chain = _save(test_session, num=[1, 2, 3])
+    catalog = test_session.catalog
+    assert catalog.warehouse.stats_compute_is_cheap() is False
+    _, version = _dataset_version(catalog, chain)
+    assert version.stats is None
+
+
+def test_stats_computed_eagerly_when_backend_is_cheap(test_session, monkeypatch):
+    monkeypatch.setattr(
+        type(test_session.catalog.warehouse),
+        "stats_compute_is_cheap",
+        lambda self: True,
+    )
+    chain = _save(test_session, num=[1, 2, 3])
+    catalog = test_session.catalog
+    _, version = _dataset_version(catalog, chain)
+    assert version.stats is not None
+    assert version.stats["columns"]["num"]["max"] == 3
+
+
+def test_python_accessor_computes_and_caches(test_session):
+    chain = _save(test_session, num=[1, 2, 3], label=["x", "y", "x"])
+    catalog = test_session.catalog
+
+    stats = chain.stats()
+    assert stats["row_count"] == 3
+    assert stats["columns"]["label"]["distinct_count"] == 2
+
+    # The result was persisted on the version and is loaded on a fresh read.
+    _, version = _dataset_version(catalog, chain)
+    assert version.stats is not None
+    assert version.stats["columns"]["num"]["max"] == 3
+
+
+def test_get_dataset_stats_uses_cache(test_session):
+    chain = _save(test_session, num=[1, 2, 3])
+    catalog = test_session.catalog
+
+    first = catalog.get_dataset_stats(chain.name, chain.version)
+
+    calls = {"n": 0}
+    original = catalog.warehouse.compute_dataset_stats
+
+    def counting(*args, **kwargs):
+        calls["n"] += 1
+        return original(*args, **kwargs)
+
+    catalog.warehouse.compute_dataset_stats = counting  # type: ignore[method-assign]
+
+    cached = catalog.get_dataset_stats(chain.name, chain.version)
+    assert calls["n"] == 0  # served from cache, not recomputed
+    assert cached["computed_at"] == first["computed_at"]
+
+    forced = catalog.get_dataset_stats(chain.name, chain.version, force=True)
+    assert calls["n"] == 1
+    assert forced["row_count"] == 3
+
+
+def test_cli_dataset_stats_table_and_json(test_session, capsys):
+    from datachain.cli.commands.datasets import dataset_stats
+
+    chain = _save(test_session, num=[1, 2, 3], label=["a", "a", "b"])
+    catalog = test_session.catalog
+
+    dataset_stats(catalog, chain.name, chain.version)
+    out = capsys.readouterr().out
+    assert "rows: 3" in out
+    assert "num" in out
+    assert "label" in out
+
+    dataset_stats(catalog, chain.name, chain.version, as_json=True)
+    out = capsys.readouterr().out
+    assert '"stats_version": 1' in out
+    assert '"row_count": 3' in out

--- a/tests/func/test_dataset_stats.py
+++ b/tests/func/test_dataset_stats.py
@@ -178,3 +178,98 @@ def test_cli_dataset_stats_table_and_json(test_session, capsys):
     out = capsys.readouterr().out
     assert '"stats_version": 1' in out
     assert '"row_count": 3' in out
+
+
+def test_stats_empty_dataset(test_session):
+    chain = (
+        dc.read_values(x=[1, 2, 3], y=[1.0, 2.0, 3.0], session=test_session)
+        .filter(dc.C("x") > 100)
+        .save(uuid.uuid4().hex)
+    )
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+    assert stats["row_count"] == 0
+    assert stats["columns"]["x"]["non_null_count"] == 0
+    assert stats["columns"]["x"]["null_count"] == 0
+    assert stats["columns"]["x"]["min"] is None
+    assert stats["columns"]["y"]["histogram"] is None
+
+
+def test_stats_numeric_with_nulls(test_session):
+    chain = _save(test_session, num=[10, None, 30, None])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    col = catalog.warehouse.compute_dataset_stats(dataset, chain.version)["columns"][
+        "num"
+    ]
+    assert col["null_count"] == 2
+    assert col["non_null_count"] == 2
+    assert col["min"] == 10
+    assert col["max"] == 30
+
+
+def test_stats_single_value_histogram(test_session):
+    chain = _save(test_session, num=[5, 5, 5])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    hist = catalog.warehouse.compute_dataset_stats(dataset, chain.version)["columns"][
+        "num"
+    ]["histogram"]
+    assert sum(hist["counts"]) == 3
+    assert len(hist["edges"]) == len(hist["counts"]) + 1
+
+
+def test_stats_bins_zero_is_clamped(test_session):
+    chain = _save(test_session, num=[1, 2, 3, 4])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    # bins=0 must be clamped, not raise ZeroDivisionError
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version, bins=0)
+    assert stats["columns"]["num"]["histogram"] is not None
+
+
+def test_stats_max_columns_truncation(test_session):
+    chain = _save(test_session, a=[1], b=[2], c=[3])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(
+        dataset, chain.version, max_columns=1
+    )
+    assert len(stats["columns"]) == 1
+    assert len(stats["skipped_columns"]) == 2
+    assert "max_columns_exceeded" in stats["skipped_columns"].values()
+
+
+def test_stats_columns_filter(test_session):
+    chain = _save(test_session, a=[1, 2], b=[3, 4])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(
+        dataset, chain.version, columns=["a"]
+    )
+    assert set(stats["columns"]) == {"a"}
+
+
+def test_stats_temporal_json_serializable(test_session):
+    import json as stdlib_json
+
+    a = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    b = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    chain = _save(test_session, ts=[a, b])
+    catalog = test_session.catalog
+    dataset, _ = _dataset_version(catalog, chain)
+
+    stats = catalog.warehouse.compute_dataset_stats(dataset, chain.version)
+    col = stats["columns"]["ts"]
+    assert isinstance(col["min"], str)
+    assert isinstance(col["max"], str)
+    # Regression: temporal values must be coerced so the result is stdlib-JSON
+    # serializable and consistent with the value reloaded from the DB.
+    stdlib_json.dumps(stats)


### PR DESCRIPTION
## What & why

Adds **built-in per-dataset statistics** as a first-class, cached, backend-aware feature. Today this is a user-land script (one `group_by` per column → N+1 queries, categorical-only, not cached or surfaced). This makes it native across both warehouse backends (SQLite here; ClickHouse in SaaS via overridable hooks), cached on the dataset version, and exposed in the CLI and Python SDK.

## Design (3 layers + adaptive timing)

- **Compute** — `AbstractWarehouse.compute_dataset_stats()` classifies leaf columns by SQL type and runs a few aggregate passes (batched scalar aggregates; per-column numeric histograms; categorical top-K + distinct). Portable SQLAlchemy both backends inherit; small overridable hooks (`_stats_distinct_count`/`_stats_top_k`/`_stats_numeric_histogram`) let the SaaS ClickHouse warehouse use native `uniq`/`topK`/`histogram`.
- **Storage** — a nullable `stats` JSON column on `_datasets_versions` (auto-migrated). `None` = "not computed yet". `DatasetVersion.stats`; optional in `from_dict` → backward compatible with remote/Studio payloads.
- **Timing (adaptive)** — `Catalog.get_dataset_stats()` computes-and-caches lazily; `stats_compute_is_cheap()` lets cheap backends (ClickHouse) compute **eagerly on save**, while SQLite stays lazy.

## Stats per column (kind-aware)

numeric → min/max/avg/stddev + equal-width histogram · categorical → top-K + (approx) distinct + null count · boolean → true/false counts · temporal → min/max (ISO). Complex/array/JSON/embedding/File-internal columns are recorded in `skipped_columns`.

## Surface

- **CLI**: `datachain dataset stats <name> [--version V] [--force] [--json]`
- **Python**: `dc.read_dataset("x").stats()` and `DatasetVersion.stats`
- **JSON contract** is versioned (`stats_version`) — the integration point for a future Studio UI.

## Tested

`tests/func/test_dataset_stats.py` (17 tests): numeric/categorical/boolean/temporal, nulls, empty dataset, single-value histogram, `max_columns` truncation, `columns` filter, lazy-vs-eager, force recompute, CLI table+JSON, temporal JSON-serializability. ruff + mypy clean.

## Reviewed

Went through an independent multi-angle review pass. Fixes folded into the second commit: temporal ISO coercion (JSON-serializable + cache-consistent), clamp `top_k`/`bins`/`max_columns` ≥1 (bins=0 guard), dropped the unused/untested sampling path (deferred), CLI catches `DatasetVersionNotFoundError`.

## Out of scope / follow-ups

- SaaS: ClickHouse hook overrides + `stats_compute_is_cheap → True`
- Studio: UI rendering the JSON contract
- Sampling for very large tables on slow backends
- Stats as a queryable DataChain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
