### PR TITLE
Use logical names in cast complex object errors

### DIFF
--- a/src/datachain/func/func.py
+++ b/src/datachain/func/func.py
@@ -14,7 +14,7 @@ from datachain.lib.convert.sql_to_python import sql_to_python
 from datachain.lib.data_model import NULLABLE_SCALARS, unwrap_optional
 from datachain.lib.model_store import ModelStore
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
-from datachain.query.schema import Column, ColumnExpr, ColumnMeta
+from datachain.query.schema import DEFAULT_DELIMITER, Column, ColumnExpr, ColumnMeta
 from datachain.sql.functions import numeric
 from datachain.sql.functions.conversion import datetime_to_string
 from datachain.sql.types import SQLType
@@ -480,10 +480,11 @@ class Func(Function):  # noqa: PLW1641
                 continue
             t_with_sub = signals_schema.get_column_type(arg, with_subtree=True)
             if ModelStore.is_pydantic(t_with_sub):
+                user_col = arg.replace(DEFAULT_DELIMITER, ".")
                 raise DataChainParamsError(
                     f"Function {self.name} doesn't support complex object "
-                    f"columns like '{arg}'. Use a leaf field (e.g., "
-                    f"'{arg}.path') or use UDFs to operate on complex objects."
+                    f"columns like '{user_col}'. Use a leaf field (e.g., "
+                    f"'{user_col}.path') or use UDFs to operate on complex objects."
                 )
 
     def _resolve_col(

--- a/tests/func/functions/test_cast.py
+++ b/tests/func/functions/test_cast.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import CompileError
 import datachain as dc
 from datachain import C, func
 from datachain.lib.file import File
+from datachain.lib.utils import DataChainParamsError
 
 
 def test_cast_in_mutate_filter_and_order_by(test_session):
@@ -108,6 +109,29 @@ def test_cast_nested_string_column_in_mutate(test_session):
     )
 
     assert rows == [("a.txt", "2"), ("b.txt", "10"), ("c.txt", "1")]
+
+
+def test_cast_complex_object_error_uses_user_column_name(test_session):
+    class Foo(dc.DataModel):
+        path: str
+
+    foo_type = Foo
+
+    class Item(dc.DataModel):
+        Foo: foo_type
+
+    chain = dc.read_values(
+        item=[Item(Foo=Foo(path="a.txt"))],
+        session=test_session,
+    )
+
+    with pytest.raises(DataChainParamsError) as exc_info:
+        chain.mutate(value=func.cast("item.Foo", str))
+
+    message = str(exc_info.value)
+    assert "columns like 'item.Foo'" in message
+    assert "'item.Foo.path'" in message
+    assert "item__Foo" not in message
 
 
 def test_cast_datetime_in_mutate_and_order_by(test_session):


### PR DESCRIPTION
Fixes #1826.

## Summary
- Render complex-object column names with the user-facing dotted form in `func.cast()` errors.
- Keep the schema lookup and SQL path unchanged; only the error message changes.
- Add regression coverage for `item.Foo` so the message suggests `item.Foo.path` instead of the internal `item__Foo.path`.

## Tests
- `.venv/bin/python -m pytest tests/func/functions/test_cast.py -q`
- `.venv/bin/python -m pytest tests/unit/test_func.py -q`
- `.venv/bin/python -m pytest tests/func/functions/test_aggregate.py -k complex_object -q`
- `.venv/bin/python -m pytest tests/func/functions/test_conditional.py -k complex_object -q`
- `.venv/bin/python -m ruff format --check src/datachain/func/func.py tests/func/functions/test_cast.py`
- `.venv/bin/python -m ruff check src/datachain/func/func.py tests/func/functions/test_cast.py`
- `git diff --check`

AI assistance was used under my direction.
