### PR TITLE
Reflect only the requested table in SQLiteWarehouse.get_table

### DIFF
--- a/src/datachain/data_storage/sqlite.py
+++ b/src/datachain/data_storage/sqlite.py
@@ -767,20 +767,6 @@ class SQLiteWarehouse(AbstractWarehouse):
         (db_class, db_args, db_kwargs) = db_clone_params
         return cls(db=db_class(*db_args, **db_kwargs))
 
-    def _reflect_tables(self, filter_tables=None):
-        """
-        Since some tables are prone to schema extension, meaning we can add
-        additional columns to it, we should reflect changes in metadata
-        to have the latest columns when dealing with those tables.
-        If filter function is defined, it's used to filter out tables to reflect,
-        otherwise all tables are reflected
-        """
-        self.db.metadata.reflect(
-            bind=self.db.engine,
-            extend_existing=True,
-            only=filter_tables,
-        )
-
     def create_dataset_rows_table(
         self,
         name: str,
@@ -847,11 +833,14 @@ class SQLiteWarehouse(AbstractWarehouse):
         return cast(func.instr(source, target), sqlalchemy.Boolean)
 
     def get_table(self, name: str) -> sqlalchemy.Table:
-        # load table with latest schema to metadata
-        self._reflect_tables(filter_tables=lambda t, _: t == name)
         try:
-            return self.db.metadata.tables[name]
-        except KeyError:
+            return Table(
+                name,
+                self.db.metadata,
+                autoload_with=self.db.engine,
+                extend_existing=True,
+            )
+        except sqlalchemy.exc.NoSuchTableError:
             raise TableMissingError(f"Table '{name}' not found") from None
 
     def python_type(self, col_type: Union["TypeEngine", "SQLType"]) -> Any:


### PR DESCRIPTION
Fix for something I hit while investigating #1829. Small change, but worth applying IMO.

---

`SQLiteWarehouse.get_table` re-reflected the whole schema on every call — `metadata.reflect(only=...)` introspects every table even with a name filter. So it was O(number of tables), and `get_table` runs a few times per query. Now it reflects just the one table, so cost no longer scales with how many tables are in the DB.

## Performance

Local in-memory SQLite — absolute numbers are machine-specific; what matters is **linear → flat**.

Per-query time in a `read_values().map().sum()` loop as tables pile up (datasets / temp / UDF):

| tables | before | after |
|--------|--------|-------|
| 40     | 58 ms  | 28 ms |
| 115    | 109 ms | 37 ms |
| 215    | 217 ms | 50 ms |
| 315    | 284 ms | 57 ms |
| 365    | 370 ms | 59 ms |

Before climbs with table count (~6× at 365 and rising); after stays flat-ish.

Same refresh behavior (`extend_existing`), missing tables still raise `TableMissingError`. On a small DB the difference is negligible — it only shows up once tables accumulate.

🤖 Made with the help of Claude Code