### PR TITLE
Fix flaky test

### DIFF
--- a/src/datachain/asyn.py
+++ b/src/datachain/asyn.py
@@ -172,7 +172,7 @@ class AsyncMapper(Generic[InputT, ResultT]):
 
     def iterate(self, timeout=None) -> Generator[ResultT, None, None]:
         init = asyncio.run_coroutine_threadsafe(self.init(), self.loop)
-        init.result(timeout=1)
+        init.result()
         async_run = asyncio.run_coroutine_threadsafe(self.run(), self.loop)
         try:
             while True:


### PR DESCRIPTION
Fix flaky `TimeoutError` in async prefetch/UDF iteration: https://github.com/datachain-ai/datachain/actions/runs/27865280601/job/82468248317

### What

Removed the hard-coded 1s timeout on the init step in `AsyncMapper.iterate()`:

```python
init.result(timeout=1)  →  init.result()
```

### Why

We hit this on `main` CI ([run](https://github.com/datachain-ai/datachain/actions/runs/27865280601/job/82468248317)):

```
FAILED tests/func/test_datachain.py::test_to_read_parquet_remote[...]
  - concurrent.futures._base.TimeoutError
```

`init()` just allocates two `asyncio.Queue`s — microseconds of work. It runs on the shared fsspec loop thread, and `iterate()` waited at most 1s for it. Under heavy parallel load (8-core runner, many xdist workers), the loop thread can be starved past 1s, so a trivial setup step "times out" even though nothing is actually wrong.

This isn't test-only: the same starvation can hit any user running prefetch or a UDF on a busy machine, aborting their pipeline mid-run.

### Why just remove it (not bump it)

The 1s deadline only ever covered the setup step. The real work — `_produce`, the workers, `next_result` — already waits on the loop thread with **no** timeout. So the timeout never protected a running job from a stuck loop; it only randomly killed jobs whose setup happened to be delayed. Removing it makes init consistent with the rest of the pipeline and can't false-positive under load.

No new hang risk: the only case where this now blocks forever ("loop never makes progress") already hangs one step later in the existing unbounded waits.

### Notes

- Couldn't reproduce locally (only shows up under heavy parallel load) — the fix is mechanism-based, validated by the existing `tests/unit/test_asyn.py` suite.

---

🤖 Made with the help of Claude Code