### PR TITLE
Avoid waking the warehouse on metadata-only dataset edits

### DIFF
--- a/src/datachain/catalog/catalog.py
+++ b/src/datachain/catalog/catalog.py
@@ -1095,7 +1095,11 @@ class Catalog:
     def update_dataset(self, dataset: DatasetRecord, **kwargs) -> DatasetRecord:
         """Updates dataset fields."""
         dataset_updated = self.metastore.update_dataset(dataset, **kwargs)
-        self.warehouse.rename_dataset_tables(dataset, dataset_updated)
+        # Renaming dataset tables touches (and may wake) the warehouse, so only
+        # do it when a field that feeds the table name changes. See
+        # AbstractWarehouse._construct_dataset_table_name for those fields.
+        if kwargs.keys() & {"name", "project_id"}:
+            self.warehouse.rename_dataset_tables(dataset, dataset_updated)
         return dataset_updated
 
     def remove_dataset_version(

--- a/tests/func/test_datasets.py
+++ b/tests/func/test_datasets.py
@@ -54,6 +54,20 @@ def saved_dataset(test_session):
     )
 
 
+@pytest.fixture
+def warehouse_access_forbidden(test_session):
+    catalog = test_session.catalog
+    original = catalog.warehouse
+
+    class ForbiddenWarehouse:
+        def __getattr__(self, name):
+            raise AssertionError(f"warehouse accessed via {name!r}")
+
+    catalog.warehouse = ForbiddenWarehouse()
+    yield
+    catalog.warehouse = original
+
+
 def test_create_dataset_no_version_specified(test_session, project):
     catalog = test_session.catalog
 
@@ -443,6 +457,22 @@ def test_edit_dataset(test_session, saved_dataset):
     )
     assert expected_table_row_count
     assert dataset.get_version("1.0.0").num_objects == expected_table_row_count
+
+
+def test_edit_dataset_metadata_only_does_not_touch_warehouse(
+    test_session, saved_dataset, warehouse_access_forbidden
+):
+    catalog = test_session.catalog
+    catalog.edit_dataset(
+        saved_dataset.name,
+        saved_dataset.project,
+        description="new description",
+        attrs=["cats", "birds"],
+    )
+
+    dataset = catalog.get_dataset(saved_dataset.name, versions=["1.0.0"])
+    assert dataset.description == "new description"
+    assert dataset.attrs == ["cats", "birds"]
 
 
 @pytest.mark.parametrize("is_studio", [True])


### PR DESCRIPTION
edit_dataset (and update_dataset under it) always called warehouse.rename_dataset_tables, even when only the description or attrs changed. A dataset's table name is built solely from its namespace, project, name and version, so metadata-only edits can never trigger a rename - but the call still reached into the warehouse, which for remote/Studio backends means waking up compute we don't need.

We now only rename the tables when a field that actually feeds the table name changes (name or project_id), so a pure metadata update no longer touches the warehouse at all. The move path keeps working since it passes project_id, and rename_dataset_tables still no-ops when the name is unchanged.
