### PR TITLE
Fixing list duplication

### DIFF
--- a/src/datachain/cli/commands/datasets.py
+++ b/src/datachain/cli/commands/datasets.py
@@ -42,7 +42,7 @@ def list_datasets(
     catalog: "Catalog",
     studio: bool = False,
     local: bool = False,
-    all: bool = True,
+    all: bool = False,
     team: str | None = None,
     latest_only: bool = True,
     name: str | None = None,

--- a/src/datachain/cli/commands/datasets.py
+++ b/src/datachain/cli/commands/datasets.py
@@ -54,9 +54,7 @@ def list_datasets(
 
     local_datasets = set(list_datasets_local(catalog, name)) if all or local else set()
     studio_datasets = (
-        set(list_datasets_studio(team=team, name=name))
-        if (all or studio) and token
-        else set()
+        set(list_datasets_studio(team=team, name=name)) if all or studio else set()
     )
 
     # Group the datasets for both local and studio sources.
@@ -96,7 +94,7 @@ def list_datasets(
     rows = [
         _datasets_tabulate_row(
             name=n,
-            both=(all or (local and studio)) and token,
+            both=all or (local and studio),
             local_version=local_version,
             studio_version=studio_version,
         )

--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -24,7 +24,7 @@ def ls(
     all, local, studio = determine_flavors(studio, local, all, token)
 
     show_local = all or local
-    show_studio = (all or studio) and token
+    show_studio = (all or studio) and bool(token)
     label_sections = show_local and show_studio
 
     if show_local:

--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -24,7 +24,7 @@ def ls(
     all, local, studio = determine_flavors(studio, local, all, token)
 
     show_local = all or local
-    show_studio = (all or studio) and bool(token)
+    show_studio = all or studio
     label_sections = show_local and show_studio
 
     if show_local:

--- a/src/datachain/cli/commands/ls.py
+++ b/src/datachain/cli/commands/ls.py
@@ -16,17 +16,25 @@ def ls(
     long: bool = False,
     studio: bool = False,
     local: bool = False,
-    all: bool = True,
+    all: bool = False,
     team: str | None = None,
     **kwargs,
 ):
     token = Config().read().get("studio", {}).get("token")
     all, local, studio = determine_flavors(studio, local, all, token)
 
-    if all or local:
+    show_local = all or local
+    show_studio = (all or studio) and token
+    label_sections = show_local and show_studio
+
+    if show_local:
+        if label_sections:
+            print("Local:")
         ls_local(sources, long=long, **kwargs)
 
-    if (all or studio) and token:
+    if show_studio:
+        if label_sections:
+            print("\nStudio:")
         ls_remote(sources, long=long, team=team)
 
 

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -249,14 +249,14 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--studio",
         action="store_true",
         default=False,
-        help="List datasets from Studio only",
+        help="List the datasets in the Studio",
     )
     datasets_ls_parser.add_argument(
         "-L",
         "--local",
         action="store_true",
         default=False,
-        help="List local datasets only (default)",
+        help="List local datasets only",
     )
     datasets_ls_parser.add_argument(
         "-a",
@@ -326,14 +326,14 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--studio",
         action="store_true",
         default=False,
-        help="List files from Studio only",
+        help="List the files in the Studio",
     )
     parse_ls.add_argument(
         "-L",
         "--local",
         action="store_true",
         default=False,
-        help="List local files only (default)",
+        help="List local files only",
     )
     parse_ls.add_argument(
         "-a",

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -249,21 +249,21 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--studio",
         action="store_true",
         default=False,
-        help="List the files in the Studio",
+        help="List datasets from Studio only",
     )
     datasets_ls_parser.add_argument(
         "-L",
         "--local",
         action="store_true",
         default=False,
-        help="List local files only",
+        help="List local datasets only (default)",
     )
     datasets_ls_parser.add_argument(
         "-a",
         "--all",
         action="store_true",
-        default=True,
-        help="List all files including hidden files",
+        default=False,
+        help="List both local and Studio datasets",
     )
     datasets_ls_parser.add_argument(
         "--team",
@@ -326,21 +326,21 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--studio",
         action="store_true",
         default=False,
-        help="List the files in the Studio",
+        help="List files from Studio only",
     )
     parse_ls.add_argument(
         "-L",
         "--local",
         action="store_true",
         default=False,
-        help="List local files only",
+        help="List local files only (default)",
     )
     parse_ls.add_argument(
         "-a",
         "--all",
         action="store_true",
-        default=True,
-        help="List all files including hidden files",
+        default=False,
+        help="List both local and Studio files",
     )
     parse_ls.add_argument(
         "--team",

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -256,7 +256,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--local",
         action="store_true",
         default=False,
-        help="List local datasets only",
+        help="List local datasets only (default)",
     )
     datasets_ls_parser.add_argument(
         "-a",
@@ -333,7 +333,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--local",
         action="store_true",
         default=False,
-        help="List local files only",
+        help="List local files only (default)",
     )
     parse_ls.add_argument(
         "-a",
@@ -346,7 +346,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--team",
         action="store",
         default=None,
-        help="The team to list datasets for. By default, it will use team from config",
+        help="The team to list files for. By default, it will use team from config",
     )
 
     parse_du = subp.add_parser(

--- a/src/datachain/cli/parser/__init__.py
+++ b/src/datachain/cli/parser/__init__.py
@@ -256,7 +256,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--local",
         action="store_true",
         default=False,
-        help="List local datasets only (default)",
+        help="List local datasets (default)",
     )
     datasets_ls_parser.add_argument(
         "-a",
@@ -333,7 +333,7 @@ def get_parser() -> ArgumentParser:  # noqa: PLR0915
         "--local",
         action="store_true",
         default=False,
-        help="List local files only (default)",
+        help="List local files (default)",
     )
     parse_ls.add_argument(
         "-a",

--- a/src/datachain/cli/utils.py
+++ b/src/datachain/cli/utils.py
@@ -80,6 +80,7 @@ def determine_flavors(studio: bool, local: bool, all: bool, token: str | None):
     if local or studio:
         all = False
 
-    all = all and not (local or studio)
+    if not (studio or local or all):
+        local = True
 
     return all, local, studio

--- a/src/datachain/cli/utils.py
+++ b/src/datachain/cli/utils.py
@@ -80,6 +80,10 @@ def determine_flavors(studio: bool, local: bool, all: bool, token: str | None):
     if local or studio:
         all = False
 
+    if all and not token:
+        all = False
+        local = True
+
     if not (studio or local or all):
         local = True
 

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -1,6 +1,6 @@
+import importlib
 import posixpath
 import re
-import sys
 from datetime import datetime
 from struct import pack
 from time import sleep
@@ -242,7 +242,7 @@ def test_ls_remote_sources(cloud_type, capsys, monkeypatch, studio_config):
 
 
 def test_ls_all_labels_local_and_studio_sections(capsys, monkeypatch, studio_config):
-    ls_module = sys.modules["datachain.cli.commands.ls"]
+    ls_module = importlib.import_module("datachain.cli.commands.ls")
     with monkeypatch.context() as m:
         m.setattr(ls_module, "ls_local", lambda *a, **kw: print("local-data"))
         m.setattr(ls_module, "ls_remote", lambda *a, **kw: print("studio-data"))
@@ -253,7 +253,7 @@ def test_ls_all_labels_local_and_studio_sections(capsys, monkeypatch, studio_con
 def test_ls_default_only_local_when_logged_into_studio(
     capsys, monkeypatch, studio_config
 ):
-    ls_module = sys.modules["datachain.cli.commands.ls"]
+    ls_module = importlib.import_module("datachain.cli.commands.ls")
     called = {"local": 0, "remote": 0}
     with monkeypatch.context() as m:
         m.setattr(

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -1,5 +1,6 @@
 import posixpath
 import re
+import sys
 from datetime import datetime
 from struct import pack
 from time import sleep
@@ -238,6 +239,36 @@ def test_ls_remote_sources(cloud_type, capsys, monkeypatch, studio_config):
         ls([src, f"{src}/dogs/others", f"{src}/dogs"], studio=True)
     captured = capsys.readouterr()
     assert captured.out == ls_remote_sources_output.format(src=src)
+
+
+def test_ls_all_labels_local_and_studio_sections(capsys, monkeypatch, studio_config):
+    ls_module = sys.modules["datachain.cli.commands.ls"]
+    with monkeypatch.context() as m:
+        m.setattr(ls_module, "ls_local", lambda *a, **kw: print("local-data"))
+        m.setattr(ls_module, "ls_remote", lambda *a, **kw: print("studio-data"))
+        ls(["s3://x"], all=True)
+    assert capsys.readouterr().out == "Local:\nlocal-data\n\nStudio:\nstudio-data\n"
+
+
+def test_ls_default_only_local_when_logged_into_studio(
+    capsys, monkeypatch, studio_config
+):
+    ls_module = sys.modules["datachain.cli.commands.ls"]
+    called = {"local": 0, "remote": 0}
+    with monkeypatch.context() as m:
+        m.setattr(
+            ls_module,
+            "ls_local",
+            lambda *a, **kw: called.__setitem__("local", called["local"] + 1),
+        )
+        m.setattr(
+            ls_module,
+            "ls_remote",
+            lambda *a, **kw: called.__setitem__("remote", called["remote"] + 1),
+        )
+        ls(["s3://x"])
+    assert called == {"local": 1, "remote": 0}
+    assert "Local:" not in capsys.readouterr().out
 
 
 REMOTE_DATA: dict[str, list[dict[str, Any]]] = {

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -441,9 +441,13 @@ def test_studio_datasets(capsys, studio_datasets, mocker):
 
     assert main(["dataset", "ls"]) == 0
     out = capsys.readouterr().out
-    assert sorted(out.splitlines()) == sorted(both_output.splitlines())
+    assert sorted(out.splitlines()) == sorted(local_output.splitlines())
 
     assert main(["dataset", "ls", "--versions"]) == 0
+    out = capsys.readouterr().out
+    assert sorted(out.splitlines()) == sorted(local_output.splitlines())
+
+    assert main(["dataset", "ls", "--versions", "--all"]) == 0
     out = capsys.readouterr().out
     assert sorted(out.splitlines()) == sorted(both_output_versions.splitlines())
 

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -120,9 +120,9 @@ def test_datasets_ls_flavor_defaults():
         # No flags defaults to local-only (regardless of token presence)
         (False, False, False, None, (False, True, False)),
         (False, False, False, "tok", (False, True, False)),
-        # Explicit --all keeps studio off unless a token is present (caller gates it)
+        # Explicit --all keeps both on with a token, downgrades to local without
         (False, False, True, "tok", (True, False, False)),
-        (False, False, True, None, (True, False, False)),
+        (False, False, True, None, (False, True, False)),
         # Explicit single-source flags clear --all
         (True, False, False, "tok", (False, False, True)),
         (False, True, False, None, (False, True, False)),

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -6,7 +6,8 @@ import pytest
 from datachain.cli import get_logging_level, get_parser
 from datachain.cli.parser.utils import CustomArgumentParser as ArgumentParser
 from datachain.cli.parser.utils import find_columns_type
-from datachain.cli.utils import CommaSeparatedArgs
+from datachain.cli.utils import CommaSeparatedArgs, determine_flavors
+from datachain.error import DataChainError
 
 
 def test_find_columns_type():
@@ -95,3 +96,43 @@ def test_bucket_no_subcommand():
     args = parser.parse_args(("bucket",))
     assert args.command == "bucket"
     assert args.bucket_cmd is None
+
+
+def test_ls_flavor_defaults():
+    parser = get_parser()
+    args = parser.parse_args(("ls", "s3://example/"))
+    assert args.local is False
+    assert args.studio is False
+    assert args.all is False
+
+
+def test_datasets_ls_flavor_defaults():
+    parser = get_parser()
+    args = parser.parse_args(("dataset", "ls"))
+    assert args.local is False
+    assert args.studio is False
+    assert args.all is False
+
+
+@pytest.mark.parametrize(
+    "studio,local,all,token,expected",
+    [
+        # No flags defaults to local-only (regardless of token presence)
+        (False, False, False, None, (False, True, False)),
+        (False, False, False, "tok", (False, True, False)),
+        # Explicit --all keeps studio off unless a token is present (caller gates it)
+        (False, False, True, "tok", (True, False, False)),
+        (False, False, True, None, (True, False, False)),
+        # Explicit single-source flags clear --all
+        (True, False, False, "tok", (False, False, True)),
+        (False, True, False, None, (False, True, False)),
+        (True, True, False, "tok", (False, True, True)),
+    ],
+)
+def test_determine_flavors(studio, local, all, token, expected):
+    assert determine_flavors(studio, local, all, token) == expected
+
+
+def test_determine_flavors_studio_without_token():
+    with pytest.raises(DataChainError, match="Not logged in to Studio"):
+        determine_flavors(studio=True, local=False, all=False, token=None)


### PR DESCRIPTION
Fixes #1836.

Before, `datachain ls` and `datachain dataset ls` would list both local and Studio when you were logged in, which caused duplicated output.

Now:
- No flag (default): local only.
- `--studio`: Studio only.
- `--local`: local only.
- `--all`: both, with `Local:` and `Studio:` headers between sections.

Tested locally:

```
$ datachain ls s3://dc-readme/
fiona.jpg
fleet-cameras/
models/
oxford-pets-micro/
oxford-pets-small/
```

```
$ datachain ls --all s3://dc-readme/
Local:
fiona.jpg
fleet-cameras/
models/
oxford-pets-micro/
oxford-pets-small/

Studio:
s3://dc-readme/:
  ...
```

```
$ datachain dataset ls
Name                               Latest Version
---------------------------------  ----------------
local.local.nums                   v1.0.8
local.local.nums_doubled           v1.0.3
...
```

```
$ datachain dataset ls --all
Name                               Studio    Local
---------------------------------  --------  -------
@ilongin.default.pagination_test   v1.0.1    ✖
local.local.nums                   ✖         v1.0.8
local.local.nums_doubled           ✖         v1.0.3
...
```
