### PR TITLE
Route framework logs to a separate fd when DATACHAIN_INTERNAL_LOG_FD is set

### DIFF
--- a/src/datachain/cli/__init__.py
+++ b/src/datachain/cli/__init__.py
@@ -5,6 +5,7 @@ import traceback
 from multiprocessing import freeze_support
 
 from datachain.cli.utils import get_logging_level
+from datachain.log_routing import setup_internal_log_routing
 from datachain.studio import process_pipeline_args
 
 from .commands import (
@@ -37,6 +38,8 @@ def main(argv: list[str] | None = None) -> int:
     datachain_parser = get_parser()
     args = datachain_parser.parse_args(argv)
 
+    logs_routed = setup_internal_log_routing()
+
     if args.command == "internal-run-udf":
         return handle_udf()
     if args.command == "internal-run-udf-worker":
@@ -46,9 +49,13 @@ def main(argv: list[str] | None = None) -> int:
         datachain_parser.print_help(sys.stderr)
         return 1
 
-    logger.addHandler(logging.StreamHandler())
     logging_level = get_logging_level(args)
-    logger.setLevel(logging_level)
+    if not logs_routed:
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(logging_level)
+    elif logging_level < logging.INFO:
+        # -v widens what reaches the internal stream
+        logger.setLevel(logging_level)
 
     client_config = (
         {

--- a/src/datachain/log_routing.py
+++ b/src/datachain/log_routing.py
@@ -1,0 +1,112 @@
+"""Route framework (datachain/datachain_saas/compute) logs to a Studio-provided fd.
+
+Inside a SaaS job, framework log records go to the fd from
+DATACHAIN_INTERNAL_LOG_FD as one JSON line each (message, time, level, logger)
+instead of the captured stdout/stderr, so the parent worker can tell framework
+logs from user output.
+"""
+
+import json
+import logging
+import os
+from contextlib import suppress
+from datetime import datetime, timezone
+from io import TextIOWrapper
+
+INTERNAL_LOG_FD_ENV = "DATACHAIN_INTERNAL_LOG_FD"
+INTERNAL_LOG_LEVEL_ENV = "DATACHAIN_INTERNAL_LOG_LEVEL"
+
+_FRAMEWORK_LOGGERS = ("datachain", "datachain_saas", "compute")
+
+_routed = False
+
+
+def setup_internal_log_routing() -> bool:
+    """Route framework loggers to the parent fd; True if routing is active."""
+    global _routed  # noqa: PLW0603
+    if _routed:
+        return True
+
+    fd = _fd_from_env()
+    if fd is None:
+        return False
+
+    try:
+        pipe = os.fdopen(fd, "w", buffering=1)
+    except OSError:
+        return False
+
+    level = logging.getLevelName(os.getenv(INTERNAL_LOG_LEVEL_ENV, "INFO").upper())
+    if not isinstance(level, int):
+        level = logging.INFO
+
+    handler = _FdJsonHandler(pipe)
+    for name in _FRAMEWORK_LOGGERS:
+        framework_logger = logging.getLogger(name)
+        framework_logger.handlers[:] = [handler]
+        framework_logger.setLevel(level)
+        framework_logger.propagate = False
+    _routed = True
+
+    return True
+
+
+def internal_log_fds() -> tuple[int, ...]:
+    """Return the fds that framework logs are routed to, or empty if none."""
+    fd = _fd_from_env()
+    if fd is None:
+        return ()
+
+    try:
+        os.fstat(fd)
+    except OSError:
+        return ()
+
+    return (fd,)
+
+
+def _fd_from_env() -> int | None:
+    fd_raw = os.getenv(INTERNAL_LOG_FD_ENV)
+    if not fd_raw:
+        return None
+
+    try:
+        return int(fd_raw)
+    except ValueError:
+        return None
+
+
+class _FdJsonHandler(logging.Handler):
+    stream: TextIOWrapper | None
+
+    def __init__(self, stream: TextIOWrapper) -> None:
+        super().__init__()
+        self.stream = stream
+
+    def close(self) -> None:
+        if self.stream is not None:
+            with suppress(OSError, ValueError):
+                self.stream.close()
+            self.stream = None
+        super().close()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self.stream is None:
+            return
+
+        try:
+            entry = {
+                "message": self.format(record),
+                "time": datetime.now(timezone.utc).isoformat(),
+                "level": record.levelname.lower(),
+                "logger": record.name,
+            }
+            self.stream.write(json.dumps(entry, default=str) + "\n")
+        except OSError:
+            # Dead fd: disable quietly; handleError would dump a traceback
+            # into the captured stream (the job log) for every record.
+            with suppress(OSError, ValueError):
+                self.stream.close()
+            self.stream = None
+        except Exception:  # noqa: BLE001
+            self.handleError(record)

--- a/src/datachain/log_routing.py
+++ b/src/datachain/log_routing.py
@@ -1,9 +1,9 @@
-"""Route framework (datachain/datachain_saas/compute) logs to a Studio-provided fd.
+"""Route framework logs to a caller-provided fd.
 
-Inside a SaaS job, framework log records go to the fd from
-DATACHAIN_INTERNAL_LOG_FD as one JSON line each (message, time, level, logger)
-instead of the captured stdout/stderr, so the parent worker can tell framework
-logs from user output.
+Inside a SaaS job, records from the `datachain` logger (plus any loggers named
+in DATACHAIN_INTERNAL_LOG_LOGGERS) go to the fd from DATACHAIN_INTERNAL_LOG_FD as
+one JSON line each (message, time, level, logger) instead of the captured
+stdout/stderr, so the parent worker can tell framework logs from user output.
 """
 
 import json
@@ -15,8 +15,7 @@ from io import TextIOWrapper
 
 INTERNAL_LOG_FD_ENV = "DATACHAIN_INTERNAL_LOG_FD"
 INTERNAL_LOG_LEVEL_ENV = "DATACHAIN_INTERNAL_LOG_LEVEL"
-
-_FRAMEWORK_LOGGERS = ("datachain", "datachain_saas", "compute")
+INTERNAL_LOG_LOGGERS_ENV = "DATACHAIN_INTERNAL_LOG_LOGGERS"
 
 _routed = False
 
@@ -41,7 +40,7 @@ def setup_internal_log_routing() -> bool:
         level = logging.INFO
 
     handler = _FdJsonHandler(pipe)
-    for name in _FRAMEWORK_LOGGERS:
+    for name in _framework_loggers():
         framework_logger = logging.getLogger(name)
         framework_logger.handlers[:] = [handler]
         framework_logger.setLevel(level)
@@ -74,6 +73,12 @@ def _fd_from_env() -> int | None:
         return int(fd_raw)
     except ValueError:
         return None
+
+
+def _framework_loggers() -> tuple[str, ...]:
+    extra = os.getenv(INTERNAL_LOG_LOGGERS_ENV, "")
+    names = ["datachain", *(n.strip() for n in extra.split(",") if n.strip())]
+    return tuple(dict.fromkeys(names))
 
 
 class _FdJsonHandler(logging.Handler):

--- a/src/datachain/query/dataset.py
+++ b/src/datachain/query/dataset.py
@@ -56,6 +56,7 @@ from datachain.lib.listing import is_listing_dataset, listing_dataset_expired
 from datachain.lib.signal_schema import SignalSchema, generate_merge_root_mapping
 from datachain.lib.udf import JsonSerializationError, UdfError, _get_cache
 from datachain.lib.utils import type_to_str
+from datachain.log_routing import internal_log_fds
 from datachain.progress import (
     CombinedDownloadCallback,
     TqdmCombinedDownloadCallback,
@@ -853,7 +854,10 @@ class UDFStep(Step, ABC):
                     process_data = filtered_cloudpickle_dumps(udf_info)
 
                     with subprocess.Popen(  # noqa: S603
-                        cmd, env=envs, stdin=subprocess.PIPE
+                        cmd,
+                        env=envs,
+                        stdin=subprocess.PIPE,
+                        pass_fds=internal_log_fds(),
                     ) as process:
                         try:
                             process.communicate(process_data)

--- a/tests/unit/test_log_routing.py
+++ b/tests/unit/test_log_routing.py
@@ -12,6 +12,7 @@ from datachain.cli import main
 from datachain.log_routing import (
     INTERNAL_LOG_FD_ENV,
     INTERNAL_LOG_LEVEL_ENV,
+    INTERNAL_LOG_LOGGERS_ENV,
     internal_log_fds,
     setup_internal_log_routing,
 )
@@ -73,6 +74,7 @@ def test_unopenable_fd_is_noop(tmp_path, monkeypatch, restore_loggers):
 
 @pytest.mark.parametrize("name", ["datachain", "datachain_saas", "compute"])
 def test_records_go_to_fd_as_json(monkeypatch, restore_loggers, internal_fd, name):
+    monkeypatch.setenv(INTERNAL_LOG_LOGGERS_ENV, "datachain_saas,compute")
     studio = io.StringIO()
     monkeypatch.setattr(sys, "stderr", studio)
 
@@ -89,6 +91,7 @@ def test_records_go_to_fd_as_json(monkeypatch, restore_loggers, internal_fd, nam
 
 
 def test_warning_also_goes_to_fd(monkeypatch, restore_loggers, internal_fd):
+    monkeypatch.setenv(INTERNAL_LOG_LOGGERS_ENV, "compute")
     studio = io.StringIO()
     monkeypatch.setattr(sys, "stderr", studio)
 
@@ -99,6 +102,19 @@ def test_warning_also_goes_to_fd(monkeypatch, restore_loggers, internal_fd):
     assert entry["message"] == "hello-warn"
     assert entry["level"] == "warning"
     assert "hello-warn" not in studio.getvalue()
+
+
+def test_own_logger_routed_extras_opt_in(monkeypatch, restore_loggers, internal_fd):
+    monkeypatch.delenv(INTERNAL_LOG_LOGGERS_ENV, raising=False)
+    logging.getLogger("datachain_saas").propagate = True
+
+    assert setup_internal_log_routing() is True
+    logging.getLogger("datachain").info("own")
+    logging.getLogger("datachain_saas").info("extra")
+
+    lines = internal_fd.read_text().splitlines()
+    assert [json.loads(line)["message"] for line in lines] == ["own"]
+    assert logging.getLogger("datachain_saas").propagate is True
 
 
 def test_level_env_widens_fd_band(monkeypatch, restore_loggers, internal_fd):

--- a/tests/unit/test_log_routing.py
+++ b/tests/unit/test_log_routing.py
@@ -1,0 +1,251 @@
+import gc
+import io
+import json
+import logging
+import os
+import sys
+
+import pytest
+
+from datachain import log_routing
+from datachain.cli import main
+from datachain.log_routing import (
+    INTERNAL_LOG_FD_ENV,
+    INTERNAL_LOG_LEVEL_ENV,
+    internal_log_fds,
+    setup_internal_log_routing,
+)
+
+
+@pytest.fixture
+def restore_loggers(monkeypatch):
+    monkeypatch.setattr(log_routing, "_routed", False)
+    names = ("datachain", "datachain_saas", "compute")
+    saved = {
+        n: (
+            list(logging.getLogger(n).handlers),
+            logging.getLogger(n).level,
+            logging.getLogger(n).propagate,
+        )
+        for n in names
+    }
+    yield
+    for name, (handlers, level, propagate) in saved.items():
+        lg = logging.getLogger(name)
+        for handler in lg.handlers:
+            if handler not in handlers:
+                handler.close()
+        lg.handlers[:] = handlers
+        lg.setLevel(level)
+        lg.propagate = propagate
+
+
+@pytest.fixture
+def internal_fd(tmp_path, monkeypatch):
+    out_file = tmp_path / "internal.log"
+    fd = os.open(out_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, str(fd))
+    return out_file
+
+
+def test_missing_env_leaves_loggers_untouched(monkeypatch, restore_loggers):
+    monkeypatch.delenv(INTERNAL_LOG_FD_ENV, raising=False)
+    logging.getLogger("datachain").propagate = True
+    assert setup_internal_log_routing() is False
+    assert logging.getLogger("datachain").propagate is True
+
+
+def test_invalid_fd_is_noop(monkeypatch, restore_loggers):
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, "not-an-int")
+    logging.getLogger("datachain").propagate = True
+    assert setup_internal_log_routing() is False
+    assert logging.getLogger("datachain").propagate is True
+
+
+def test_unopenable_fd_is_noop(tmp_path, monkeypatch, restore_loggers):
+    fd = os.open(tmp_path / "gone.log", os.O_WRONLY | os.O_CREAT)
+    os.close(fd)
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, str(fd))
+    logging.getLogger("datachain").propagate = True
+    assert setup_internal_log_routing() is False
+    assert logging.getLogger("datachain").propagate is True
+
+
+@pytest.mark.parametrize("name", ["datachain", "datachain_saas", "compute"])
+def test_records_go_to_fd_as_json(monkeypatch, restore_loggers, internal_fd, name):
+    studio = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", studio)
+
+    assert setup_internal_log_routing() is True
+    logging.getLogger(name).info("hello-info")
+
+    entry = json.loads(internal_fd.read_text().splitlines()[0])
+    assert entry["message"] == "hello-info"
+    assert entry["logger"] == name
+    assert entry["level"] == "info"
+    assert entry["time"]
+    assert "hello-info" not in studio.getvalue()
+    assert logging.getLogger(name).propagate is False
+
+
+def test_warning_also_goes_to_fd(monkeypatch, restore_loggers, internal_fd):
+    studio = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", studio)
+
+    assert setup_internal_log_routing() is True
+    logging.getLogger("compute").warning("hello-warn")
+
+    entry = json.loads(internal_fd.read_text().splitlines()[0])
+    assert entry["message"] == "hello-warn"
+    assert entry["level"] == "warning"
+    assert "hello-warn" not in studio.getvalue()
+
+
+def test_level_env_widens_fd_band(monkeypatch, restore_loggers, internal_fd):
+    monkeypatch.setenv(INTERNAL_LOG_LEVEL_ENV, "debug")
+
+    assert setup_internal_log_routing() is True
+    logging.getLogger("datachain").debug("hello-debug")
+
+    entry = json.loads(internal_fd.read_text().splitlines()[0])
+    assert entry["message"] == "hello-debug"
+    assert entry["level"] == "debug"
+
+
+def test_invalid_level_env_defaults_to_info(monkeypatch, restore_loggers, internal_fd):
+    monkeypatch.setenv(INTERNAL_LOG_LEVEL_ENV, "not-a-level")
+
+    assert setup_internal_log_routing() is True
+    logging.getLogger("datachain").debug("hello-debug")
+    logging.getLogger("datachain").info("hello-info")
+
+    lines = internal_fd.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["message"] == "hello-info"
+
+
+def test_traceback_is_a_single_json_line(restore_loggers, internal_fd):
+    assert setup_internal_log_routing() is True
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logging.getLogger("datachain").exception("udf failed")
+
+    lines = internal_fd.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert "udf failed" in entry["message"]
+    assert "Traceback" in entry["message"]
+    assert "ValueError: boom" in entry["message"]
+
+
+def test_fd_handler_self_disables_on_dead_fd(monkeypatch, restore_loggers, tmp_path):
+    out_file = tmp_path / "internal.log"
+    fd = os.open(out_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, str(fd))
+    studio = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", studio)
+
+    assert setup_internal_log_routing() is True
+    os.close(fd)
+    logging.getLogger("datachain").info("first-after-close")
+    logging.getLogger("datachain").info("second-after-close")
+
+    assert "Logging error" not in studio.getvalue()
+    assert "first-after-close" not in studio.getvalue()
+    assert "second-after-close" not in studio.getvalue()
+
+
+def test_setup_is_idempotent(monkeypatch, restore_loggers, internal_fd):
+    assert setup_internal_log_routing() is True
+    handlers = list(logging.getLogger("datachain").handlers)
+    assert setup_internal_log_routing() is True
+    assert logging.getLogger("datachain").handlers == handlers
+
+    gc.collect()
+    logging.getLogger("datachain").info("after-second-setup")
+    assert "after-second-setup" in internal_fd.read_text()
+
+
+def test_cli_routes_instead_of_default_handler(
+    tmp_path, monkeypatch, restore_loggers, internal_fd
+):
+    monkeypatch.chdir(tmp_path)
+    studio = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", studio)
+
+    assert main(["completion"]) == 0
+    dc_logger = logging.getLogger("datachain")
+    assert [type(h).__name__ for h in dc_logger.handlers] == ["_FdJsonHandler"]
+    assert dc_logger.propagate is False
+
+    dc_logger.info("CLI_INFO")
+    entry = json.loads(internal_fd.read_text().splitlines()[0])
+    assert entry["message"] == "CLI_INFO"
+    assert "CLI_INFO" not in studio.getvalue()
+
+
+def test_cli_udf_worker_routes_before_dispatch(
+    monkeypatch, restore_loggers, internal_fd
+):
+    monkeypatch.setattr("datachain.cli.handle_udf_runner", lambda: 0)
+
+    assert main(["internal-run-udf-worker"]) == 0
+    assert logging.getLogger("datachain").propagate is False
+
+    logging.getLogger("datachain").info("UDF_INFO")
+    entry = json.loads(internal_fd.read_text().splitlines()[0])
+    assert entry["message"] == "UDF_INFO"
+
+
+def test_cli_verbose_widens_fd_band(
+    tmp_path, monkeypatch, restore_loggers, internal_fd
+):
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["completion", "-v"]) == 0
+    dc_logger = logging.getLogger("datachain")
+    assert dc_logger.level == logging.DEBUG
+
+    dc_logger.debug("CLI_DEBUG")
+    lines = internal_fd.read_text().splitlines()
+    assert any(json.loads(line)["message"] == "CLI_DEBUG" for line in lines)
+
+
+def test_internal_log_fds_forwards_open_fd(tmp_path, monkeypatch):
+    fd = os.open(tmp_path / "internal.log", os.O_WRONLY | os.O_CREAT)
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, str(fd))
+    try:
+        assert internal_log_fds() == (fd,)
+    finally:
+        os.close(fd)
+
+
+def test_internal_log_fds_empty_without_env(monkeypatch):
+    monkeypatch.delenv(INTERNAL_LOG_FD_ENV, raising=False)
+    assert internal_log_fds() == ()
+
+
+def test_internal_log_fds_empty_on_invalid_value(monkeypatch):
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, "not-an-int")
+    assert internal_log_fds() == ()
+
+
+def test_internal_log_fds_empty_on_closed_fd(tmp_path, monkeypatch):
+    fd = os.open(tmp_path / "internal.log", os.O_WRONLY | os.O_CREAT)
+    os.close(fd)
+    monkeypatch.setenv(INTERNAL_LOG_FD_ENV, str(fd))
+    assert internal_log_fds() == ()
+
+
+def test_cli_default_handler_without_routing_env(
+    tmp_path, monkeypatch, restore_loggers
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(INTERNAL_LOG_FD_ENV, raising=False)
+    dc_logger = logging.getLogger("datachain")
+    dc_logger.handlers[:] = []
+
+    assert main(["completion"]) == 0
+    assert [type(h).__name__ for h in dc_logger.handlers] == ["StreamHandler"]
+    assert dc_logger.level == logging.INFO


### PR DESCRIPTION
Follow-up to datachain-ai/studio#13028: keep datachain's internal `INFO`/`DEBUG` out of the customer-facing job log no matter how the job configures logging. See also related Studio PR.

**Known limitation**: A job that reconfigures logging with `dictConfig(disable_existing_loggers=True)` (the default) can still disable these loggers.

Adds `datachain.log_routing`. When `DATACHAIN_INTERNAL_LOG_FD` is set (Studio jobs), the framework loggers (`datachain`, `datachain_saas`, `compute`) are detached from the root logger and every record is written as one JSON line — `{message, time, level, logger}` — to that fd instead of stdout/stderr, so the worker on the other end can tell framework logs apart from user output.

Completely inert without the env var: outside a Studio job the loggers are left untouched and the CLI behaves exactly as before (regression-tested). The level comes from `DATACHAIN_INTERNAL_LOG_LEVEL` (default `INFO`); `-v` still widens the CLI's own console output.

Covers every child we spawn that logs: the CLI self-routes in `main()` (shell jobs and UDF workers), and the parallel-UDF spawn passes the fd through `pass_fds` so it survives `close_fds`.