### PR TITLE
feat: garbage collect superseded, unused listing versions

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1878,7 +1878,7 @@ class AbstractDBMetastore(AbstractMetastore):
             )
         )
 
-        if job_id:
+        if job_id is not None:
             query = query.where(dv.c.job_id == job_id)
 
         versions = self._fetch_version_pairs(query)

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -350,7 +350,7 @@ class AbstractMetastore(ABC, Serializable):
           - there is no associated job (job_id is NULL) and the version is
             older than STALE_CREATED_THRESHOLD_HOURS
         - Status REMOVING: marked for deletion
-        - Listing versions that are not the latest, older than
+        - Listing versions superseded by a newer completed version, older than
           LISTING_GC_MIN_AGE_SECONDS, and unused by any dataset
 
         Returns:
@@ -1899,9 +1899,13 @@ class AbstractDBMetastore(AbstractMetastore):
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=min_age_seconds)
 
         newer = dv.alias("dv_newer")
-        has_newer_version = (
+        has_newer_complete_version = (
             select(newer.c.id)
-            .where(newer.c.dataset_id == dv.c.dataset_id, newer.c.id > dv.c.id)
+            .where(
+                newer.c.dataset_id == dv.c.dataset_id,
+                newer.c.id > dv.c.id,
+                newer.c.status == DatasetStatus.COMPLETE,
+            )
             .exists()
         )
         is_referenced = (
@@ -1917,7 +1921,7 @@ class AbstractDBMetastore(AbstractMetastore):
                 dv.c.status == DatasetStatus.COMPLETE,
                 dv.c.finished_at.isnot(None),
                 dv.c.finished_at < cutoff,
-                has_newer_version,
+                has_newer_complete_version,
                 ~is_referenced,
             )
         )

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -1680,7 +1680,7 @@ class AbstractDBMetastore(AbstractMetastore):
         query = self._base_list_datasets_query(include_incomplete=include_incomplete)
         if project_id:
             query = query.where(d.c.project_id == project_id)
-        query = query.where(self._datasets.c.name.startswith(prefix))
+        query = query.where(self._datasets.c.name.startswith(prefix, autoescape=True))
         yield from self._parse_dataset_list(self.db.execute(query))
 
     def get_dataset_by_version_uuid(
@@ -1863,7 +1863,7 @@ class AbstractDBMetastore(AbstractMetastore):
                     ),
                     # Session datasets from finished jobs (orphaned intermediates)
                     and_(
-                        d.c.name.startswith("session_"),
+                        d.c.name.startswith("session_", autoescape=True),
                         dv.c.status == DatasetStatus.COMPLETE,
                         dv.c.job_id.isnot(None),
                         j.c.status.in_(
@@ -1917,7 +1917,7 @@ class AbstractDBMetastore(AbstractMetastore):
             .select_from(base_from)
             .where(
                 d.c.project_id == self.listing_project.id,
-                d.c.name.startswith(LISTING_PREFIX),
+                d.c.name.startswith(LISTING_PREFIX, autoescape=True),
                 dv.c.status == DatasetStatus.COMPLETE,
                 dv.c.finished_at.isnot(None),
                 dv.c.finished_at < cutoff,

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -76,6 +76,8 @@ from datachain.project import Project
 # cleaning up in-flight operations.
 STALE_CREATED_THRESHOLD_HOURS = 1
 
+LISTING_GC_MIN_AGE_SECONDS = 7 * 24 * 60 * 60
+
 if TYPE_CHECKING:
     from sqlalchemy import CTE, Delete, Insert, Select, Subquery, Update
     from sqlalchemy.schema import SchemaItem
@@ -348,6 +350,8 @@ class AbstractMetastore(ABC, Serializable):
           - there is no associated job (job_id is NULL) and the version is
             older than STALE_CREATED_THRESHOLD_HOURS
         - Status REMOVING: marked for deletion
+        - Listing versions that are not the latest, older than
+          LISTING_GC_MIN_AGE_SECONDS, and unused by any dataset
 
         Returns:
             List of (DatasetRecord, version_string) tuples. Each DatasetRecord
@@ -1877,6 +1881,46 @@ class AbstractDBMetastore(AbstractMetastore):
         if job_id:
             query = query.where(dv.c.job_id == job_id)
 
+        versions = self._fetch_version_pairs(query)
+        if job_id is None:
+            versions += self._listing_versions_to_clean(LISTING_GC_MIN_AGE_SECONDS)
+        return versions
+
+    def _listing_versions_to_clean(
+        self, min_age_seconds: int
+    ) -> list[tuple[DatasetRecord, str]]:
+        from datachain.lib.listing import LISTING_PREFIX
+
+        select_cols, base_from = self._dataset_version_query_base()
+        d = self._datasets
+        dv = self._datasets_versions
+        dd = self._datasets_dependencies
+
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=min_age_seconds)
+
+        newer = dv.alias("dv_newer")
+        has_newer_version = (
+            select(newer.c.id)
+            .where(newer.c.dataset_id == dv.c.dataset_id, newer.c.id > dv.c.id)
+            .exists()
+        )
+        is_referenced = (
+            select(dd.c.id).where(dd.c.dataset_version_id == dv.c.id).exists()
+        )
+
+        query = (
+            self._datasets_select(*select_cols)
+            .select_from(base_from)
+            .where(
+                d.c.project_id == self.listing_project.id,
+                d.c.name.startswith(LISTING_PREFIX),
+                dv.c.status == DatasetStatus.COMPLETE,
+                dv.c.finished_at.isnot(None),
+                dv.c.finished_at < cutoff,
+                has_newer_version,
+                ~is_referenced,
+            )
+        )
         return self._fetch_version_pairs(query)
 
     def get_dataset_versions(

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -1258,3 +1258,22 @@ def test_keeps_last_complete_listing_when_newer_version_incomplete(
     to_clean = metastore.get_dataset_versions_to_clean()
 
     assert (ds.name, "1.0.0") not in {(d.name, v) for d, v in to_clean}
+
+
+def test_listing_prefix_is_matched_literally(metastore):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+    project = metastore.listing_project
+    # "lstXX" matches LIKE 'lst__%' only if the underscores are wildcards.
+    decoy = metastore.create_dataset(
+        "lstXX", project_id=project.id, status=DatasetStatus.COMPLETE
+    )
+    decoy, _ = metastore.create_dataset_version(
+        decoy, "1.0.0", DatasetStatus.COMPLETE, finished_at=old
+    )
+    metastore.create_dataset_version(
+        decoy, "1.0.1", DatasetStatus.COMPLETE, finished_at=old
+    )
+
+    to_clean = metastore.get_dataset_versions_to_clean()
+
+    assert not any(ds.name == "lstXX" for ds, _ in to_clean)

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -1182,3 +1182,60 @@ def test_cleanup_session_dataset_versions(
     to_clean = metastore.get_dataset_versions_to_clean()
     found = ds.name in {d.name for d, _ in to_clean}
     assert found == expected
+
+
+def _create_listing(metastore, uri, specs):
+    project = metastore.listing_project
+    dataset = metastore.create_dataset(
+        f"lst__{uri}", project_id=project.id, status=DatasetStatus.COMPLETE
+    )
+    for version, finished_at in specs:
+        dataset, _ = metastore.create_dataset_version(
+            dataset, version, DatasetStatus.COMPLETE, finished_at=finished_at
+        )
+    return metastore.get_dataset(
+        dataset.name,
+        namespace_name=project.namespace.name,
+        project_name=project.name,
+        versions=None,
+    )
+
+
+def test_get_dataset_versions_to_clean_cleans_superseded_unused_listings(metastore):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+    recent = datetime.now(timezone.utc) - timedelta(hours=1)
+
+    lst = _create_listing(
+        metastore, "s3://bkt/", [("1.0.0", old), ("1.0.1", old), ("1.0.2", old)]
+    )
+    consumer = metastore.create_dataset("consumer")
+    consumer, _ = metastore.create_dataset_version(
+        consumer, "1.0.0", DatasetStatus.COMPLETE, finished_at=old
+    )
+    consumer = metastore.get_dataset("consumer", versions=None)
+    metastore.add_dataset_dependency(consumer, "1.0.0", lst, "1.0.1")
+
+    _create_listing(metastore, "s3://bkt2/", [("1.0.0", recent), ("1.0.1", recent)])
+
+    to_clean = metastore.get_dataset_versions_to_clean()
+
+    cleaned = {(ds.name, v) for ds, v in to_clean if ds.name.startswith("lst__")}
+    assert cleaned == {(lst.name, "1.0.0")}
+
+
+def test_get_dataset_versions_to_clean_keeps_single_version_listing(metastore):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+    _create_listing(metastore, "s3://only/", [("1.0.0", old)])
+
+    to_clean = metastore.get_dataset_versions_to_clean()
+
+    assert not any(ds.name.startswith("lst__") for ds, _ in to_clean)
+
+
+def test_get_dataset_versions_to_clean_excludes_listings_when_scoped_to_job(metastore):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+    _create_listing(metastore, "s3://bkt/", [("1.0.0", old), ("1.0.1", old)])
+
+    to_clean = metastore.get_dataset_versions_to_clean(job_id=str(uuid4()))
+
+    assert not any(ds.name.startswith("lst__") for ds, _ in to_clean)

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -1239,3 +1239,22 @@ def test_get_dataset_versions_to_clean_excludes_listings_when_scoped_to_job(meta
     to_clean = metastore.get_dataset_versions_to_clean(job_id=str(uuid4()))
 
     assert not any(ds.name.startswith("lst__") for ds, _ in to_clean)
+
+
+@pytest.mark.parametrize("newer_status", [DatasetStatus.CREATED, DatasetStatus.FAILED])
+def test_keeps_last_complete_listing_when_newer_version_incomplete(
+    metastore, newer_status
+):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+    project = metastore.listing_project
+    ds = metastore.create_dataset(
+        "lst__s3://bkt/", project_id=project.id, status=DatasetStatus.COMPLETE
+    )
+    ds, _ = metastore.create_dataset_version(
+        ds, "1.0.0", DatasetStatus.COMPLETE, finished_at=old
+    )
+    metastore.create_dataset_version(ds, "1.0.1", newer_status, finished_at=old)
+
+    to_clean = metastore.get_dataset_versions_to_clean()
+
+    assert (ds.name, "1.0.0") not in {(d.name, v) for d, v in to_clean}


### PR DESCRIPTION
## Summary

`datachain gc` does not reclaim cached bucket listings. Listings are datasets named `lst__*` in the system listing project; each re-list adds a version, so old versions build up in the metastore and warehouse.

## Behavior

On a full sweep (`job_id is None`), `get_dataset_versions_to_clean` returns listing versions that are:
- COMPLETE,
- not the latest version of their listing (the latest is kept),
- older than `LISTING_GC_MIN_AGE_SECONDS` (7 days), and
- not referenced by any dataset dependency.

Per-job cleanup (`job_id` set) is unchanged. `cleanup_dataset_versions` reclaims the returned versions through the existing removal path, dropping the warehouse rows table and the metastore version. Each listing keeps at least its latest version.

## Implementation

- `LISTING_GC_MIN_AGE_SECONDS` constant.
- `AbstractDBMetastore._listing_versions_to_clean(min_age_seconds)` — selection query using correlated `EXISTS` for "has a newer version" and "is referenced", reusing `_dataset_version_query_base()` / `_fetch_version_pairs()`.
- `get_dataset_versions_to_clean` includes it when `job_id is None`.

## Tests

`tests/func/test_metastore.py`: cleans an unused non-latest old listing version; keeps the latest, a dependency-referenced version, and too-young versions; keeps single-version listings; excludes listings when scoped to a `job_id`.