### PR TITLE
Clear stale Studio default team on login and logout

### DIFF
--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -223,6 +223,8 @@ def login(args: "Namespace"):
         file_path = _save_default_team(team_names[0], level)
         print(f"Set default team to '{team_names[0]}' in {file_path}")
     else:
+        with Config(level).edit() as conf:
+            conf.get("studio", {}).pop("team", None)
         print("You can now use 'datachain auth team' to set the default team.")
     return 0
 
@@ -263,6 +265,7 @@ def logout(local: bool = False):
 
     with Config(level).edit() as conf:
         del conf["studio"]["token"]
+        conf["studio"].pop("team", None)
 
     print("Logged out from Studio. (you can log back in with 'datachain auth login')")
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -194,6 +194,38 @@ def test_studio_login_default_expiration(mocker):
     assert token == "isat_access_token"  # noqa: S105
 
 
+def test_studio_login_single_team_sets_default(mocker):
+    mocker.patch(
+        "dvc_studio_client.auth.get_access_token",
+        return_value=("token_name", "isat_access_token"),
+    )
+
+    assert main(["auth", "login", "--team", "ml-team"]) == 0
+
+    config = Config().read()
+    assert config["studio"]["team"] == "ml-team"
+
+
+def test_studio_login_clears_stale_default_team(mocker):
+    mocker.patch(
+        "dvc_studio_client.auth.get_access_token",
+        return_value=("token_name", "isat_access_token"),
+    )
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
+        conf["studio"] = {
+            "token": "old_token",
+            "url": "https://old-studio.example.com",
+            "team": "old-team",
+        }
+
+    assert main(["auth", "login", "--hostname", "https://new-studio.example.com"]) == 0
+
+    config = Config(ConfigLevel.GLOBAL).read()
+    assert config["studio"]["token"] == "isat_access_token"  # noqa: S105
+    assert config["studio"]["url"] == "https://new-studio.example.com"
+    assert "team" not in config["studio"]
+
+
 def test_studio_logout():
     with Config(ConfigLevel.GLOBAL).edit() as conf:
         conf["studio"] = {"token": "isat_access_token", "url": STUDIO_URL}
@@ -211,6 +243,26 @@ def test_studio_logout():
     assert "token" not in config["studio"]
 
     assert main(["auth", "logout"]) == 1
+
+
+def test_studio_logout_clears_default_team():
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
+        conf["studio"] = {
+            "token": "isat_access_token",
+            "url": STUDIO_URL,
+            "team": "demo-1",
+        }
+
+    with requests_mock.mock() as m:
+        m.post(
+            f"{STUDIO_URL}/api/device-logout",
+            json={"detail": "Token revoked successfully"},
+        )
+        assert main(["auth", "logout"]) == 0
+
+    config = Config(ConfigLevel.GLOBAL).read()
+    assert "token" not in config["studio"]
+    assert "team" not in config["studio"]
 
 
 def test_studio_logout_token_already_revoked(capsys):


### PR DESCRIPTION
## Problem

`datachain auth team` could report a default team belonging to a *previous* Studio instance/token:

```
$ datachain dataset ls --studio
Error: Not authorized for the team demo
```

The Studio config keeps `url`, `token`, and `team` in one flat `[studio]` table (not scoped per instance):
- `logout` deleted only `token`, leaving `team` behind.
- `login` set `team` only when exactly one `--team` was passed; otherwise it left the existing value untouched.

So after logging out of one instance and into another — or just switching instances, since `login` only blocks re-login to the *same* hostname — the old `team` survived and `datachain auth team` kept printing it.

### Repro
1. Log into Studio, default team set to `demo`.
2. `datachain auth logout`
3. `datachain auth login
4. `datachain auth team` → prints `Default team is 'demo'` (stale)

## Fix

Enforce the invariant that a stored default team always belongs to the current token:
- `login` clears `studio.team` whenever it is not setting exactly one explicit `--team` (setting a single `--team` is unchanged).
- `logout` drops `studio.team` together with `studio.token`.

The `login`-side clear is what makes instance-switching correct even without an explicit logout.

> Note: this is preventive, not retroactive — an already-stale config is cleaned on the next login/logout, or via `datachain auth team <name>`.

## Testing
- `test_studio_login_clears_stale_default_team` — instance-switch login wipes the old team
- `test_studio_logout_clears_default_team` — logout removes token + team
- `test_studio_login_single_team_sets_default` — single `--team` still sets the default
- Full `tests/test_cli_studio.py`: **53 passed**; `ruff check` / `ruff format --check` clean.

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>