### PR TITLE
Pass update_version through the delta save path

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -670,7 +670,9 @@ class DataChain:
 
         # Handle retry and delta functionality
         if not result:
-            result = self._handle_delta(name, version, project, schema, kwargs)
+            result = self._handle_delta(
+                name, version, project, schema, update_version, kwargs
+            )
 
         if not result:
             # calculate chain if we already don't have result from checkpoint or delta
@@ -841,6 +843,7 @@ class DataChain:
         version: str | None,
         project: Project,
         schema: dict,
+        update_version: str | None,
         kwargs: dict,
     ) -> "DataChain | None":
         """Try to save as a delta dataset.
@@ -872,6 +875,7 @@ class DataChain:
                     project=project,
                     feature_schema=schema,
                     dependencies=dependencies,
+                    update_version=update_version,
                     **kwargs,
                 )
             )

--- a/tests/func/test_delta.py
+++ b/tests/func/test_delta.py
@@ -106,6 +106,23 @@ def test_delta_update_from_dataset(test_session, tmp_dir, tmp_path):
     create_delta_dataset(ds_name)
 
 
+def test_delta_update_respects_update_version(test_session):
+    source_name = f"delta_uv_source_{uuid.uuid4().hex[:8]}"
+    result_name = f"delta_uv_result_{uuid.uuid4().hex[:8]}"
+
+    dc.read_values(id=[1, 2, 3], session=test_session).save(source_name)
+    dc.read_dataset(source_name, session=test_session, delta=True, delta_on="id").save(
+        result_name
+    )
+
+    dc.read_values(id=[1, 2, 3, 4], session=test_session).save(source_name)
+    res = dc.read_dataset(
+        source_name, session=test_session, delta=True, delta_on="id"
+    ).save(result_name, update_version="major")
+
+    assert res.version == "2.0.0"
+
+
 def test_delta_falls_back_when_dependency_missing(test_session, no_studio_dataset):
     catalog = test_session.catalog
 


### PR DESCRIPTION
`update_version` was silently dropped in `_handle_delta` — it's an explicit param of `DataChain.save()`, so it never lands in `**kwargs`, and delta saves always did a patch bump no matter what was passed. Now it's forwarded explicitly. Added a test that fails without the fix.

**Note**: description/attrs are dropped on the same path too, leaving that for a separate PR.