### PR TITLE
Pass description and attrs through the delta save path

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -671,7 +671,14 @@ class DataChain:
         # Handle retry and delta functionality
         if not result:
             result = self._handle_delta(
-                name, version, project, schema, update_version, kwargs
+                name,
+                version,
+                project,
+                schema,
+                description,
+                attrs,
+                update_version,
+                kwargs,
             )
 
         if not result:
@@ -843,6 +850,8 @@ class DataChain:
         version: str | None,
         project: Project,
         schema: dict,
+        description: str | None,
+        attrs: list[str] | None,
         update_version: str | None,
         kwargs: dict,
     ) -> "DataChain | None":
@@ -875,6 +884,8 @@ class DataChain:
                     project=project,
                     feature_schema=schema,
                     dependencies=dependencies,
+                    description=description,
+                    attrs=attrs,
                     update_version=update_version,
                     **kwargs,
                 )

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -671,14 +671,14 @@ class DataChain:
         # Handle retry and delta functionality
         if not result:
             result = self._handle_delta(
-                name,
-                version,
-                project,
-                schema,
-                description,
-                attrs,
-                update_version,
-                kwargs,
+                name=name,
+                version=version,
+                project=project,
+                schema=schema,
+                description=description,
+                attrs=attrs,
+                update_version=update_version,
+                kwargs=kwargs,
             )
 
         if not result:

--- a/tests/func/test_delta.py
+++ b/tests/func/test_delta.py
@@ -118,9 +118,12 @@ def test_delta_update_respects_update_version(test_session):
     dc.read_values(id=[1, 2, 3, 4], session=test_session).save(source_name)
     res = dc.read_dataset(
         source_name, session=test_session, delta=True, delta_on="id"
-    ).save(result_name, update_version="major")
+    ).save(result_name, update_version="major", description="new desc", attrs=["NLP"])
 
     assert res.version == "2.0.0"
+    dataset = test_session.catalog.get_dataset(result_name)
+    assert dataset.description == "new desc"
+    assert dataset.attrs == ["NLP"]
 
 
 def test_delta_falls_back_when_dependency_missing(test_session, no_studio_dataset):


### PR DESCRIPTION
Same bug as [#1855](https://github.com/iterative/datachain/pull/1855), next two params over: `description` and `attrs` are explicit params of `DataChain.save()`, so they never reach `**kwargs` and were silently dropped on the delta path. Now forwarded explicitly, with assertions added to the delta versioning test.

**Note**: Not sure now if it was a good idea to split those in 2 PRs 👀