### PR TITLE
Cap litellm below 1.92 to unbreak Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ dependencies = [
   "dvc-studio-client>=0.23.0,<1",
   "tabulate",
   "websockets",
-  "litellm>=1.83.0,<2",  # >=1.83 excludes the compromised 1.82.7/1.82.8 releases
+  # >=1.83 excludes the compromised 1.82.7/1.82.8 releases;
+  # <1.92 is the last pure-python release — 1.92.0 adds a Rust extension with
+  # no cp314/macOS/Windows wheels and an sdist that can't build on Python 3.14
+  "litellm>=1.83.0,<1.92",
   "tomli;python_version<'3.11'"
 ]
 


### PR DESCRIPTION
litellm 1.92.0 is the first release with a native Rust extension and ships only manylinux cp310-cp313 wheels. On Python 3.14 (all OSes) installs fall back to the sdist, which fails to build because its pinned PyO3 0.23.5 supports at most Python 3.13. Cap to 1.91.x, the last pure-python release, until upstream ships cp314 wheels or upgrades PyO3.

See this CI run for details: https://github.com/datachain-ai/datachain/actions/runs/29347557256