### PR TITLE
fix: preserve nullability of Arrow list items

### DIFF
--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -10,7 +10,11 @@ from pyarrow.dataset import CsvFileFormat, dataset
 from datachain import json
 from datachain.fs.reference import ReferenceFileSystem
 from datachain.lib.convert.flatten import classify_field, iter_flat_columns
-from datachain.lib.data_model import dict_to_data_model, optional_tag_is_absent
+from datachain.lib.data_model import (
+    NULLABLE_SCALARS,
+    dict_to_data_model,
+    optional_tag_is_absent,
+)
 from datachain.lib.file import ArrowRow, File
 from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import SignalSchema
@@ -239,7 +243,9 @@ def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa:
     if pa.types.is_string(col_type) or pa.types.is_large_string(col_type):
         return str
     if pa.types.is_list(col_type):
-        item_type = _arrow_field_type_mapper(col_type.value_field, column)
+        item_type = _arrow_field_type_mapper(
+            col_type.value_field, column, nullable_scalars_only=True
+        )
         return list[item_type]  # type: ignore[return-value, valid-type]
     if pa.types.is_struct(col_type):
         type_dict = {}
@@ -255,9 +261,15 @@ def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa:
     raise TypeError(f"{col_type!r} datatypes not supported, column: {column}")
 
 
-def _arrow_field_type_mapper(field: pa.Field, column: str = "") -> type:
+def _arrow_field_type_mapper(
+    field: pa.Field, column: str = "", *, nullable_scalars_only: bool = False
+) -> type:
     dtype = arrow_type_mapper(field.type, column)
-    if field.nullable and not ModelStore.is_pydantic(dtype):
+    if (
+        field.nullable
+        and not ModelStore.is_pydantic(dtype)
+        and (not nullable_scalars_only or dtype in NULLABLE_SCALARS)
+    ):
         return dtype | None  # type: ignore[return-value]
     return dtype
 

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -265,13 +265,14 @@ def _arrow_field_type_mapper(
     field: pa.Field, column: str = "", *, nullable_scalars_only: bool = False
 ) -> type:
     dtype = arrow_type_mapper(field.type, column)
-    if (
-        field.nullable
-        and not ModelStore.is_pydantic(dtype)
-        and (not nullable_scalars_only or dtype in NULLABLE_SCALARS)
-    ):
-        return dtype | None  # type: ignore[return-value]
-    return dtype
+    if not field.nullable:
+        return dtype
+    if nullable_scalars_only and dtype not in NULLABLE_SCALARS:
+        # https://github.com/datachain-ai/datachain/issues/1873
+        return dtype
+    if ModelStore.is_pydantic(dtype):
+        return dtype
+    return dtype | None  # type: ignore[return-value]
 
 
 def _get_hf_schema(

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -215,10 +215,7 @@ def schema_to_output(
 
     output = {}
     for field, column in zip(schema, col_names, strict=False):
-        dtype = arrow_type_mapper(field.type, column)
-        if field.nullable and not ModelStore.is_pydantic(dtype):
-            dtype = dtype | None  # type: ignore[assignment]
-        output[column] = dtype
+        output[column] = _arrow_field_type_mapper(field, column)
 
     return output, list(normalized_col_dict.values())
 
@@ -242,14 +239,12 @@ def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa:
     if pa.types.is_string(col_type) or pa.types.is_large_string(col_type):
         return str
     if pa.types.is_list(col_type):
-        return list[arrow_type_mapper(col_type.value_type)]  # type: ignore[return-value, misc]
+        item_type = _arrow_field_type_mapper(col_type.value_field)
+        return list[item_type]  # type: ignore[return-value, valid-type]
     if pa.types.is_struct(col_type):
         type_dict = {}
         for field in col_type:
-            dtype = arrow_type_mapper(field.type, field.name)
-            if field.nullable and not ModelStore.is_pydantic(dtype):
-                dtype = dtype | None  # type: ignore[assignment]
-            type_dict[field.name] = dtype
+            type_dict[field.name] = _arrow_field_type_mapper(field, field.name)
         return dict_to_data_model(f"ArrowDataModel_{column}", type_dict)
     if pa.types.is_map(col_type):
         return dict
@@ -258,6 +253,13 @@ def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa:
     if pa.types.is_null(col_type):
         return str  # use strings for null columns
     raise TypeError(f"{col_type!r} datatypes not supported, column: {column}")
+
+
+def _arrow_field_type_mapper(field: pa.Field, column: str = "") -> type:
+    dtype = arrow_type_mapper(field.type, column)
+    if field.nullable and not ModelStore.is_pydantic(dtype):
+        return dtype | None  # type: ignore[return-value]
+    return dtype
 
 
 def _get_hf_schema(

--- a/src/datachain/lib/arrow.py
+++ b/src/datachain/lib/arrow.py
@@ -239,7 +239,7 @@ def arrow_type_mapper(col_type: pa.DataType, column: str = "") -> type:  # noqa:
     if pa.types.is_string(col_type) or pa.types.is_large_string(col_type):
         return str
     if pa.types.is_list(col_type):
-        item_type = _arrow_field_type_mapper(col_type.value_field)
+        item_type = _arrow_field_type_mapper(col_type.value_field, column)
         return list[item_type]  # type: ignore[return-value, valid-type]
     if pa.types.is_struct(col_type):
         type_dict = {}

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import get_args
 
 import pandas as pd
 import pyarrow as pa
@@ -170,6 +171,13 @@ def test_arrow_type_mapper_struct():
     assert list(fields.keys()) == ["x", "y", "z"]
     dtypes = [field.annotation for field in fields.values()]
     assert dtypes == [int | None, str | None, str | None]
+
+
+def test_arrow_type_mapper_list_struct_preserves_column_name():
+    item_field = pa.field("item", pa.struct({"x": pa.int32()}), nullable=False)
+    (item_type,) = get_args(arrow_type_mapper(pa.list_(item_field), "items"))
+
+    assert item_type.__name__ == "ArrowDataModel_items"
 
 
 def test_arrow_type_error():

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -155,7 +155,8 @@ def test_arrow_generator_partitioned(tmp_path, catalog, cache):
         (pa.large_string(), str),
         (pa.map_(pa.string(), pa.int32()), dict),
         (pa.dictionary(pa.int64(), pa.string()), str),
-        (pa.list_(pa.string()), list[str]),
+        (pa.list_(pa.string()), list[str | None]),
+        (pa.list_(pa.field("item", pa.string(), nullable=False)), list[str]),
         (pa.null(), str),
     ),
 )

--- a/tests/unit/lib/test_arrow.py
+++ b/tests/unit/lib/test_arrow.py
@@ -173,11 +173,40 @@ def test_arrow_type_mapper_struct():
     assert dtypes == [int | None, str | None, str | None]
 
 
-def test_arrow_type_mapper_list_struct_preserves_column_name():
-    item_field = pa.field("item", pa.struct({"x": pa.int32()}), nullable=False)
-    (item_type,) = get_args(arrow_type_mapper(pa.list_(item_field), "items"))
+def test_arrow_type_mapper_list_struct_models_distinct_per_column():
+    users = pa.list_(pa.struct({"name": pa.string()}))
+    orders = pa.list_(pa.struct({"amount": pa.int32()}))
 
-    assert item_type.__name__ == "ArrowDataModel_items"
+    (users_model,) = get_args(arrow_type_mapper(users, "users"))
+    (orders_model,) = get_args(arrow_type_mapper(orders, "orders"))
+
+    assert users_model.__name__ != orders_model.__name__
+    assert "users" in users_model.__name__
+
+
+def test_arrow_type_mapper_nested_list_only_nullable_scalars():
+    nested = pa.list_(pa.list_(pa.string()))
+
+    assert arrow_type_mapper(nested) == list[list[str | None]]
+
+
+def test_read_parquet_multiple_struct_list_columns_roundtrip(test_session, tmp_path):
+    df = pd.DataFrame(
+        {
+            "users": [[{"name": "alice"}, {"name": "bob"}]],
+            "orders": [[{"amount": 5}]],
+        }
+    )
+    path = tmp_path / "data.parquet"
+    df.to_parquet(path)
+
+    dc.read_parquet(path.as_posix(), session=test_session).save("two_structs")
+    back = dc.read_dataset("two_structs", session=test_session)
+
+    (users,) = back.to_values("users")
+    (orders,) = back.to_values("orders")
+    assert [user.name for user in users] == ["alice", "bob"]
+    assert [order.amount for order in orders] == [5]
 
 
 def test_arrow_type_error():

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1707,6 +1707,14 @@ def test_explode(tmp_dir, test_session, column_type, column, model_name):
     assert chain.limit(1).to_values(column)[0].__class__.__name__ == model_name
 
 
+def test_explode_list_with_null_items(test_session):
+    chain = dc.read_values(
+        json=[{"email": ["user@example.com", None]}], session=test_session
+    ).explode("json")
+
+    assert chain.to_values("json_expl.email") == [["user@example.com", None]]
+
+
 def test_explode_raises_on_wrong_column_type(test_session):
     chain = dc.read_values(f1=features, session=test_session)
 


### PR DESCRIPTION
## Root cause

`arrow_type_mapper()` mapped Arrow list fields from `value_type` alone, discarding the list value field's `nullable` metadata. As a result, inferred JSON such as `["user@example.com", null]` became `list[str]`, and `DataChain.explode()` failed Pydantic validation when executing the lazy query. List-of-struct item models also lost their parent column context, producing ambiguous generated model names.

## Changes

- map Arrow fields through a shared helper that preserves field nullability
- use the list `value_field`, rather than only its data type, when mapping item types
- retain non-null item types for explicitly non-nullable Arrow value fields
- propagate nullable list items only for storage-supported scalar types, including nested lists
- derive list-of-struct model names from the parent column
- add public `DataChain.explode()` and Parquet round-trip regressions

Nullable model items and nullable nested-list items need a downstream representation decision and remain tracked in #1873.

## Tests

- `uv run pytest tests/unit/lib/test_arrow.py -q` (37 passed)
- `uv run pytest tests/unit/lib/test_datachain.py -q` (348 passed)
- `uv run pre-commit run --files src/datachain/lib/arrow.py tests/unit/lib/test_arrow.py tests/unit/lib/test_datachain.py`
- `uv run mypy src/datachain/lib/arrow.py tests/unit/lib/test_arrow.py tests/unit/lib/test_datachain.py`

Closes #1440