### PR TITLE
fix: preserve interactive sessions after exceptions

### DIFF
--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -340,6 +340,11 @@ class Session:
 
     @staticmethod
     def except_hook(exc_type, exc_value, exc_traceback):
+        if hasattr(sys, "ps1"):
+            if Session.ORIGINAL_EXCEPT_HOOK:
+                Session.ORIGINAL_EXCEPT_HOOK(exc_type, exc_value, exc_traceback)
+            return
+
         if Session.GLOBAL_SESSION_CTX:
             # Handle KeyboardInterrupt specially - mark as canceled and exit with
             # signal code

--- a/src/datachain/query/session.py
+++ b/src/datachain/query/session.py
@@ -340,9 +340,9 @@ class Session:
 
     @staticmethod
     def except_hook(exc_type, exc_value, exc_traceback):
-        if hasattr(sys, "ps1"):
-            if Session.ORIGINAL_EXCEPT_HOOK:
-                Session.ORIGINAL_EXCEPT_HOOK(exc_type, exc_value, exc_traceback)
+        if getattr(sys, "ps1", None):
+            original_hook = Session.ORIGINAL_EXCEPT_HOOK or sys.__excepthook__
+            original_hook(exc_type, exc_value, exc_traceback)
             return
 
         if Session.GLOBAL_SESSION_CTX:

--- a/tests/unit/test_job_management.py
+++ b/tests/unit/test_job_management.py
@@ -176,6 +176,34 @@ def test_except_hook_delegates_to_original(test_session, patch_argv, monkeypatch
     assert db_job.status == JobStatus.FAILED
 
 
+def test_except_hook_preserves_interactive_session(test_session, monkeypatch):
+    monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+    monkeypatch.setattr("sys.ps1", ">>> ", raising=False)
+    called = []
+    monkeypatch.setattr(
+        Session, "ORIGINAL_EXCEPT_HOOK", lambda *args: called.append(args)
+    )
+    Session.GLOBAL_SESSION_CTX = test_session
+    chain = dc.read_values(value=[1, 2], session=test_session).persist()
+    job = test_session.get_or_create_job()
+
+    try:
+        try:
+            raise AttributeError("typo")
+        except AttributeError as exc:
+            Session.except_hook(type(exc), exc, exc.__traceback__)
+
+        assert len(called) == 1
+        assert called[0][0] is AttributeError
+        assert str(called[0][1]) == "typo"
+        assert called[0][2] is not None
+        assert chain.to_values("value") == [1, 2]
+        db_job = test_session.catalog.metastore.get_job(job.id)
+        assert db_job.status == JobStatus.RUNNING
+    finally:
+        Session.GLOBAL_SESSION_CTX = None
+
+
 @pytest.mark.parametrize("use_datachain_job_id_env", [True, False])
 def test_job_is_created_after_save(test_session, monkeypatch, use_datachain_job_id_env):
     if use_datachain_job_id_env:

--- a/tests/unit/test_job_management.py
+++ b/tests/unit/test_job_management.py
@@ -148,6 +148,7 @@ def test_nested_sessions_share_same_job(test_session, patch_argv, monkeypatch):
 def test_except_hook_delegates_to_original(test_session, patch_argv, monkeypatch):
     """Test that Session.except_hook delegates to ORIGINAL_EXCEPT_HOOK."""
     monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
+    monkeypatch.setattr("sys.ps1", None, raising=False)
 
     # Set up global session for this test
     Session.GLOBAL_SESSION_CTX = test_session
@@ -202,6 +203,18 @@ def test_except_hook_preserves_interactive_session(test_session, monkeypatch):
         assert db_job.status == JobStatus.RUNNING
     finally:
         Session.GLOBAL_SESSION_CTX = None
+
+
+def test_except_hook_uses_default_hook_in_interactive_session(monkeypatch):
+    monkeypatch.setattr("sys.ps1", ">>> ", raising=False)
+    monkeypatch.setattr(Session, "ORIGINAL_EXCEPT_HOOK", None)
+    called = []
+    monkeypatch.setattr("sys.__excepthook__", lambda *args: called.append(args))
+
+    exc = AttributeError("typo")
+    Session.except_hook(type(exc), exc, exc.__traceback__)
+
+    assert called == [(AttributeError, exc, None)]
 
 
 @pytest.mark.parametrize("use_datachain_job_id_env", [True, False])


### PR DESCRIPTION
## Root cause

DataChain installs `Session.except_hook` as the process exception hook. The hook finalized the active job and removed temporary datasets for every uncaught exception. That is correct when a script terminates, but the standard Python REPL invokes the hook and then continues running. A simple typo after `.persist()` therefore deleted the persisted table while the chain was still usable, causing the next operation to fail with `TableMissingError`.

## Changes

- Detect the standard interactive interpreter through `sys.ps1`.
- Delegate interactive exceptions to the original exception hook without finalizing the job or cleaning the session.
- Add a regression that verifies the traceback hook is called, the job stays running, and persisted values remain readable.

Non-interactive exceptions keep the existing failure finalization and cleanup behavior.

## Tests

- `python -m pytest tests/unit/test_job_management.py tests/unit/test_session.py tests/func/test_session.py -q` (27 passed)
- `ruff check src/datachain/query/session.py tests/unit/test_job_management.py`
- `ruff format --check src/datachain/query/session.py tests/unit/test_job_management.py`
- `mypy src/datachain/query/session.py tests/unit/test_job_management.py`
- Real `python -i` smoke test: an uncaught missing-method `AttributeError` is displayed and the persisted chain still returns `[1, 2]`
- `git diff --check`

Closes #1157