### PR TITLE
build: exclude sdist-only numkong 7.7.1 on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ remote = [
 ]
 vector = [
   "usearch",
-  # sdist-only numkong release breaks macOS install; unpin per #1874
+  # Temporary macOS workaround: exclude sdist-only numkong 7.7.1; remove per #1874
   "numkong!=7.7.1 ; sys_platform == 'darwin'"
 ]
 hf = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,9 @@ remote = [
   "requests>=2.22.0"
 ]
 vector = [
-  "usearch"
+  "usearch",
+  # sdist-only numkong release breaks macOS install; unpin per #1874
+  "numkong!=7.7.1 ; sys_platform == 'darwin'"
 ]
 hf = [
   "numba>=0.60.0",


### PR DESCRIPTION
## Problem

macOS CI fails for every PR since 2026-07-21 ~21:20 UTC: `numkong` 7.7.1 (transitive: `usearch` → `numkong`, unbounded) hit PyPI **sdist-only** — the upstream wheel pipeline [failed mid-release](https://github.com/ashvardanian/NumKong/actions/workflows/release-python.yml). The sdist needs OpenMP; Apple clang has no `omp.h`:

```
python/distance.c:17:10: fatal error: 'omp.h' file not found
nox > Session tests-3.10 failed.
```

Example failing jobs (on #1860, unrelated to its changes): [macos 3.10](https://github.com/datachain-ai/datachain/actions/runs/29873356872/job/88778612605), [macos 3.14](https://github.com/datachain-ai/datachain/actions/runs/29873356872/job/88778612580).

## Change

Add `numkong!=7.7.1 ; sys_platform == 'darwin'` to the `vector` extra. Resolution verified: falls back to `numkong==7.7.0` (14 macOS wheels) with `usearch==2.26.0` unchanged. Also fixes `pip install 'datachain[vector]'` for macOS users, not just CI.

Temporary — removal tracked in #1874 (upstream ships wheel matrices regularly and fixed a similar publishing failure within days: ashvardanian/NumKong#359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)