### PR TITLE
fix: stabilize HF llm-eval example and flaky interactive-session test

### DIFF
--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -33,7 +33,7 @@ def eval_dialog(
 ) -> DialogEval:
     try:
         completion = client.chat_completion(
-            model="Qwen/Qwen2.5-7B-Instruct",
+            model="openai/gpt-oss-20b",
             messages=[
                 {
                     "role": "user",
@@ -64,7 +64,8 @@ def eval_dialog(
         "hf://datasets/infinite-dataset-hub/MobilePlanAssistant/data.csv", source=False
     )
     .settings(parallel=True)
-    .setup(client=lambda: InferenceClient(api_key=HF_TOKEN))
+    # Pin the provider: auto-routing may pick one that ignores json_schema.
+    .setup(client=lambda: InferenceClient(api_key=HF_TOKEN, provider="together"))
     .map(response=eval_dialog)
     .to_parquet("hf://datasets/dvcorg/test-datachain-llm-eval/data.parquet")
 )

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -75,7 +75,8 @@ result = dc.read_parquet(
 errors = result.filter(dc.C("response.result") == "Error")
 
 if result.count() == errors.count():
-    errors.show(3)
+    for (reason,) in errors.limit(3).to_iter("response.reason"):
+        print(reason)
     raise RuntimeError("All Hugging Face inference requests failed.")
 
 # Read it back to filter and show.

--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -64,7 +64,6 @@ def eval_dialog(
         "hf://datasets/infinite-dataset-hub/MobilePlanAssistant/data.csv", source=False
     )
     .settings(parallel=True)
-    # Pin the provider: auto-routing may pick one that ignores json_schema.
     .setup(client=lambda: InferenceClient(api_key=HF_TOKEN, provider="together"))
     .map(response=eval_dialog)
     .to_parquet("hf://datasets/dvcorg/test-datachain-llm-eval/data.parquet")

--- a/tests/unit/test_job_management.py
+++ b/tests/unit/test_job_management.py
@@ -198,7 +198,7 @@ def test_except_hook_preserves_interactive_session(test_session, monkeypatch):
         assert called[0][0] is AttributeError
         assert str(called[0][1]) == "typo"
         assert called[0][2] is not None
-        assert chain.to_values("value") == [1, 2]
+        assert sorted(chain.to_values("value")) == [1, 2]
         db_job = test_session.catalog.metastore.get_job(job.id)
         assert db_job.status == JobStatus.RUNNING
     finally:


### PR DESCRIPTION
Stabilizes CI around the `hf-dataset-llm-eval.py` example and a flaky Studio test.

## Changes

- **Print full HF error reasons before failing** (`hf-dataset-llm-eval.py`): `errors.show(3)` truncates cells to pandas' 50-char `max_colwidth`, so CI logs showed only `(Request ID: Root=...` — hiding the HTTP status/message needed to diagnose failures. Print the complete `response.reason` strings instead. (This immediately paid off: it surfaced the two real causes below.)
- **Pin the example to `openai/gpt-oss-20b` on `together`**: the previous `Qwen/Qwen2.5-7B-Instruct` lost its last default-enabled provider when Together dropped its `-Turbo` deployment (`model_not_supported`). Auto-routing is also unreliable for structured output — some providers silently ignore `json_schema`. `gpt-oss-20b` is live on 8 providers and Together enforces the schema (verified through `InferenceClient`).
- **Fix order-dependent assertion** in `test_except_hook_preserves_interactive_session`: `to_values` without `order_by` has no guaranteed row order; the test flaked on Studio warehouse backends (`[2, 1] != [1, 2]`).

## Timeline of the CI failures this untangles

1. Jul 22 ~01:00 UTC: HF account depleted its monthly Inference Providers credits → every request 402 → `llm_and_nlp` red on main (message was truncated in logs).
2. Jul 22: credits purchased; meanwhile Together's Qwen2.5-7B-Turbo deployment went to `status: error` → 400 `model_not_supported`.
3. Studio shards: one genuine ordering flake (above); sibling shards were fail-fast cancellations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
