### PR TITLE
ci: stabilize example and import-time tests

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,8 +25,25 @@ computer_vision_examples = sorted(
     ]
 )
 
+# API keys are unavailable on fork, Dependabot and Copilot PRs — skip instead
+# of failing there.
+required_env_vars = {
+    "claude-query.py": ("ANTHROPIC_API_KEY",),
+    "dc-llm-query.py": ("ANTHROPIC_API_KEY",),
+    "dc-llm-functions.py": ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"),
+    "hf-dataset-llm-eval.py": ("HF_TOKEN",),
+    "openai_image_desc_lib.py": ("OPENAI_API_KEY",),
+}
+
 
 def smoke_test(example: str, env: dict | None = None):
+    missing = [
+        var
+        for var in required_env_vars.get(os.path.basename(example), ())
+        if not os.environ.get(var)
+    ]
+    if missing:
+        pytest.skip(f"requires {', '.join(missing)}")
     try:
         completed_process = subprocess.run(  # noqa: S603
             [sys.executable, example],

--- a/tests/test_import_time.py
+++ b/tests/test_import_time.py
@@ -10,7 +10,7 @@ import datachain as dc
 logger = logging.getLogger(__name__)
 
 MAX_ATTEMPTS = 3
-MAX_IMPORT_TIME_MS = 800
+MAX_IMPORT_TIME_MS = 1000
 
 lazy_modules = [
     "adlfs",


### PR DESCRIPTION
## Context

14 of the last 40 Tests runs failed. A sweep of the failure logs found **zero genuine branch-caused failures** — every red run traces to one of four environmental causes:

1. **Missing secrets on fork/Dependabot/Copilot PRs** (the dominant one — 13/14 failing runs). Five examples hard-require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `HF_TOKEN`; such PR runs never receive repo secrets, so the `llm_and_nlp` and `multimodal` example jobs fail deterministically there (e.g. `openai_image_desc_lib.py` exits 1 with "This example requires an OpenAI API key").
2. **`test_import_time` timing flake**: min-of-3 import time lands at 805–812ms against an 800ms budget on `ubuntu-latest-8-cores`, observed on three unrelated branches.
3. `numkong 7.7.1` sdist build breakage on macOS — already fixed by #1875.
4. A transient HF Inference Providers outage (2026-07-22 ~00:30–03:30 UTC) — external, resolved on rerun; log visibility for the next occurrence is improved by #1879.

## Changes

- **Skip API-key-dependent examples when the key is absent** (`tests/examples/test_examples.py`): maps each example to its required env vars and `pytest.skip`s when unset/empty. Runs with secrets still exercise everything; secretless runs now go green with explicit skips instead of failing.
- **Bump import-time budget 800ms → 1000ms** (`tests/test_import_time.py`): removes the ~1% headroom flake. The `lazy_modules` assertions still catch eager imports of heavy dependencies, which is where real regressions come from.

## Verification

- `pytest tests/examples -m llm_and_nlp` with no keys in env: `4 skipped` (was 4 failures), with per-test skip reasons naming the missing variable.
- `pytest tests/test_import_time.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
