### PR TITLE
fix: ignore tombstoned dep referrers in listing GC

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -2012,8 +2012,29 @@ class AbstractDBMetastore(AbstractMetastore):
             )
             .exists()
         )
+        # Ignore dependency rows whose referrer is a tombstone
+        # (REMOVING/REMOVED). Tombstoned datasets keep their dep rows so their
+        # lineage stays intact, but they must not pin listings from GC.
+        src_dv = dv.alias("dv_src")
         is_referenced = (
-            select(dd.c.id).where(dd.c.dataset_version_id == dv.c.id).exists()
+            select(dd.c.id)
+            .select_from(
+                dd.join(
+                    src_dv,
+                    src_dv.c.id == dd.c.source_dataset_version_id,
+                    isouter=True,
+                )
+            )
+            .where(
+                dd.c.dataset_version_id == dv.c.id,
+                or_(
+                    src_dv.c.status.is_(None),
+                    src_dv.c.status.notin_(
+                        [DatasetStatus.REMOVING, DatasetStatus.REMOVED]
+                    ),
+                ),
+            )
+            .exists()
         )
 
         query = (

--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -1223,6 +1223,68 @@ def test_get_dataset_versions_to_clean_cleans_superseded_unused_listings(metasto
     assert cleaned == {(lst.name, "1.0.0")}
 
 
+@pytest.mark.parametrize(
+    "referrer_status", [DatasetStatus.REMOVED, DatasetStatus.REMOVING]
+)
+def test_get_dataset_versions_to_clean_ignores_tombstoned_referrers(
+    metastore, referrer_status
+):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+
+    lst = _create_listing(
+        metastore, "s3://bkt/", [("1.0.0", old), ("1.0.1", old), ("1.0.2", old)]
+    )
+    consumer = metastore.create_dataset("consumer")
+    consumer, _ = metastore.create_dataset_version(
+        consumer, "1.0.0", DatasetStatus.COMPLETE, finished_at=old
+    )
+    consumer = metastore.get_dataset("consumer", versions=None)
+    metastore.add_dataset_dependency(consumer, "1.0.0", lst, "1.0.1")
+
+    dv = metastore._datasets_versions
+    metastore.db.execute(
+        dv.update().where(dv.c.dataset_id == consumer.id).values(status=referrer_status)
+    )
+
+    to_clean = metastore.get_dataset_versions_to_clean()
+
+    cleaned = {(ds.name, v) for ds, v in to_clean if ds.name.startswith("lst__")}
+    assert cleaned == {(lst.name, "1.0.0"), (lst.name, "1.0.1")}
+
+
+def test_get_dataset_versions_to_clean_keeps_listing_with_live_referrer(metastore):
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+
+    lst = _create_listing(
+        metastore, "s3://bkt/", [("1.0.0", old), ("1.0.1", old), ("1.0.2", old)]
+    )
+    live = metastore.create_dataset("live_consumer")
+    live, _ = metastore.create_dataset_version(
+        live, "1.0.0", DatasetStatus.COMPLETE, finished_at=old
+    )
+    live = metastore.get_dataset("live_consumer", versions=None)
+    metastore.add_dataset_dependency(live, "1.0.0", lst, "1.0.1")
+
+    dead = metastore.create_dataset("dead_consumer")
+    dead, _ = metastore.create_dataset_version(
+        dead, "1.0.0", DatasetStatus.COMPLETE, finished_at=old
+    )
+    dead = metastore.get_dataset("dead_consumer", versions=None)
+    metastore.add_dataset_dependency(dead, "1.0.0", lst, "1.0.1")
+
+    dv = metastore._datasets_versions
+    metastore.db.execute(
+        dv.update()
+        .where(dv.c.dataset_id == dead.id)
+        .values(status=DatasetStatus.REMOVED)
+    )
+
+    to_clean = metastore.get_dataset_versions_to_clean()
+
+    cleaned = {(ds.name, v) for ds, v in to_clean if ds.name.startswith("lst__")}
+    assert cleaned == {(lst.name, "1.0.0")}
+
+
 def test_get_dataset_versions_to_clean_keeps_single_version_listing(metastore):
     old = datetime.now(timezone.utc) - timedelta(days=10)
     _create_listing(metastore, "s3://only/", [("1.0.0", old)])


### PR DESCRIPTION
Closes #1878.

- `_listing_versions_to_clean` treated any `datasets_dependencies` row as a live reference, so tombstoned datasets kept listings pinned forever.
- Now the referrer check skips rows whose source version is `REMOVING` or `REMOVED`.
- Added tests covering both statuses, plus a mixed case where a live consumer still pins the listing.