### PR TITLE
feat(metastore): include REMOVING when include_removed

### DIFF
--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -398,8 +398,7 @@ class AbstractMetastore(ABC, Serializable):
     ) -> Iterator[DatasetListRecord]:
         """Lists all datasets in some project or in all projects.
 
-        When ``include_removed=True`` also returns finalized REMOVED
-        tombstones (used by ``dataset ls --include-removed``).
+        When ``include_removed=True`` also returns REMOVING and REMOVED tombstones.
         """
 
     @abstractmethod
@@ -1631,7 +1630,7 @@ class AbstractDBMetastore(AbstractMetastore):
             if not include_incomplete:
                 allowed = [DatasetStatus.COMPLETE]
                 if include_removed:
-                    allowed.append(DatasetStatus.REMOVED)
+                    allowed.extend((DatasetStatus.REMOVING, DatasetStatus.REMOVED))
                 query = query.where(
                     select(literal(1))
                     .where(
@@ -1661,11 +1660,10 @@ class AbstractDBMetastore(AbstractMetastore):
         # Build join condition with status filter
         join_condition = d.c.id == dv.c.dataset_id
         if not include_incomplete:
-            # COMPLETE by default (hide CREATED/FAILED); include finalized
-            # REMOVED tombstones when explicitly requested.
+            # COMPLETE by default; REMOVING/REMOVED when include_removed.
             allowed = [DatasetStatus.COMPLETE]
             if include_removed:
-                allowed.append(DatasetStatus.REMOVED)
+                allowed.extend((DatasetStatus.REMOVING, DatasetStatus.REMOVED))
             join_condition = and_(join_condition, dv.c.status.in_(allowed))
 
         j = (

--- a/src/datachain/lib/dc/datasets.py
+++ b/src/datachain/lib/dc/datasets.py
@@ -263,7 +263,8 @@ def datasets(
             attribute without value e.g "NLP", or attribute with value
             e.g "location=US". Attribute with value can also accept "*" to target
             all that have specific name e.g "location=*"
-        include_removed: If True, also lists REMOVED tombstones. Defaults to False.
+        include_removed: If True, also lists REMOVING and REMOVED versions.
+            Defaults to False.
 
     Returns:
         DataChain: A new DataChain instance containing dataset information.

--- a/tests/unit/test_metastore.py
+++ b/tests/unit/test_metastore.py
@@ -242,13 +242,62 @@ def test_list_datasets_include_removed(metastore):
     assert versions[1].is_removed
 
 
-def test_list_datasets_include_removed_only_tombstones(metastore):
-    """A dataset with only tombstoned versions still appears when
-    include_removed is True."""
+def test_list_datasets_include_removed_includes_removing_excludes_failed(metastore):
+    ds = metastore.create_dataset("list-with-removing")
+    metastore.create_dataset_version(ds, "1.0.0", DatasetStatus.COMPLETE)
+    metastore.create_dataset_version(ds, "1.0.1", DatasetStatus.REMOVING)
+    metastore.create_dataset_version(ds, "1.0.2", DatasetStatus.FAILED)
+
+    default = {d.name: d for d in metastore.list_datasets()}
+    assert [v.version for v in default["list-with-removing"].versions] == ["1.0.0"]
+
+    results = {d.name: d for d in metastore.list_datasets(include_removed=True)}
+    versions = results["list-with-removing"].all_versions
+    assert [v.version for v in versions] == ["1.0.0", "1.0.1"]
+    assert versions[1].status == DatasetStatus.REMOVING
+    assert versions[1].is_removed
+
+
+def test_get_dataset_include_removed_includes_removing(metastore):
+    ds = metastore.create_dataset("get-with-removing")
+    metastore.create_dataset_version(ds, "1.0.0", DatasetStatus.COMPLETE)
+    metastore.create_dataset_version(ds, "1.0.1", DatasetStatus.REMOVING)
+
+    default = metastore.get_dataset(
+        "get-with-removing", versions=None, include_incomplete=False
+    )
+    assert [v.version for v in default.versions] == ["1.0.0"]
+
+    with_tombstones = metastore.get_dataset(
+        "get-with-removing",
+        versions=None,
+        include_incomplete=False,
+        include_removed=True,
+    )
+    versions = with_tombstones.all_versions
+    assert [v.version for v in versions] == ["1.0.0", "1.0.1"]
+    assert versions[1].status == DatasetStatus.REMOVING
+
+
+def test_list_datasets_include_removed_lists_dataset_with_only_removed_versions(
+    metastore,
+):
     ds = metastore.create_dataset("tombstoned-only")
     metastore.create_dataset_version(ds, "1.0.0", DatasetStatus.REMOVED)
 
     assert "tombstoned-only" not in {d.name for d in metastore.list_datasets()}
     assert "tombstoned-only" in {
+        d.name for d in metastore.list_datasets(include_removed=True)
+    }
+
+
+def test_list_datasets_include_removed_lists_dataset_with_only_removing_versions(
+    metastore,
+):
+    ds = metastore.create_dataset("removing-only")
+    metastore.create_dataset_version(ds, "1.0.0", DatasetStatus.REMOVING)
+
+    assert "removing-only" not in {d.name for d in metastore.list_datasets()}
+    assert "removing-only" in {
         d.name for d in metastore.list_datasets(include_removed=True)
     }


### PR DESCRIPTION
## Summary

`include_removed=True` previously returned only finalized `REMOVED` tombstones and skipped in-flight `REMOVING` versions. This aligns the metastore allow-list so catalog/`dataset ls --include-removed` surfaces both tombstone states (`COMPLETE` + `REMOVING` + `REMOVED`), matching Studio soft-delete UX that needs to see deletions in progress.

## Details

- Extend `_get_dataset_query` / list-datasets status filter to allow `REMOVING` alongside `REMOVED` when `include_removed=True`
- Update docs/docstrings for `list_datasets` and `datasets(include_removed=...)`
- Tests: `get_dataset` / `list_datasets` include `REMOVING`, still exclude `FAILED`; datasets with only `REMOVING` versions appear when the flag is set

## Testing

- [x] Unit tests in `tests/unit/test_metastore.py` for include_removed + REMOVING
- [x] `pytest tests/unit/test_metastore.py -k include_removed`

## Related

- Related to [datachain-ai/studio#13051](https://github.com/datachain-ai/studio/issues/13051)
- Complements Studio BE soft-delete / `includeRemoved` work (https://github.com/datachain-ai/studio/pull/13082)

Note: No Studio BE change — keeps DataChain metastore consistent with the shared tombstone statuses (REMOVING + REMOVED).