### PR TITLE
fix: cap max_tokens in HF llm-eval example

### DIFF
--- a/examples/llm_and_nlp/hf-dataset-llm-eval.py
+++ b/examples/llm_and_nlp/hf-dataset-llm-eval.py
@@ -34,6 +34,7 @@ def eval_dialog(
     try:
         completion = client.chat_completion(
             model="openai/gpt-oss-20b",
+            max_tokens=512,
             messages=[
                 {
                     "role": "user",


### PR DESCRIPTION
Follow-up to #1879. The HF billing dashboard showed the pinned `openai/gpt-oss-20b` costing ~$9 for ~1k requests (~80x the old Qwen per-request cost), while a normal response is only ~150 tokens. Since billing is token-based, that means CI requests averaged ~45k output tokens: with no `max_tokens` set, some rows send the reasoning model into runaway generation up to the provider default.

Cap `max_tokens` at 512 — typical responses need ~150, and the worst case per 100-row run drops from ~$1 to ~$0.01. Verified through `InferenceClient` on a real dataset row (136 completion tokens, valid schema output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
