### PR TITLE
Support account in az:// URIs (az://container@account/...)

### DIFF
--- a/docs/guide/remotes.md
+++ b/docs/guide/remotes.md
@@ -244,6 +244,14 @@ DataChain uses [gcsfs](https://gcsfs.readthedocs.io/en/latest/) to interact with
 
 DataChain uses [adlfs](https://fsspec.github.io/adlfs/) to interact with Azure Blob Storage. Authentication can be achieved by using any of the method described at [adlfs documentation](https://github.com/fsspec/adlfs?tab=readme-ov-file#setting-credentials). You can also pass the following configuration parameters to the adlfs filesystem as client_config dictionary.
 
+An `az://` URI names only the container, so the storage account has to be provided separately (`account_name`, `AZURE_STORAGE_ACCOUNT_NAME`, or a connection string) — unless it is embedded in the URI itself:
+
+```
+az://container-name@account-name/path/to/data
+```
+
+The embedded account takes precedence over `account_name` from the client config, so URIs pointing to different storage accounts can be mixed in a single run. Note that account keys, SAS tokens, and connection strings are account-specific — mixing accounts requires credentials valid for each account (e.g. Azure AD or anonymous access), and a connection string configured for a different account than the URI names raises an error.
+
 - `account_name`: `str` (default: `None`)
 
     The storage account name. This is used to authenticate requests

--- a/src/datachain/client/__init__.py
+++ b/src/datachain/client/__init__.py
@@ -7,8 +7,9 @@ def bucket_status(uri: str, **client_config) -> BucketStatus:
     Args:
         uri: Bucket URI, e.g. "s3://my-bucket/", "gs://my-bucket/", "az://my-container/"
         **client_config: Storage client configuration (aws_key, etc.)
-            For Azure, pass ``account_name`` to enable anonymous access detection;
-            without it, only authenticated access is probed.
+            For Azure, the storage account is needed to enable anonymous access
+            detection; embed it in the URI ("az://container@account/") or pass
+            ``account_name``. Without it, only authenticated access is probed.
 
     Returns:
         BucketStatus(exists, access) where access is one of:

--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -84,8 +84,6 @@ class AzureClient(Client):
     )
 
     def __init__(self, name: str, fs_kwargs: dict[str, Any], cache: "Cache") -> None:
-        # An az:// netloc is "container" or "container@account"; the account,
-        # when present, overrides any account_name from fs kwargs.
         netloc = name.split("/", 1)[0]
         self.container, _, account = netloc.partition("@")
         if account:

--- a/src/datachain/client/azure.py
+++ b/src/datachain/client/azure.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -11,6 +12,7 @@ from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
 )
+from azure.core.utils import parse_connection_string
 from azure.storage.blob import BlobServiceClient
 from fsspec.asyn import get_loop, sync
 
@@ -20,7 +22,31 @@ from datachain.progress import tqdm
 from .fsspec import DELIMITER, BucketStatus, Client, ResultQueue
 
 if TYPE_CHECKING:
+    from datachain.cache import Cache
     from datachain.client.writeconfig import WriteConfig
+    from datachain.dataset import StorageURI
+
+
+def _reject_connection_string_mismatch(account: str, kwargs: dict[str, Any]) -> None:
+    # adlfs gives a connection string precedence over account_name, which
+    # would silently route the URI's account to the connection string's one.
+    conn = kwargs.get("connection_string") or os.getenv(
+        "AZURE_STORAGE_CONNECTION_STRING"
+    )
+    if not conn:
+        return
+    try:
+        conn_account = parse_connection_string(conn, case_sensitive_keys=False).get(
+            "accountname"
+        )
+    except ValueError:
+        return
+    if conn_account and conn_account != account:
+        raise ValueError(
+            f"Azure account '{account}' from the URI conflicts with the"
+            f" configured connection string for account '{conn_account}'"
+        )
+
 
 # Streams larger than this spill to disk while being buffered for upload_blob;
 # smaller ones stay in memory.
@@ -57,8 +83,29 @@ class AzureClient(Client):
         }
     )
 
+    def __init__(self, name: str, fs_kwargs: dict[str, Any], cache: "Cache") -> None:
+        # An az:// netloc is "container" or "container@account"; the account,
+        # when present, overrides any account_name from fs kwargs.
+        netloc = name.split("/", 1)[0]
+        self.container, _, account = netloc.partition("@")
+        if account:
+            _reject_connection_string_mismatch(account, fs_kwargs)
+            fs_kwargs = {**fs_kwargs, "account_name": account}
+        super().__init__(name, fs_kwargs, cache)
+
+    @classmethod
+    def from_source(cls, uri: "StorageURI", cache: "Cache", **kwargs) -> "AzureClient":
+        # adlfs._strip_protocol drops the "@account" part, so strip the
+        # protocol manually to keep the account in the client name.
+        return cls(uri[len(cls.PREFIX) :].rstrip("/"), kwargs, cache)
+
     @classmethod
     def bucket_status(cls, name: str, **kwargs) -> BucketStatus:
+        container, _, account = name.partition("@")
+        if account:
+            _reject_connection_string_mismatch(account, kwargs)
+            kwargs = {**kwargs, "account_name": account}
+
         # Step 1: Anonymous probe — uses BlobServiceClient directly (not adlfs)
         # to avoid picking up credentials from environment variables like
         # AZURE_STORAGE_CONNECTION_STRING.
@@ -67,7 +114,7 @@ class AzureClient(Client):
             try:
                 url = f"https://{account_name}.blob.core.windows.net"
                 anon_client = BlobServiceClient(account_url=url)
-                anon_client.get_container_client(name).get_container_properties()
+                anon_client.get_container_client(container).get_container_properties()
                 return BucketStatus(exists=True, access="anonymous")
             except ClientAuthenticationError:
                 pass
@@ -75,7 +122,7 @@ class AzureClient(Client):
                 return BucketStatus(
                     exists=False,
                     access="denied",
-                    error=f"Azure container '{name}' not found",
+                    error=f"Azure container '{container}' not found",
                 )
             except HttpResponseError as e:
                 if e.status_code not in (401, 403):
@@ -84,20 +131,20 @@ class AzureClient(Client):
         # Step 2: Authenticated probe.
         try:
             auth_fs = cls.create_fs(**kwargs)
-            sync(get_loop(), auth_fs._info, name)
+            sync(get_loop(), auth_fs._info, container)
             return BucketStatus(exists=True, access="authenticated")
         except (PermissionError, ClientAuthenticationError):
             return BucketStatus(
                 exists=True,
                 access="denied",
-                error=f"Access denied to Azure container '{name}'"
+                error=f"Access denied to Azure container '{container}'"
                 " — check credentials/configuration",
             )
         except FileNotFoundError:
             return BucketStatus(
                 exists=False,
                 access="denied",
-                error=f"Azure container '{name}' not found",
+                error=f"Azure container '{container}' not found",
             )
         except ValueError as e:
             return BucketStatus(exists=False, access="denied", error=str(e))
@@ -260,7 +307,7 @@ class AzureClient(Client):
         try:
             with tqdm(desc=f"Listing {self.uri}", unit=" objects", leave=False) as pbar:
                 async with self.fs.service_client.get_container_client(
-                    container=self.name
+                    container=self.container
                 ) as container_client:
                     async for page in container_client.list_blobs(
                         include=["metadata", "versions"], name_starts_with=prefix

--- a/src/datachain/skill/knowledge/SKILL.md
+++ b/src/datachain/skill/knowledge/SKILL.md
@@ -131,7 +131,7 @@ to this skill.
 
 When any storage URI is encountered, enlist the whole bucket first.
 
-1. **Extract bucket root.** From any URI, derive `{scheme}://{bucket}/`.
+1. **Extract bucket root.** From any URI, derive `{scheme}://{bucket}/`. For Azure, keep the storage account in the URI (`az://container@account/`); without it, the account must come from the environment (`AZURE_STORAGE_ACCOUNT_NAME`, connection string) and anonymous-access detection and file links may be unavailable.
 2. **Check if already enlisted.** Look for `dc-knowledge/buckets/{scheme}/{bucket_slug}.md` or `.json`. If either exists, skip.
 3. **Access check.** Run `datachain bucket status {root_uri}`. If denied / not found, stop and ask.
 4. **Scan with timeout.** Default 60s; user can override:
@@ -139,7 +139,7 @@ When any storage URI is encountered, enlist the whole bucket first.
    python3 {skill_dir}/scripts/bucket_scan.py {root_uri} \
      --output dc-knowledge/buckets/{scheme}/{bucket_slug}.json --timeout 60
    ```
-5. **Handle timeout** (exit code 124). Run the hierarchical fallback:
+5. **Handle timeout** (exit code 124). Run the hierarchical fallback (add `--anon` if the access check reported anonymous):
    ```bash
    python3 {skill_dir}/scripts/bucket_overview.py {root_uri} \
      --bucket-json dc-knowledge/buckets/{scheme}/{bucket_slug}.json

--- a/src/datachain/skill/knowledge/scripts/bucket_overview.py
+++ b/src/datachain/skill/knowledge/scripts/bucket_overview.py
@@ -32,6 +32,10 @@ def _open(uri: str, anon: bool):
         kw: dict[str, str | bool] = {}
         if anon:
             kw = {"token": "anon"} if scheme == "gs" else {"anon": True}
+        if scheme == "az":
+            account = urlparse(uri).netloc.partition("@")[2]
+            if account:
+                kw["account_name"] = account
         return fsspec.filesystem(scheme, **kw), path, scheme
     raw = uri.removeprefix("file://") if scheme == "file" else uri
     return (
@@ -65,7 +69,9 @@ def _make_file(scheme: str, netloc: str, entry: dict):
 
     name = entry["name"]
     if scheme in REMOTE:
-        path = name.removeprefix(netloc + "/") if netloc else name
+        # adlfs names entries by bare container, without the "@account" part.
+        prefix = netloc.partition("@")[0] if scheme == "az" else netloc
+        path = name.removeprefix(prefix + "/") if prefix else name
         source = f"{scheme}://{netloc}/" if netloc else f"{scheme}://"
     else:
         path = name
@@ -82,7 +88,11 @@ def bucket_overview(
     netloc = urlparse(uri).netloc if scheme in REMOTE else ""
     files = [_make_file(scheme, netloc, e) for e in _sample(fs, root, limit)]
     name = name or f"overview_{_slug(uri)}_{int(time.time())}"
-    return dc.read_values(file=files).save(name)
+    session = None
+    if anon and scheme in REMOTE:
+        # Keep the saved File rows readable during later enrichment.
+        session = dc.Session.get(client_config={"anon": True})
+    return dc.read_values(file=files, session=session).save(name)
 
 
 def _to_bucket_json(ds, uri: str, anon: bool, dataset_name: str, output: str) -> None:

--- a/src/datachain/skill/knowledge/scripts/utils.py
+++ b/src/datachain/skill/knowledge/scripts/utils.py
@@ -464,8 +464,7 @@ def source_to_https(source: str) -> str | None:
     if scheme == "gs":
         return f"https://storage.googleapis.com/{bucket}"
     if scheme == "az":
-        # Azure needs account + container in the URL; the account comes from
-        # the container@account netloc or the environment.
+        # Azure needs account + container in the URL.
         container, _, account = bucket.partition("@")
         account = account or os.environ.get("AZURE_STORAGE_ACCOUNT_NAME", "")
         if container and account:

--- a/src/datachain/skill/knowledge/scripts/utils.py
+++ b/src/datachain/skill/knowledge/scripts/utils.py
@@ -451,9 +451,9 @@ def source_to_https(source: str) -> str | None:
     Returns None for local paths or unrecognized schemes.
 
     Examples:
-        s3://my-bucket/prefix/  -> https://my-bucket.s3.amazonaws.com
-        gs://demo/data/         -> https://storage.googleapis.com/demo
-        az://acct/container/    -> https://acct.blob.core.windows.net/container
+        s3://my-bucket/prefix/       -> https://my-bucket.s3.amazonaws.com
+        gs://demo/data/              -> https://storage.googleapis.com/demo
+        az://container@acct/prefix/  -> https://acct.blob.core.windows.net/container
     """
     parts = parse_uri(source)
     scheme = parts["scheme"]
@@ -464,11 +464,11 @@ def source_to_https(source: str) -> str | None:
     if scheme == "gs":
         return f"https://storage.googleapis.com/{bucket}"
     if scheme == "az":
-        # az://account/container/... -> bucket=account, prefix=container/...
-        # Azure needs account + container in the URL
-        prefix = parts["prefix"].rstrip("/")
-        container = prefix.split("/", 1)[0] if prefix else None
-        if container:
-            return f"https://{bucket}.blob.core.windows.net/{container}"
+        # Azure needs account + container in the URL; the account comes from
+        # the container@account netloc or the environment.
+        container, _, account = bucket.partition("@")
+        account = account or os.environ.get("AZURE_STORAGE_ACCOUNT_NAME", "")
+        if container and account:
+            return f"https://{account}.blob.core.windows.net/{container}"
         return None
     return None

--- a/tests/func/test_client.py
+++ b/tests/func/test_client.py
@@ -76,6 +76,22 @@ def test_scandir_alternate(client):
     match_entries(results, ENTRIES)
 
 
+@pytest.mark.parametrize("cloud_type", ["azure"], indirect=True)
+def test_scandir_azure_account_in_uri(cloud_server, cloud_server_credentials):
+    conn_str = cloud_server.client_config["connection_string"]
+    account = dict(p.split("=", 1) for p in conn_str.split(";") if p)["AccountName"]
+    uri = f"{cloud_server.src_uri}@{account}"
+
+    client = Client.get_implementation(uri).from_source(
+        uri, cache=None, **cloud_server.client_config
+    )
+
+    assert client.fs_kwargs["account_name"] == account
+    results = scandir(client, "")
+    match_entries(results, ENTRIES)
+    assert all(e.source == uri for e in results)
+
+
 def test_gcs_client_gets_credentials_from_env(monkeypatch, mocker):
     from datachain.client.gcs import GCSClient
 

--- a/tests/unit/test_client_azure.py
+++ b/tests/unit/test_client_azure.py
@@ -8,8 +8,16 @@ from fsspec.asyn import sync
 from fsspec.callbacks import DEFAULT_CALLBACK
 
 from datachain.asyn import get_loop
+from datachain.client import Client
 from datachain.client.azure import AzureClient
+from datachain.dataset import StorageURI
 from datachain.lib.file import File
+
+
+@pytest.fixture(autouse=True)
+def _no_env_connection_string(monkeypatch):
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+
 
 _FAKE_SAS = "https://account.blob.core.windows.net/mycontainer/blob.txt?sv=x&sig=y"
 _VER = "ver-abc-123"
@@ -28,6 +36,107 @@ def _make_client() -> AzureClient:
     client._fs._info = AsyncMock(return_value=_INFO)
     client._fs._get_file = AsyncMock(return_value=None)
     return client
+
+
+def test_name_without_account():
+    client = AzureClient("mycontainer", {}, MagicMock())
+    assert client.name == "mycontainer"
+    assert client.container == "mycontainer"
+    assert client.uri == "az://mycontainer"
+    assert "account_name" not in client.fs_kwargs
+
+
+def test_name_with_account():
+    client = AzureClient("mycontainer@myaccount", {}, MagicMock())
+    assert client.name == "mycontainer@myaccount"
+    assert client.container == "mycontainer"
+    assert client.uri == "az://mycontainer@myaccount"
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
+def test_uri_account_overrides_client_config():
+    client = AzureClient(
+        "mycontainer@myaccount", {"account_name": "other"}, MagicMock()
+    )
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
+def test_client_config_account_kept_without_uri_account():
+    client = AzureClient("mycontainer", {"account_name": "other"}, MagicMock())
+    assert client.fs_kwargs["account_name"] == "other"
+
+
+_CONN_STR = (
+    "DefaultEndpointsProtocol=https;AccountName=myaccount;"
+    "AccountKey=dGVzdA==;EndpointSuffix=core.windows.net"
+)
+
+
+def test_uri_account_conflicting_connection_string_raises():
+    with pytest.raises(ValueError, match="conflicts with"):
+        AzureClient("mycontainer@other", {"connection_string": _CONN_STR}, MagicMock())
+
+
+def test_uri_account_matching_connection_string_ok():
+    client = AzureClient(
+        "mycontainer@myaccount", {"connection_string": _CONN_STR}, MagicMock()
+    )
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
+def test_uri_account_conflicting_env_connection_string_raises(monkeypatch):
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", _CONN_STR)
+    with pytest.raises(ValueError, match="conflicts with"):
+        AzureClient("mycontainer@other", {}, MagicMock())
+
+
+def test_no_uri_account_ignores_connection_string_account():
+    client = AzureClient("mycontainer", {"connection_string": _CONN_STR}, MagicMock())
+    assert "account_name" not in client.fs_kwargs
+
+
+def test_parse_url_with_account():
+    uri, rel_path = Client.parse_url("az://mycontainer@myaccount/dir/blob.txt")
+    assert uri == "az://mycontainer@myaccount"
+    assert rel_path == "dir/blob.txt"
+
+
+def test_get_client_with_account():
+    client = Client.get_client("az://mycontainer@myaccount/dir/blob.txt", MagicMock())
+    assert isinstance(client, AzureClient)
+    assert client.uri == "az://mycontainer@myaccount"
+    assert client.container == "mycontainer"
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
+def test_from_source_preserves_account():
+    client = AzureClient.from_source(
+        StorageURI("az://mycontainer@myaccount"), MagicMock()
+    )
+    assert client.name == "mycontainer@myaccount"
+    assert client.container == "mycontainer"
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
+def test_from_source_with_path_parses_netloc_account():
+    client = AzureClient.from_source(
+        StorageURI("az://mycontainer@myaccount/exports/"), MagicMock()
+    )
+    assert client.name == "mycontainer@myaccount/exports"
+    assert client.container == "mycontainer"
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
+def test_get_uri_with_account():
+    client = AzureClient("mycontainer@myaccount", {}, MagicMock())
+    assert client.get_uri("dir/blob.txt") == "az://mycontainer@myaccount/dir/blob.txt"
+
+
+def test_create_fs_receives_account_name():
+    client = AzureClient("mycontainer@myaccount", {}, MagicMock())
+    with patch.object(AzureClient, "FS_CLASS") as mock_fs_cls:
+        _ = client.fs
+    assert mock_fs_cls.call_args[1]["account_name"] == "myaccount"
 
 
 def test_url_versioned_versionid_exactly_once():
@@ -110,7 +219,7 @@ _DETAILS_MOCK = [
 ]
 
 
-def _make_client_sdk():
+def _make_client_sdk(name="mycontainer"):
     """AzureClient whose _info/_get_file run real adlfs code with
     service_client mocked at the Azure SDK boundary."""
     bc = AsyncMock()
@@ -175,9 +284,19 @@ def _make_client_sdk():
     mock_fs._info = _real_info
     mock_fs._get_file = _real_get_file
 
-    client = AzureClient("mycontainer", {}, MagicMock())
+    client = AzureClient(name, {}, MagicMock())
     client._fs = mock_fs
     return client, service_client, bc
+
+
+def test_get_file_info_with_account_in_name():
+    client, service_client, _bc = _make_client_sdk("mycontainer@myaccount")
+    file = client.get_file_info("dir/blob.txt", version_id=_VER)
+    container, path = service_client.get_blob_client.call_args[0]
+    assert container == "mycontainer"
+    assert path == "dir/blob.txt"
+    assert file.source == "az://mycontainer@myaccount"
+    assert file.path == "dir/blob.txt"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_client_azure.py
+++ b/tests/unit/test_client_azure.py
@@ -95,6 +95,13 @@ def test_no_uri_account_ignores_connection_string_account():
     assert "account_name" not in client.fs_kwargs
 
 
+def test_malformed_connection_string_skips_conflict_check():
+    client = AzureClient(
+        "mycontainer@myaccount", {"connection_string": "garbage"}, MagicMock()
+    )
+    assert client.fs_kwargs["account_name"] == "myaccount"
+
+
 def test_parse_url_with_account():
     uri, rel_path = Client.parse_url("az://mycontainer@myaccount/dir/blob.txt")
     assert uri == "az://mycontainer@myaccount"

--- a/tests/unit/test_client_bucket_status.py
+++ b/tests/unit/test_client_bucket_status.py
@@ -212,6 +212,51 @@ def test_azure_bucket_status(
 
 @patch("datachain.client.azure.BlobServiceClient")
 @patch.object(AzureClient, "create_fs")
+def test_azure_bucket_status_account_in_name(mock_create_fs, mock_blob_svc):
+    container = MagicMock()
+    mock_blob_svc.return_value.get_container_client.return_value = container
+    container.get_container_properties.side_effect = ClientAuthenticationError
+
+    auth_fs = MagicMock()
+    mock_create_fs.return_value = auth_fs
+    auth_fs._info = AsyncMock()
+
+    status = AzureClient.bucket_status("c@acct")
+
+    assert status == BucketStatus(True, "authenticated")
+    assert mock_blob_svc.call_args[1] == {
+        "account_url": "https://acct.blob.core.windows.net"
+    }
+    mock_blob_svc.return_value.get_container_client.assert_called_once_with("c")
+    assert mock_create_fs.call_args[1]["account_name"] == "acct"
+    auth_fs._info.assert_awaited_once_with("c")
+
+
+@patch("datachain.client.azure.BlobServiceClient")
+@patch.object(AzureClient, "create_fs")
+def test_azure_bucket_status_name_account_wins_over_kwargs(
+    _mock_create_fs, mock_blob_svc
+):
+    container = MagicMock()
+    mock_blob_svc.return_value.get_container_client.return_value = container
+
+    status = AzureClient.bucket_status("c@acct", account_name="other")
+
+    assert status == BucketStatus(True, "anonymous")
+    assert mock_blob_svc.call_args[1] == {
+        "account_url": "https://acct.blob.core.windows.net"
+    }
+
+
+def test_azure_bucket_status_conflicting_connection_string_raises(monkeypatch):
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+    conn = "DefaultEndpointsProtocol=https;AccountName=a;AccountKey=dGVzdA=="
+    with pytest.raises(ValueError, match="conflicts with"):
+        AzureClient.bucket_status("c@b", connection_string=conn)
+
+
+@patch("datachain.client.azure.BlobServiceClient")
+@patch.object(AzureClient, "create_fs")
 def test_azure_bucket_status_http_500_reraises(_mock_create_fs, mock_blob_svc):
     container = MagicMock()
     mock_blob_svc.return_value.get_container_client.return_value = container

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -245,6 +245,8 @@ def _ds_name(uri: str) -> str:
         ("s3://bucket/dir%20path/", "s3://bucket/dir_x2520path/"),
         # @ is encoded (_x40)
         ("s3://bucket/user@host/", "s3://bucket/user_x40host/"),
+        # Azure account in the netloc is encoded too
+        ("az://container@account/dir/", "az://container_x40account/dir/"),
         # Literal _x in path is doubled
         ("s3://bucket/export_xml/", "s3://bucket/export_x_xml/"),
     ],
@@ -268,6 +270,7 @@ def test_parse_listing_uri_no_collision_dot_vs_underscore():
         "s3://bucket/v1.0/",
         "s3://bucket/dir%25/",
         "s3://bucket/user@host/",
+        "az://container@account/dir/",
         "s3://bucket/export_xml/",
         "s3://my.company.data/path/to/files/",
         "gs://bucket-with_underscores_x_and.dots/",

--- a/tests/unit/test_skill_knowledge_scripts.py
+++ b/tests/unit/test_skill_knowledge_scripts.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call
 
 # Insert the scripts directory so bare imports work (matches runtime behavior).
 SCRIPTS_DIR = str(
@@ -13,6 +14,7 @@ SCRIPTS_DIR = str(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
+from bucket_overview import bucket_overview  # noqa: E402
 from changes import build_changes, compute_dep_changes  # noqa: E402
 from render_index import render_index  # noqa: E402
 from schema import parse_dataset_name, type_name  # noqa: E402
@@ -382,9 +384,31 @@ def test_source_to_https_gs():
     assert source_to_https("gs://demo") == "https://storage.googleapis.com/demo"
 
 
-def test_source_to_https_az():
+def test_source_to_https_az(monkeypatch):
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_NAME", raising=False)
     assert (
-        source_to_https("az://account/container")
+        source_to_https("az://container@account/prefix/")
+        == "https://account.blob.core.windows.net/container"
+    )
+
+
+def test_source_to_https_az_no_account_returns_none(monkeypatch):
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_NAME", raising=False)
+    assert source_to_https("az://container/prefix/") is None
+
+
+def test_source_to_https_az_account_from_env(monkeypatch):
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "envacct")
+    assert (
+        source_to_https("az://container/")
+        == "https://envacct.blob.core.windows.net/container"
+    )
+
+
+def test_source_to_https_az_uri_account_wins_over_env(monkeypatch):
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "envacct")
+    assert (
+        source_to_https("az://container@account/")
         == "https://account.blob.core.windows.net/container"
     )
 
@@ -395,6 +419,76 @@ def test_source_to_https_local_returns_none():
 
 def test_source_to_https_empty_returns_none():
     assert source_to_https("") is None
+
+
+# ---------------------------------------------------------------------------
+# bucket_overview.py
+# ---------------------------------------------------------------------------
+
+
+def _overview_fs(monkeypatch, entries):
+    fs = MagicMock()
+    fs.ls.return_value = entries
+    filesystem = MagicMock(return_value=fs)
+    monkeypatch.setattr("fsspec.filesystem", filesystem)
+    return filesystem
+
+
+def _capture_read_values(monkeypatch):
+    captured = {}
+
+    def fake_read_values(file, session=None):
+        captured["files"] = file
+        captured["session"] = session
+        return MagicMock()
+
+    monkeypatch.setattr("datachain.read_values", fake_read_values)
+    return captured
+
+
+def test_bucket_overview_az_account_in_uri(monkeypatch):
+    filesystem = _overview_fs(
+        monkeypatch, [{"name": "container/dir/blob.txt", "type": "file", "size": 5}]
+    )
+    captured = _capture_read_values(monkeypatch)
+
+    bucket_overview("az://container@account/", name="ds")
+
+    assert filesystem.call_args == call("az", account_name="account")
+    (f,) = captured["files"]
+    assert f.source == "az://container@account/"
+    assert f.path == "dir/blob.txt"
+    assert captured["session"] is None
+
+
+def test_bucket_overview_az_without_account(monkeypatch):
+    filesystem = _overview_fs(
+        monkeypatch, [{"name": "container/blob.txt", "type": "file", "size": 5}]
+    )
+    captured = _capture_read_values(monkeypatch)
+
+    bucket_overview("az://container/", name="ds")
+
+    assert filesystem.call_args == call("az")
+    (f,) = captured["files"]
+    assert f.source == "az://container/"
+    assert f.path == "blob.txt"
+
+
+def test_bucket_overview_anon_creates_anon_session(monkeypatch):
+    filesystem = _overview_fs(
+        monkeypatch, [{"name": "container/blob.txt", "type": "file", "size": 5}]
+    )
+    captured = _capture_read_values(monkeypatch)
+    fake_session = object()
+    session_get = MagicMock(return_value=fake_session)
+    monkeypatch.setattr("datachain.Session.get", session_get)
+
+    bucket_overview("az://container@account/", anon=True, name="ds")
+
+    assert filesystem.call_args == call("az", anon=True, account_name="account")
+    session_get.assert_called_once_with(client_config={"anon": True})
+    assert captured["session"] is fake_session
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements #1859: embed the Azure storage account in the URI — `az://container@account/path` — so a single string identifies both the container and the account, and URIs pointing to different accounts can coexist in one run. Supersedes #1798, which threaded `--account-name` through the knowledge-skill scripts instead.

## Design

The account is parsed once, at the `AzureClient` boundary, and **stays in the client name**: `client.name`, `client.uri`, and `File.source` keep `container@account`, so saved datasets round-trip the account with no side-channel config. adlfs already tolerates `az://container@account/path` in every path operation (`_strip_protocol` folds the netloc back into `container/path`), so the change is confined to:

- `AzureClient.__init__` — parse the netloc, inject `account_name` into fs kwargs (URI wins over `client_config`), keep `self.container` for container-level SDK calls (`_fetch_flat`)
- `AzureClient.from_source` — preserve `@account` (base `_strip_protocol` would drop it)
- `AzureClient.bucket_status` — accept `container@account`, enabling the anonymous-access probe without an extra flag

Listing dataset names need nothing: `@` is already sanitized injectively (`_x40`) and round-trips.

## Knowledge skill

- `source_to_https` builds `https://account.blob.core.windows.net/container` from the `container@account` netloc (env `AZURE_STORAGE_ACCOUNT_NAME` as fallback). The old code read `az://account/container/`, which is inverted relative to how DataChain actually lists Azure — fixed.
- `bucket_overview` passes the account to `fsspec.filesystem("az", ...)`, strips the bare container (not the logical netloc) from adlfs entry names, and with `--anon` builds the chain on a session with `client_config={"anon": True}` so sampled File rows stay readable during enrichment. SKILL.md documents both.
- `bucket_scan` needed no changes — the account rides through in the URI.

## Guard: conflicting connection string

adlfs gives a connection string precedence over `account_name`, which would silently read account A while `File.source` says B. If the URI embeds an account and an explicit or env connection string names a *different* `AccountName`, the client now raises. A matching connection string works as before (this is also what the azurite functional test exercises). Documented in the remotes guide: account keys / SAS tokens / connection strings are account-specific, so mixing accounts in one run needs per-account-valid credentials (Azure AD or anonymous).

## Not included (deliberately)

- `abfss://` alias — open question in #1859, needs its own justification.
- The listing-error JSON handling and empty-bucket guards discussed in #1798 — valid but orthogonal to this change.

Closes #1859

<sup>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sup>