### PR TITLE
Remove redundant comments and docstrings from tests

### DIFF
--- a/tests/func/test_metastore.py
+++ b/tests/func/test_metastore.py
@@ -875,14 +875,12 @@ def test_update_dataset_dependency_source(metastore):
         dataset=tgt, version="1.0.0", status=DatasetStatus.COMPLETE
     )
 
-    # Add dependency: src1@1.0.0 -> tgt@1.0.0
     metastore.add_dataset_dependency(src1, "1.0.0", tgt, "1.0.0")
     deps = metastore.get_direct_dataset_dependencies(src1, "1.0.0")
     assert len(deps) == 1
     assert deps[0].name == "tgt"
     assert deps[0].version == "1.0.0"
 
-    # Update dependency to src2@1.0.0
     metastore.update_dataset_dependency_source(
         src1, "1.0.0", new_source_dataset=src2, new_source_dataset_version="1.0.0"
     )
@@ -909,7 +907,6 @@ def test_update_dataset_dependency_source_default_new_source(metastore):
         dataset=tgt, version="1.0.0", status=DatasetStatus.COMPLETE
     )
 
-    # Add dependency: src@1.0.0 -> tgt@1.0.0
     metastore.add_dataset_dependency(src, "1.0.0", tgt, "1.0.0")
     deps = metastore.get_direct_dataset_dependencies(src, "1.0.0")
     assert len(deps) == 1

--- a/tests/func/test_mutate.py
+++ b/tests/func/test_mutate.py
@@ -171,8 +171,6 @@ def test_mutate_rename_column_no_db_leakage(test_session):
 
 
 def test_mutate_with_window_functions(test_session):
-    """Test mutate with window functions"""
-
     files = _create_test_files(
         [
             ("cats/cat1", 4),

--- a/tests/func/test_read_dataset_version_specifiers.py
+++ b/tests/func/test_read_dataset_version_specifiers.py
@@ -63,7 +63,6 @@ def test_read_dataset_version_specifiers_no_match(test_session):
 
 
 def test_read_dataset_version_specifiers_exact_version(test_session):
-    """Test that version specifiers work alongside with exact version reads."""
     dataset_name = "test_backward_compatibility"
 
     dc.read_values(data=[1, 2], session=test_session).save(

--- a/tests/func/test_retry.py
+++ b/tests/func/test_retry.py
@@ -114,7 +114,6 @@ def test_retry_with_missing_records(test_session):
         .save("partial_result")
     )
 
-    # Should now have all 4 records
     assert retry_chain.count() == 4
 
     # Verify all records are present
@@ -165,7 +164,6 @@ def test_retry_with_missing_and_new_records(test_session):
         .save("partial_result")
     )
 
-    # Should now have all 3 records
     assert retry_chain.count() == 5
 
     # Verify all records are present

--- a/tests/func/test_to_database.py
+++ b/tests/func/test_to_database.py
@@ -451,7 +451,6 @@ def test_to_database_conflict_columns_normalization(postgres_connection, test_se
 
 
 def test_to_database_table_exists_different_schema(connection, test_session):
-    """Test to_database when table exists but has different schema."""
     engine = _get_engine_from_connection(connection)
     with engine.connect() as conn:
         with conn.begin():
@@ -729,8 +728,6 @@ def test_to_database_column_mapping_defaultdict_with_datachain_format(
 
 
 def test_to_database_column_mapping_complex_nested_names(connection, test_session):
-    """Test column mapping with complex/nested column names."""
-
     class NestedData(dc.DataModel):
         value: str
         metadata: dict

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -785,7 +785,6 @@ def test_studio_run(capsys, mocker, tmp_dir):
         first_request.url
         == f"{STUDIO_URL}/api/datachain/jobs/files?team_name=team_name"
     )
-    # Check that it's multipart/form-data request
     assert "multipart/form-data" in first_request.headers.get("Content-Type", "")
     # Check query parameters
     assert first_request.qs["team_name"] == ["team_name"]

--- a/tests/test_job_management_e2e.py
+++ b/tests/test_job_management_e2e.py
@@ -57,7 +57,6 @@ def test_single_job_for_multiple_saves(tmp_path, catalog_tmpfile):
     jobs = list(catalog_tmpfile.metastore.db.execute(query))
     assert len(jobs) == 1, f"Expected exactly 1 job, but got {len(jobs)}"
 
-    # Get the job for this script
     job = catalog_tmpfile.metastore.get_last_job_by_name(str(script))
     assert job is not None
     assert job.name == str(script)
@@ -135,7 +134,6 @@ def test_job_marked_on_exception(
     jobs = list(catalog_tmpfile.metastore.db.execute(query))
     assert len(jobs) == 1, f"Expected exactly 1 job, but got {len(jobs)}"
 
-    # Get the job for this script
     job = catalog_tmpfile.metastore.get_last_job_by_name(str(script))
     assert job is not None
     assert job.name == str(script)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -315,7 +315,6 @@ def test_read_records_with_file_objects(test_session):
     # Insert records
     ds = dc.read_records(records, schema={"file": File}, session=test_session)
 
-    # Verify count
     assert ds.count() == 3
 
     # Verify we can retrieve File objects back
@@ -347,7 +346,6 @@ def test_read_records_with_nested_datamodel(test_session):
     # Insert records
     ds = dc.read_records(records, schema={"data": MyNested}, session=test_session)
 
-    # Verify count
     assert ds.count() == 3
 
     # Verify we can retrieve nested DataModel objects back
@@ -2688,7 +2686,6 @@ def test_count_with_empty_results(test_session):
     empty_chain = chain.filter(C("numbers") > 10)
     assert empty_chain.count() == 0
 
-    # Limit to 0
     assert chain.limit(0).count() == 0
     assert empty_chain.limit(0).count() == 0
     assert chain.count() == 5

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -2735,7 +2735,6 @@ def test_distinct_basic(test_session):
 
 
 def test_distinct_multiple_columns(test_session):
-    """Test distinct with multiple columns."""
     chain = dc.read_values(
         category=["A", "A", "B", "B", "C"], value=[1, 2, 1, 2, 2], session=test_session
     )
@@ -2832,14 +2831,12 @@ def test_distinct_after_operations(test_session):
 
 
 def test_distinct_with_empty_chain(test_session):
-    """Test distinct with empty chain."""
     chain = dc.read_values(numbers=[], session=test_session)
     distinct_chain = chain.distinct("numbers")
     assert distinct_chain.count() == 0
 
 
 def test_distinct_with_single_item(test_session):
-    """Test distinct with single item."""
     chain = dc.read_values(numbers=[42], session=test_session)
     distinct_chain = chain.distinct("numbers")
     assert distinct_chain.count() == 1
@@ -3004,7 +3001,6 @@ def test_filter_with_strings(test_session):
 
 
 def test_filter_with_glob_patterns(test_session):
-    """Test filter with glob patterns."""
     files = [
         File(path="image1.jpg", size=100),
         File(path="image2.png", size=200),
@@ -3095,7 +3091,6 @@ def test_filter_with_regexp(test_session):
 
 
 def test_filter_with_in_operator(test_session):
-    """Test filter with 'in' operator."""
     chain = dc.read_values(
         numbers=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         categories=["A", "B", "A", "C", "B", "A", "C", "B", "A", "C"],
@@ -3146,7 +3141,6 @@ def test_filter_with_and_operator(test_session):
 
 
 def test_filter_with_or_operator(test_session):
-    """Test filter with OR operator."""
     chain = dc.read_values(
         numbers=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         categories=["A", "B", "A", "C", "B", "A", "C", "B", "A", "C"],
@@ -3169,7 +3163,6 @@ def test_filter_with_or_operator(test_session):
 
 
 def test_filter_with_not_operator(test_session):
-    """Test filter with NOT operator."""
     chain = dc.read_values(
         numbers=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         categories=["A", "B", "A", "C", "B", "A", "C", "B", "A", "C"],
@@ -3199,7 +3192,6 @@ def test_filter_with_not_operator(test_session):
 
 
 def test_filter_with_complex_objects(test_session):
-    """Test filter with complex objects."""
     files = [
         File(path="image1.jpg", size=100),
         File(path="image2.png", size=200),

--- a/tests/unit/lib/test_settings.py
+++ b/tests/unit/lib/test_settings.py
@@ -130,7 +130,6 @@ def test_settings_to_dict():
 
 
 def test_settings_immutability():
-    # Create original settings
     original = Settings(batch_size=1000, cache=True)
 
     # Create a copy

--- a/tests/unit/test_batch_size.py
+++ b/tests/unit/test_batch_size.py
@@ -42,7 +42,6 @@ def test_insert_rows_custom_batch_size(warehouse):
 
 
 def test_insert_rows_small_batch_size(warehouse):
-    """Test insert_rows with a very small batch size."""
     table = warehouse.create_udf_table([sa.Column("value", sa.Integer)])
 
     rows = [{"sys__id": i, "value": i} for i in range(10)]
@@ -130,33 +129,28 @@ def test_insert_rows_preserves_data_integrity(warehouse):
 
 
 def test_batch_size_default_is_none():
-    """Test that default batch_size is None."""
     settings = Settings()
     assert settings.batch_size is None
 
 
 def test_batch_size_explicit_none():
-    """Test that explicit None returns None."""
     settings = Settings(batch_size=None)
     assert settings.batch_size is None
 
 
 @pytest.mark.parametrize("batch_size", [1, 10, 100, 1000])
 def test_batch_size_custom_value(batch_size):
-    """Test that custom batch_size value is returned."""
     settings = Settings(batch_size=batch_size)
     assert settings.batch_size == batch_size
 
 
 def test_batch_size_not_in_to_dict_when_none():
-    """Test that batch_size is not in to_dict when None."""
     settings = Settings(batch_size=None)
     d = settings.to_dict()
     assert "batch_size" not in d
 
 
 def test_batch_size_in_to_dict_when_set():
-    """Test that batch_size is in to_dict when set."""
     settings = Settings(batch_size=500)
     d = settings.to_dict()
     assert d["batch_size"] == 500

--- a/tests/unit/test_batch_size_udf.py
+++ b/tests/unit/test_batch_size_udf.py
@@ -183,7 +183,6 @@ def test_negative_batch_size(test_session):
     def simple_udf(value: int) -> int:
         return value
 
-    # This should raise an error
     with pytest.raises(SettingsError):
         (
             dc.read_values(value=list(range(10)), session=test_session)
@@ -200,7 +199,6 @@ def test_zero_batch_size(test_session):
     def simple_udf(value: int) -> int:
         return value
 
-    # This should raise an error
     with pytest.raises(SettingsError):
         (
             dc.read_values(value=list(range(10)), session=test_session)

--- a/tests/unit/test_batch_size_udf.py
+++ b/tests/unit/test_batch_size_udf.py
@@ -38,8 +38,6 @@ def test_map_with_default_batch_size(test_session, warehouse):
 
 
 def test_map_with_custom_batch_size(test_session, warehouse):
-    """Test map UDF with custom batch_size."""
-
     def simple_udf(value: int) -> int:
         return value * 2
 

--- a/tests/unit/test_batching.py
+++ b/tests/unit/test_batching.py
@@ -115,7 +115,6 @@ def test_batching_ids_only(batch_size, warehouse, numbers_table):
 def numbers_partitioned(warehouse, numbers_table):
     partition_by = [numbers_table.c.primality]
 
-    # create table with partitions
     partition_tbl = warehouse.create_udf_table(partition_columns())
 
     # fill table with partitions

--- a/tests/unit/test_cli_skill.py
+++ b/tests/unit/test_cli_skill.py
@@ -7,10 +7,6 @@ import pytest
 
 from datachain.cli.parser import get_parser
 
-# ---------------------------------------------------------------------------
-# Argument parsing tests
-# ---------------------------------------------------------------------------
-
 
 def test_skill_install_defaults():
     parser = get_parser()
@@ -69,11 +65,6 @@ def test_skill_list_no_args():
     args = parser.parse_args(["skill", "list"])
     assert args.command == "skill"
     assert args.skill_cmd == "list"
-
-
-# ---------------------------------------------------------------------------
-# install_skills() functional tests
-# ---------------------------------------------------------------------------
 
 
 def test_install_invalid_skill_raises(tmp_path, fake_skills_src, fake_home):
@@ -365,11 +356,6 @@ def test_pycache_not_copied(tmp_path, fake_skills_src, fake_home):
     assert not (skills_base / "knowledge" / "scripts" / "__pycache__").exists()
 
 
-# ---------------------------------------------------------------------------
-# list_skills() smoke test
-# ---------------------------------------------------------------------------
-
-
 def test_list_skills_output(capsys):
     from datachain.cli.commands.skill import list_skills
 
@@ -382,11 +368,6 @@ def test_list_skills_output(capsys):
     assert "cursor" in out
     assert "codex" in out
     assert "pi" in out
-
-
-# ---------------------------------------------------------------------------
-# install edge cases
-# ---------------------------------------------------------------------------
 
 
 def test_install_missing_source_returns_nonzero(tmp_path, fake_home):

--- a/tests/unit/test_cli_skill.py
+++ b/tests/unit/test_cli_skill.py
@@ -350,9 +350,7 @@ def test_pycache_not_copied(tmp_path, fake_skills_src, fake_home):
     _run_install(fake_skills_src, fake_home, skills=None, target="claude", local=False)
 
     skills_base = fake_home / ".claude" / "skills"
-    # Scripts should exist
     assert (skills_base / "knowledge" / "scripts" / "plan.py").exists()
-    # But __pycache__ should NOT
     assert not (skills_base / "knowledge" / "scripts" / "__pycache__").exists()
 
 

--- a/tests/unit/test_cli_skill.py
+++ b/tests/unit/test_cli_skill.py
@@ -133,9 +133,6 @@ def _run_install(
         install_skills(skills=skills, target=target, local=local)
 
 
-# --- claude, global ---
-
-
 def test_install_all_claude_global(tmp_path, fake_skills_src, fake_home):
     _run_install(fake_skills_src, fake_home, skills=None, target="claude", local=False)
 
@@ -177,9 +174,6 @@ def test_install_only_graph_claude_global(tmp_path, fake_skills_src, fake_home):
     assert not (skills_base / "core").exists()
 
 
-# --- cursor, global ---
-
-
 def test_install_all_cursor_global(tmp_path, fake_skills_src, fake_home):
     _run_install(fake_skills_src, fake_home, skills=None, target="cursor", local=False)
 
@@ -198,9 +192,6 @@ def test_install_all_cursor_global(tmp_path, fake_skills_src, fake_home):
         assert "triggers:" not in content
 
 
-# --- codex, global ---
-
-
 def test_install_all_codex_global(tmp_path, fake_skills_src, fake_home):
     _run_install(fake_skills_src, fake_home, skills=None, target="codex", local=False)
 
@@ -210,9 +201,6 @@ def test_install_all_codex_global(tmp_path, fake_skills_src, fake_home):
 
     # codex has no commands dir
     assert not (fake_home / ".codex" / "commands").exists()
-
-
-# --- pi, global + local ---
 
 
 def test_install_all_pi_global(tmp_path, fake_skills_src, fake_home):
@@ -259,9 +247,6 @@ def test_install_pi_local(tmp_path, fake_skills_src, fake_home, monkeypatch):
     assert not (project_dir / ".pi" / "agent").exists()
     # And the user home is untouched.
     assert not (fake_home / ".pi").exists()
-
-
-# --- copilot, global ---
 
 
 def test_install_all_copilot_global(tmp_path, fake_skills_src, fake_home):
@@ -315,9 +300,6 @@ def test_install_copilot_local_uses_github_path(
     assert not (fake_home / ".copilot").exists()
 
 
-# --- local install ---
-
-
 def test_install_claude_local(tmp_path, fake_skills_src, fake_home, monkeypatch):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -340,9 +322,6 @@ def test_install_claude_local(tmp_path, fake_skills_src, fake_home, monkeypatch)
 
     # Nothing written to home
     assert not (fake_home / ".claude").exists()
-
-
-# --- __pycache__ filtering ---
 
 
 def test_pycache_not_copied(tmp_path, fake_skills_src, fake_home):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -156,7 +156,6 @@ def test_edit_config_global_level(global_config_dir):
 
     create_global_config(global_config_dir)
 
-    # Edit the global config
     with Config(ConfigLevel.GLOBAL).edit() as config:
         config["new_key"] = "new_value"
         config["studio"]["token"] = "new-token"  # noqa: S105 # nosec B105

--- a/tests/unit/test_data_storage.py
+++ b/tests/unit/test_data_storage.py
@@ -89,7 +89,6 @@ def test_list_tables(catalog):
     tables = db.list_tables()
     assert isinstance(tables, list)
 
-    # Create a test table
     table = catalog.warehouse.create_udf_table([], name="test_list_tables_abc")
     try:
         tables_after = db.list_tables()

--- a/tests/unit/test_dataset_status_management.py
+++ b/tests/unit/test_dataset_status_management.py
@@ -70,7 +70,6 @@ def test_mark_job_dataset_versions_as_failed(test_session, job, dataset_created)
     assert dataset_version.status == DatasetStatus.CREATED
     assert dataset_version.job_id == job.id
 
-    # Mark dataset versions as failed
     test_session.catalog.metastore.mark_job_dataset_versions_as_failed(job.id)
 
     # Verify status is now FAILED
@@ -89,7 +88,6 @@ def test_mark_job_dataset_versions_as_failed_skips_complete(
     assert dataset_version.status == DatasetStatus.COMPLETE
     assert dataset_version.job_id == job.id
 
-    # Mark dataset versions as failed
     test_session.catalog.metastore.mark_job_dataset_versions_as_failed(job.id)
 
     # Verify COMPLETE status is unchanged
@@ -174,7 +172,6 @@ def test_get_dataset_versions_to_clean(
     # Mark job as failed
     test_session.catalog.metastore.set_job_status(job.id, JobStatus.FAILED)
 
-    # Get failed versions to clean
     to_clean = test_session.catalog.metastore.get_dataset_versions_to_clean()
 
     # Should return CREATED and FAILED datasets, not COMPLETE
@@ -502,11 +499,9 @@ def test_public_api_read_dataset_rejects_non_complete(test_session, studio_job):
         ds_failed, DatasetStatus.FAILED, version=ds_failed.latest_version
     )
 
-    # Should raise error for CREATED dataset
     with pytest.raises(DatasetNotFoundError):
         read_dataset(ds_created.name, session=test_session)
 
-    # Should raise error for FAILED dataset
     with pytest.raises(DatasetNotFoundError):
         read_dataset(ds_failed.name, session=test_session)
 
@@ -514,11 +509,9 @@ def test_public_api_read_dataset_rejects_non_complete(test_session, studio_job):
 def test_public_api_delete_dataset_rejects_non_complete(
     test_session, dataset_created, dataset_failed
 ):
-    # Should raise error for CREATED dataset
     with pytest.raises(DatasetNotFoundError):
         delete_dataset(dataset_created.name, session=test_session)
 
-    # Should raise error for FAILED dataset
     with pytest.raises(DatasetNotFoundError):
         delete_dataset(dataset_failed.name, session=test_session)
 
@@ -526,11 +519,9 @@ def test_public_api_delete_dataset_rejects_non_complete(
 def test_public_api_move_dataset_rejects_non_complete(
     test_session, dataset_created, dataset_failed
 ):
-    # Should raise error for CREATED dataset
     with pytest.raises(DatasetNotFoundError):
         move_dataset(dataset_created.name, "new_name_created", session=test_session)
 
-    # Should raise error for FAILED dataset
     with pytest.raises(DatasetNotFoundError):
         move_dataset(dataset_failed.name, "new_name_failed", session=test_session)
 

--- a/tests/unit/test_hash_utils.py
+++ b/tests/unit/test_hash_utils.py
@@ -268,7 +268,6 @@ def test_hash_callable_include_body_false_ignores_body():
 
 
 def test_hash_callable_include_body_false_different_qualname():
-    """Different qualname → different hash even with include_body=False."""
     h1 = hash_callable(double, include_body=False)
     h2 = hash_callable(double_arg_annot, include_body=False)
     assert h1 != h2

--- a/tests/unit/test_job_management.py
+++ b/tests/unit/test_job_management.py
@@ -145,7 +145,6 @@ def test_nested_sessions_share_same_job(test_session, patch_argv, monkeypatch):
 
 
 def test_except_hook_delegates_to_original(test_session, patch_argv, monkeypatch):
-    """Test that Session.except_hook delegates to ORIGINAL_EXCEPT_HOOK."""
     monkeypatch.delenv("DATACHAIN_JOB_ID", raising=False)
     monkeypatch.setattr("sys.ps1", None, raising=False)
 

--- a/tests/unit/test_job_management.py
+++ b/tests/unit/test_job_management.py
@@ -127,7 +127,6 @@ def test_nested_sessions_share_same_job(test_session, patch_argv, monkeypatch):
     # Outer session creates a job
     job1 = test_session.get_or_create_job()
 
-    # Create nested session
     with Session("nested", catalog=test_session.catalog) as nested_session:
         job2 = nested_session.get_or_create_job()
 

--- a/tests/unit/test_metastore.py
+++ b/tests/unit/test_metastore.py
@@ -87,7 +87,6 @@ def test_expire_checkpoints():
         old = now - timedelta(hours=2)
         ttl_threshold = now - timedelta(hours=1)
 
-        # Create two jobs
         job1_id = metastore.create_job(
             "job1", "q", query_type=JobQueryType.PYTHON, status=JobStatus.COMPLETE
         )

--- a/tests/unit/test_signal_schema_partials.py
+++ b/tests/unit/test_signal_schema_partials.py
@@ -223,7 +223,6 @@ def test_get_file_signal():
 
 
 def test_to_partial_complex_signal_entire_file():
-    """Test to_partial with entire complex signal requested."""
     schema = SignalSchema({"file": File, "name": str})
     partial = schema.to_partial("file")
 
@@ -253,7 +252,6 @@ def test_to_partial_complex_nested_signal():
 
 
 def test_to_partial_complex_deeply_nested_signal():
-    """Test to_partial with deeply nested complex signals (3+ levels)."""
     from datachain.lib.file import ImageFile
 
     class Level1(DataModel):
@@ -290,8 +288,6 @@ def test_to_partial_complex_deeply_nested_signal():
 
 
 def test_to_partial_complex_nested_multiple_complex_signals():
-    """Test to_partial with multiple nested complex signals."""
-
     class Container(DataModel):
         file1: File
         file2: TextFile
@@ -376,7 +372,6 @@ def test_to_partial_complex_nested_same_type_different_paths():
 
 
 def test_to_partial_complex_signal_file_single_field():
-    """Test to_partial with File complex signal - single field."""
     schema = SignalSchema({"name": str, "file": File})
     partial = schema.to_partial("file.path")
 
@@ -416,7 +411,6 @@ def test_to_partial_complex_signal_mixed_entire_and_fields():
 
 
 def test_to_partial_complex_signal_multiple_entire_files():
-    """Test to_partial with multiple entire complex signals."""
     schema = SignalSchema({"file1": File, "file2": File, "name": str})
     partial = schema.to_partial("file1", "file2")
 
@@ -426,8 +420,6 @@ def test_to_partial_complex_signal_multiple_entire_files():
 
 
 def test_to_partial_complex_signal_nested_entire():
-    """Test to_partial with nested complex signal - entire parent."""
-
     class Container(DataModel):
         name: str
         file: File
@@ -464,7 +456,6 @@ def test_to_partial_complex_signal_error_invalid_signal():
 
 
 def test_to_partial_complex_signal_error_invalid_field():
-    """Test to_partial with invalid field in complex signal."""
     schema = SignalSchema({"file": File})
 
     with pytest.raises(

--- a/tests/unit/test_skill_jobs_scripts.py
+++ b/tests/unit/test_skill_jobs_scripts.py
@@ -27,10 +27,6 @@ if GRAPH_SCRIPTS_DIR not in sys.path:
 
 from utils import read_frontmatter  # noqa: E402
 
-# ---------------------------------------------------------------------------
-# _parse_dt
-# ---------------------------------------------------------------------------
-
 
 class TestParseDt:
     def test_z_suffix(self):
@@ -51,11 +47,6 @@ class TestParseDt:
         assert _parse_dt("not-a-date") is None
 
 
-# ---------------------------------------------------------------------------
-# _normalize_status
-# ---------------------------------------------------------------------------
-
-
 class TestNormalizeStatus:
     def test_lowercase(self):
         assert _normalize_status("Complete") == "complete"
@@ -67,11 +58,6 @@ class TestNormalizeStatus:
         assert _normalize_status("RUNNING") == "running"
 
 
-# ---------------------------------------------------------------------------
-# _duration_str
-# ---------------------------------------------------------------------------
-
-
 class TestDurationStr:
     def test_seconds(self):
         assert _duration_str(60) == "60s"
@@ -81,11 +67,6 @@ class TestDurationStr:
 
     def test_zero(self):
         assert _duration_str(0) == "0s"
-
-
-# ---------------------------------------------------------------------------
-# _strip_ordinal
-# ---------------------------------------------------------------------------
 
 
 class TestStripOrdinal:
@@ -100,11 +81,6 @@ class TestStripOrdinal:
 
     def test_empty(self):
         assert _strip_ordinal("") == ""
-
-
-# ---------------------------------------------------------------------------
-# _read_frontmatter (duplicated in jobs.py)
-# ---------------------------------------------------------------------------
 
 
 class TestJobsReadFrontmatter:

--- a/tests/unit/test_skill_knowledge_scripts.py
+++ b/tests/unit/test_skill_knowledge_scripts.py
@@ -37,10 +37,6 @@ from utils import (  # noqa: E402
     split_frontmatter,
 )
 
-# ---------------------------------------------------------------------------
-# utils.py
-# ---------------------------------------------------------------------------
-
 
 def test_parse_semver_valid():
     assert parse_semver("1.2.3") == (1, 2, 3)
@@ -397,11 +393,6 @@ def test_source_to_https_empty_returns_none():
     assert source_to_https("") is None
 
 
-# ---------------------------------------------------------------------------
-# changes.py
-# ---------------------------------------------------------------------------
-
-
 def test_compute_dep_changes_added():
     result = compute_dep_changes(
         [{"name": "a", "version": "1.0"}],
@@ -470,11 +461,6 @@ def test_build_changes_script_unchanged():
     )
     assert result["script_changed"] is False
     assert result["previous_script"] is None
-
-
-# ---------------------------------------------------------------------------
-# dataset_all.py
-# ---------------------------------------------------------------------------
 
 
 def test_merge_versions_no_duplicates():
@@ -551,11 +537,6 @@ def test_fetch_all_versions_overlays_live_enrichment_on_latest(monkeypatch):
     assert oldest["summary"] is None
 
 
-# ---------------------------------------------------------------------------
-# schema.py
-# ---------------------------------------------------------------------------
-
-
 def test_type_name_primitives():
     assert type_name(str) == "str"
     assert type_name(int) == "int"
@@ -598,11 +579,6 @@ def test_parse_dataset_name_dot_separated():
 
 def test_parse_dataset_name_slash_separated():
     assert parse_dataset_name("ns/proj/name") == ("ns", "proj", "name")
-
-
-# ---------------------------------------------------------------------------
-# render_index.py
-# ---------------------------------------------------------------------------
 
 
 def test_render_index_local_datasets():


### PR DESCRIPTION
Remove useless comments and docstrings from tests, mostly AI slope.

Found these while I was working on https://github.com/datachain-ai/datachain/pull/1887, e.g.:

```
# ---------------------------------------------------------------------------
# changes.py
# ---------------------------------------------------------------------------
```