### PR TITLE
fix: anchor glob patterns at the listing root

### DIFF
--- a/src/datachain/lib/dc/storage_pattern.py
+++ b/src/datachain/lib/dc/storage_pattern.py
@@ -243,11 +243,8 @@ def apply_glob_filter(
 
     chain = ls(dc, list_path, recursive=use_recursive, column=column)
 
-    if list_path and "/" not in pattern:
-        filter_pattern = f"{list_path.rstrip('/')}/{pattern}"
-    else:
-        filter_pattern = pattern
-
-    glob_pattern = convert_globstar_to_glob(filter_pattern)
+    glob_pattern = convert_globstar_to_glob(pattern)
+    if subpath := list_path.strip("/"):
+        glob_pattern = f"{subpath}/{glob_pattern}"
 
     return chain.filter(Column(f"{column}.path").glob(glob_pattern))

--- a/tests/func/test_datachain.py
+++ b/tests/func/test_datachain.py
@@ -85,6 +85,12 @@ def test_read_storage_glob(cloud_test_catalog):
     assert chain.count() == 3
 
 
+def test_read_storage_glob_with_dir_component(cloud_test_catalog):
+    ctc = cloud_test_catalog
+    chain = dc.read_storage(f"{ctc.src_uri}/dogs/oth*/*", session=ctc.session)
+    assert chain.count() == 1
+
+
 def test_read_storage_as_image(cloud_test_catalog):
     ctc = cloud_test_catalog
     chain = dc.read_storage(ctc.src_uri, session=ctc.session, type="image")

--- a/tests/func/test_storage_pattern.py
+++ b/tests/func/test_storage_pattern.py
@@ -202,6 +202,22 @@ def test_no_pattern_behavior_unchanged(tmp_dir):
     assert files == {"temp1.tmp", "temp2.tmp", "log1.log", "logfile"}
 
 
+def test_glob_with_literal_first_segment_under_broader_listing(tmp_dir):
+    assert dc.read_storage(f"{tmp_dir}/").count() == count_dict_items(DEEP_TREE)
+
+    result = dc.read_storage(f"{tmp_dir}/deep/media/mus*/rock/*")
+    files = {f.name for f in result.to_values("file")}
+    assert files == {"song1.mp3", "song2.flac"}
+
+
+def test_globstar_under_broader_listing(tmp_dir):
+    assert dc.read_storage(f"{tmp_dir}/").count() == count_dict_items(DEEP_TREE)
+
+    result = dc.read_storage(f"{tmp_dir}/deep/media/**/*.mp3")
+    files = {f.name for f in result.to_values("file")}
+    assert files == {"song1.mp3", "track2.mp3"}
+
+
 def test_mixed_pattern_types(tmp_dir):
     # Mix wildcard and brace expansion
     result = dc.read_storage(f"{tmp_dir}/deep/media/*/rock/*.{{mp3,flac}}")

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -6,6 +6,7 @@ import datachain as dc
 from datachain.catalog.catalog import DataSource
 from datachain.client import Client
 from datachain.fs.utils import path_to_fsspec_uri
+from datachain.lib.dc.storage_pattern import split_uri_pattern
 from datachain.lib.file import File
 from datachain.lib.listing import (
     LISTING_PREFIX,
@@ -135,6 +136,28 @@ def test_get_listing_reuse_returns_decoded_subpath(
     assert reused
     assert name == broad_name
     assert list_path == expected_list_path
+
+
+def test_get_listing_reuses_broader_listing_for_glob_base(test_session):
+    catalog = test_session.catalog
+    fake_uri = path_to_fsspec_uri("/globbase")
+    broad_name, _, _, _ = get_listing(fake_uri, test_session)
+    (
+        dc.read_values(file=[File(path="media/music/song.mp3")])
+        .settings(
+            namespace=catalog.metastore.system_namespace_name,
+            project=catalog.metastore.listing_project_name,
+        )
+        .save(broad_name, listing=True)
+    )
+
+    base, pattern = split_uri_pattern(f"{fake_uri}/media/mus*/*.mp3")
+    name, _, list_path, reused = get_listing(base, test_session)
+
+    assert pattern == "mus*/*.mp3"
+    assert reused
+    assert name == broad_name
+    assert list_path == "media/"
 
 
 def test_resolve_path_in_root(listing):


### PR DESCRIPTION
Part of #1891 — see below on why this doesn't close it.

Listing rows store paths relative to the listing root. `apply_glob_filter()` only prepended `list_path` when the glob had no `/`, so a multi-segment glob under a non-root prefix was evaluated at the wrong root and matched nothing.

It went unnoticed because a pattern starting with `*` still works: SQLite's `GLOB *` crosses `/`, so the leading wildcard absorbs the missing prefix. Only a literal first segment breaks. Nothing over-matched either way — `apply_glob_filter()` calls `ls(list_path)` first, so results stay confined to the requested subtree.

Always anchor the converted glob at `list_path`. Converting before anchoring also preserves the existing zero-directory behavior of a leading `**`.

## Relationship to #1891

The issue attributes the 0-row reads to `sql_escape_like()` emitting `LIKE` without an `ESCAPE` clause. That mechanism is real and is fixed in #1895, but it isn't what the reporter hit: `read_storage()` filters via `GLOB`, where `_` is an ordinary character, and I could not reproduce the plain-prefix repro from the issue (`s3://…/droid_100/`) on local FS or moto-S3, fresh or reused listing.

What does reproduce is the glob half, and `_` is incidental there — `droidX*/*.txt` fails identically. So this PR fixes the reported symptom and #1895 fixes the mechanism the issue names. Marked "Part of" rather than "Fixes" so merging this alone doesn't auto-close the issue while the `LIKE`/`ESCAPE` half is still open.

## Tests

- `test_get_listing_reuses_broader_listing_for_glob_base` — `read_storage()` splits the pattern off and looks the base up; pins that the lookup reuses the broader listing and returns the subpath under it.
- `test_glob_with_literal_first_segment_under_broader_listing` — the case that actually regresses.
- `test_globstar_under_broader_listing` — passes unanchored too, so it guards the globstar conversion rather than the anchoring.
- `test_read_storage_glob_with_dir_component` — the reported cloud case (`dogs/oth*/*`).

The first matters more than it looks: that subpath is what makes anchoring observable. Without reuse it comes back empty, the read builds its own listing scoped to the glob's base, and the bug cannot appear — so a local glob test alone would pass against unfixed code. Cloud is unaffected, since paths there are always bucket-relative.
