### PR TITLE
fix: desanitize listing subpath when reusing a broader local listing

### DIFF
--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -301,8 +301,6 @@ def get_listing(
     # for local file system we need to fix listing path / prefix
     # if we are reusing existing listing
     if isinstance(client, FileClient) and listing and listing.name != ds_name:
-        # dataset names are sanitized, so the remainder must be decoded back
-        # into a real path before being used as a filter prefix
         relpath = _desanitize_ds_name(ds_name.removeprefix(listing.name)).strip("/")
         list_path = f"{relpath}/{list_path}"
 

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -301,7 +301,10 @@ def get_listing(
     # for local file system we need to fix listing path / prefix
     # if we are reusing existing listing
     if isinstance(client, FileClient) and listing and listing.name != ds_name:
-        list_path = f"{ds_name.strip('/').removeprefix(listing.name)}/{list_path}"
+        # dataset names are sanitized, so the remainder must be decoded back
+        # into a real path before being used as a filter prefix
+        relpath = _desanitize_ds_name(ds_name.removeprefix(listing.name)).strip("/")
+        list_path = f"{relpath}/{list_path}"
 
     ds_name = listing.name if listing else ds_name
     return ds_name, list_uri, list_path, bool(listing)

--- a/src/datachain/lib/listing.py
+++ b/src/datachain/lib/listing.py
@@ -298,9 +298,18 @@ def get_listing(
     if listings and not update:
         listing = max(listings, key=lambda ls: ls.created_at)
 
-    # for local file system we need to fix listing path / prefix
-    # if we are reusing existing listing
+    # `list_path` filters the listing's rows, so it has to be written the way
+    # those rows store their paths - and that differs by backend. Cloud rows
+    # keep the full bucket-relative key even when the listing covers only a
+    # prefix (a listing of "droid/" stores "droid/a.txt"), and `list_path` is
+    # bucket-relative too, so the two line up whichever listing is reused.
+    # Local rows drop the listed directory instead (a listing of "/a/b/" stores
+    # "c.txt") and `list_path` comes back empty, so reusing a listing rooted
+    # higher up would filter by nothing and match everything in it. Rebuild the
+    # missing prefix from the two names, which both spell out the full URI:
+    #   lst__file:///a/b/c/  minus  lst__file:///a/  ->  b/c/
     if isinstance(client, FileClient) and listing and listing.name != ds_name:
+        # names are sanitized (`.` -> `_x2e` etc), so decode back into a path
         relpath = _desanitize_ds_name(ds_name.removeprefix(listing.name)).strip("/")
         list_path = f"{relpath}/{list_path}"
 

--- a/tests/func/test_storage_pattern.py
+++ b/tests/func/test_storage_pattern.py
@@ -315,3 +315,18 @@ def test_brace_expansion_combined_patterns(tmp_dir):
     result = dc.read_storage(f"{tmp_dir}/deep/data-*-{{10..12}}.csv")
     files = sorted(f.name for f in result.to_values("file"))
     assert files == ["data-2005-10.csv", "data-2005-11.csv", "data-2005-12.csv"]
+
+
+def test_prefix_with_special_chars_reuses_broader_listing(tmp_path):
+    # https://github.com/datachain-ai/datachain/issues/1891
+    # the relative subpath is recovered from the sanitized listing dataset
+    # name and must be decoded back into the real path
+    (tmp_path / "some.dir").mkdir()
+    (tmp_path / "some.dir" / "a.txt").write_text("a")
+    (tmp_path / "some.dir" / "b.txt").write_text("b")
+    (tmp_path / "other").mkdir()
+    (tmp_path / "other" / "c.txt").write_text("c")
+
+    assert dc.read_storage(f"{tmp_path}/").count() == 3
+    assert dc.read_storage(f"{tmp_path}/some.dir/").count() == 2
+    assert dc.read_storage(f"{tmp_path}/some.dir/*.txt").count() == 2

--- a/tests/func/test_storage_pattern.py
+++ b/tests/func/test_storage_pattern.py
@@ -317,16 +317,11 @@ def test_brace_expansion_combined_patterns(tmp_dir):
     assert files == ["data-2005-10.csv", "data-2005-11.csv", "data-2005-12.csv"]
 
 
-def test_prefix_with_special_chars_reuses_broader_listing(tmp_path):
-    # https://github.com/datachain-ai/datachain/issues/1891
-    # the relative subpath is recovered from the sanitized listing dataset
-    # name and must be decoded back into the real path
-    (tmp_path / "some.dir").mkdir()
-    (tmp_path / "some.dir" / "a.txt").write_text("a")
-    (tmp_path / "some.dir" / "b.txt").write_text("b")
-    (tmp_path / "other").mkdir()
-    (tmp_path / "other" / "c.txt").write_text("c")
+def test_prefix_with_special_chars_reuses_broader_listing(tmp_dir):
+    special = tmp_dir / "some.dir"
+    special.mkdir()
+    (special / "file").touch()
 
-    assert dc.read_storage(f"{tmp_path}/").count() == 3
-    assert dc.read_storage(f"{tmp_path}/some.dir/").count() == 2
-    assert dc.read_storage(f"{tmp_path}/some.dir/*.txt").count() == 2
+    assert dc.read_storage(f"{tmp_dir}/").count() == count_dict_items(DEEP_TREE) + 1
+    files = dc.read_storage(f"{special}/").to_values("file")
+    assert [f.name for f in files] == ["file"]

--- a/tests/func/test_storage_pattern.py
+++ b/tests/func/test_storage_pattern.py
@@ -317,11 +317,12 @@ def test_brace_expansion_combined_patterns(tmp_dir):
     assert files == ["data-2005-10.csv", "data-2005-11.csv", "data-2005-12.csv"]
 
 
-def test_prefix_with_special_chars_reuses_broader_listing(tmp_dir):
+def test_read_special_chars_prefix_after_parent_listed(tmp_dir):
     special = tmp_dir / "some.dir"
     special.mkdir()
     (special / "file").touch()
 
+    # listing the parent first is what makes the read below reuse it
     assert dc.read_storage(f"{tmp_dir}/").count() == count_dict_items(DEEP_TREE) + 1
     files = dc.read_storage(f"{special}/").to_values("file")
     assert [f.name for f in files] == ["file"]

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -97,6 +97,28 @@ def test_get_listing_returns_exact_math_on_update(test_session):
     assert not exists
 
 
+def test_get_listing_reuse_desanitizes_relative_path(test_session):
+    # https://github.com/datachain-ai/datachain/issues/1891
+    # the subpath recovered from the sanitized dataset name must be decoded
+    # back into the real path before being used as a filter prefix
+    fake_uri = path_to_fsspec_uri("/desanitize")
+    catalog = test_session.catalog
+    broad_name, _, _, _ = get_listing(fake_uri, test_session)
+    (
+        dc.read_values(file=[File(path="some.dir/a.csv")])
+        .settings(
+            namespace=catalog.metastore.system_namespace_name,
+            project=catalog.metastore.listing_project_name,
+        )
+        .save(broad_name, listing=True)
+    )
+
+    name, _, list_path, exists = get_listing(f"{fake_uri}/some.dir", test_session)
+    assert exists
+    assert name == broad_name
+    assert list_path == "some.dir/"
+
+
 def test_resolve_path_in_root(listing):
     node = listing.resolve_path("dir1")
     assert node.dir_type == DirType.DIR

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -97,28 +97,6 @@ def test_get_listing_returns_exact_math_on_update(test_session):
     assert not exists
 
 
-def test_get_listing_reuse_desanitizes_relative_path(test_session):
-    # https://github.com/datachain-ai/datachain/issues/1891
-    # the subpath recovered from the sanitized dataset name must be decoded
-    # back into the real path before being used as a filter prefix
-    fake_uri = path_to_fsspec_uri("/desanitize")
-    catalog = test_session.catalog
-    broad_name, _, _, _ = get_listing(fake_uri, test_session)
-    (
-        dc.read_values(file=[File(path="some.dir/a.csv")])
-        .settings(
-            namespace=catalog.metastore.system_namespace_name,
-            project=catalog.metastore.listing_project_name,
-        )
-        .save(broad_name, listing=True)
-    )
-
-    name, _, list_path, exists = get_listing(f"{fake_uri}/some.dir", test_session)
-    assert exists
-    assert name == broad_name
-    assert list_path == "some.dir/"
-
-
 def test_resolve_path_in_root(listing):
     node = listing.resolve_path("dir1")
     assert node.dir_type == DirType.DIR

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -97,6 +97,40 @@ def test_get_listing_returns_exact_math_on_update(test_session):
     assert not exists
 
 
+@pytest.mark.parametrize(
+    "subdir,expected_list_path",
+    [
+        ("plain", "plain/"),
+        # sanitized in the dataset name as "some_x2edir"; must come back decoded
+        ("some.dir", "some.dir/"),
+        ("nested/some.dir", "nested/some.dir/"),
+        # a dir literally named like an encoding token: pre-escaped to
+        # "v_x_x2e0" in the name, so decoding must not turn it into "v.0"
+        ("v_x2e0", "v_x2e0/"),
+    ],
+)
+def test_get_listing_reuse_returns_decoded_subpath(
+    test_session, subdir, expected_list_path
+):
+    catalog = test_session.catalog
+    fake_uri = path_to_fsspec_uri("/reuse")
+    broad_name, _, _, _ = get_listing(fake_uri, test_session)
+    (
+        dc.read_values(file=[File(path=f"{subdir}/a.csv")])
+        .settings(
+            namespace=catalog.metastore.system_namespace_name,
+            project=catalog.metastore.listing_project_name,
+        )
+        .save(broad_name, listing=True)
+    )
+
+    name, _, list_path, reused = get_listing(f"{fake_uri}/{subdir}", test_session)
+
+    assert reused
+    assert name == broad_name
+    assert list_path == expected_list_path
+
+
 def test_resolve_path_in_root(listing):
     node = listing.resolve_path("dir1")
     assert node.dir_type == DirType.DIR


### PR DESCRIPTION
A listing-reuse bug found while investigating #1891.

## What a user sees

Any directory whose name contains a character outside `[a-zA-Z0-9_/:-]` — a `.` is the common one — becomes unreadable once a broader listing of its parent exists:

```
<dir>/2024.01/a.csv
<dir>/2024.01/b.csv
<dir>/plain/c.csv
```

```python
dc.read_storage(f"{dir}/").count()              # 3   ✅ populates the broad listing
dc.read_storage(f"{dir}/2024.01/").count()      # 0   ❌ expected 2
dc.read_storage(f"{dir}/2024.01/*.csv").count() # 0   ❌ expected 2
dc.read_storage(f"{dir}/plain/").count()        # 1   ✅ no special char, fine
```

Silent — an empty chain, no error. Read `2024.01/` *before* the parent and it works, so this only shows up once something has listed the parent directory.

## Why

Local URLs split so that **every directory is its own storage root**: `FileClient.split_url()` maps `file:///a/b/c/` to `("/a/b/c", "")`, so the returned path is empty and says nothing about where that directory sits inside a broader listing rooted at `/a/b/`. Cloud URLs split at the bucket instead (`s3://bucket/a/b/c/` → `("bucket", "a/b/c/")`), which is already the origin the listing rows use, so they need no adjusting.

To bridge that, `get_listing()` reconstructs the subpath by stripping the reused listing's dataset name off the requested one:

```python
list_path = f"{ds_name.strip('/').removeprefix(listing.name)}/{list_path}"
```

Both names are **sanitized** — `_sanitize_ds_name()` encodes anything outside `[a-zA-Z0-9_/:-]` as `_xHH` — so the remainder is still encoded when it gets used as a path. `2024.01` comes back as `2024_x2e01`, which matches no real path, and the filter selects nothing.

## The fix

Decode the remainder with `_desanitize_ds_name()` before using it as a path. The old `# for local file system we need to fix listing path / prefix` comment is replaced with the reasoning above, since the *why* wasn't recoverable from the code.

## Tests

- `test_get_listing_reuse_returns_decoded_subpath` (unit) — asserts the mechanism: reuse happened, the broader listing was selected, and `list_path` comes back as `some.dir/` rather than `some_x2edir/`. Parametrized over a plain subdir (control), a dotted one, and a nested dotted one.
- `test_read_special_chars_prefix_after_parent_listed` (func) — the end-to-end symptom.

Both dotted cases of the unit test fail on `main`; the plain control passes there, as it should.

Worth noting why the unit test earns its place: the functional test only exercises reuse as a *side effect* of listing the parent on the line above, and asserted nothing about it — delete that line and it still passes against unfixed code. The unit test pins reuse explicitly so the coverage can't quietly evaporate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)