### PR TITLE
fix: use exact prefix match instead of LIKE for node path lookups

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -792,9 +792,7 @@ class AbstractWarehouse(ABC, Serializable):
             dr.select()
             .where(
                 dr.c("is_latest") == true(),
-                # not startswith(): LIKE treats `_`/`%` in the path as wildcards
-                # and is case-insensitive on SQLite
-                sa.func.substr(dr.c("path"), 1, len(path)) == path,
+                sa.func.substr(dr.c("path"), 1, sa.func.length(path)) == path,
             )
             .exists()
         )
@@ -863,10 +861,7 @@ class AbstractWarehouse(ABC, Serializable):
         q = (
             sa.select(*(field_to_expr(f) for f in fields))
             .where(
-                # not like(): the escaped pattern needs an explicit ESCAPE clause
-                # on SQLite (where LIKE is also case-insensitive), and ClickHouse
-                # doesn't support ESCAPE at all
-                sa.func.substr(dr.c("path"), 1, len(dirpath)) == dirpath,
+                sa.func.substr(dr.c("path"), 1, sa.func.length(dirpath)) == dirpath,
                 ~self.instr(pathfunc.name(dr.c("path")), "/"),
                 dr.c("is_latest") == true(),
             )

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -35,7 +35,7 @@ from datachain.query.batch import RowsOutput
 from datachain.query.schema import ColumnMeta
 from datachain.sql.functions import path as pathfunc
 from datachain.sql.types import SQLType
-from datachain.utils import safe_closing, sql_escape_like
+from datachain.utils import safe_closing
 
 if TYPE_CHECKING:
     from sqlalchemy.sql._typing import (
@@ -792,7 +792,9 @@ class AbstractWarehouse(ABC, Serializable):
             dr.select()
             .where(
                 dr.c("is_latest") == true(),
-                dr.c("path").startswith(path),
+                # not startswith(): LIKE treats `_`/`%` in the path as wildcards
+                # and is case-insensitive on SQLite
+                sa.func.substr(dr.c("path"), 1, len(path)) == path,
             )
             .exists()
         )
@@ -861,7 +863,10 @@ class AbstractWarehouse(ABC, Serializable):
         q = (
             sa.select(*(field_to_expr(f) for f in fields))
             .where(
-                dr.c("path").like(f"{sql_escape_like(dirpath)}%"),
+                # not like(): the escaped pattern needs an explicit ESCAPE clause
+                # on SQLite (where LIKE is also case-insensitive), and ClickHouse
+                # doesn't support ESCAPE at all
+                sa.func.substr(dr.c("path"), 1, len(dirpath)) == dirpath,
                 ~self.instr(pathfunc.name(dr.c("path")), "/"),
                 dr.c("is_latest") == true(),
             )

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -25,7 +25,13 @@ TREE = {
         "d2": {None: ["file1.csv", "file2.csv"]},
         None: ["dataset.csv"],
     },
-    "dir2": {None: ["diagram.png"]},
+    "dir2": {
+        "spécial": {
+            "dir_%1": {None: ["a.csv", "b.csv"]},
+            "dirXX2": {None: ["d.csv"]},
+        },
+        None: ["diagram.png"],
+    },
     None: ["users.csv"],
 }
 
@@ -50,37 +56,6 @@ def listing(test_session):
     (
         dc.read_values(file=list(_tree_to_entries(TREE)))
         .settings(namespace=listing_namespace_name, project=listing_project_name)
-        .save(dataset_name, listing=True)
-    )
-
-    with Listing(
-        catalog.metastore.clone(),
-        catalog.warehouse.clone(),
-        Client.get_client(fake_uri, catalog.cache, **catalog.client_config),
-        dataset_name=dataset_name,
-        column="file",
-    ) as listing_obj:
-        yield listing_obj
-
-
-UNDERSCORE_TREE = {
-    "dir_1": {None: ["a.csv", "b.csv"]},
-    "dirX1": {None: ["c.csv"]},
-    "dirX2": {None: ["d.csv"]},
-}
-
-
-@pytest.fixture
-def listing_with_underscores(test_session):
-    fake_uri = path_to_fsspec_uri("/underscores")
-    catalog = test_session.catalog
-    dataset_name, _, _, _ = get_listing(fake_uri, test_session)
-    (
-        dc.read_values(file=list(_tree_to_entries(UNDERSCORE_TREE)))
-        .settings(
-            namespace=catalog.metastore.system_namespace_name,
-            project=catalog.metastore.listing_project_name,
-        )
         .save(dataset_name, listing=True)
     )
 
@@ -208,25 +183,22 @@ def test_list_dir(listing):
     assert {n[0] for n in names} == {"dir1/d2", "dir1/dataset.csv"}
 
 
-def test_resolve_path_underscore_is_not_a_wildcard(listing_with_underscores):
-    # https://github.com/datachain-ai/datachain/issues/1891
-    node = listing_with_underscores.resolve_path("dir_1")
+def test_resolve_unicode_path_prefix_is_literal(listing):
+    node = listing.resolve_path("dir2/spécial/dir_%1")
     assert node.dir_type == DirType.DIR
 
-    # "dir_2" must not resolve via "dirX2" (`_` treated as a LIKE wildcard)
     with pytest.raises(FileNotFoundError):
-        listing_with_underscores.resolve_path("dir_2")
+        listing.resolve_path("dir2/spécial/dir_%2")
 
 
-def test_ls_path_tar_parent_with_underscore(listing_with_underscores):
-    # https://github.com/datachain-ai/datachain/issues/1891
-    # the LIKE-based prefix match dropped all rows on SQLite (escaped
-    # pattern without an ESCAPE clause) and must not match "dirX1" either
-    listing = listing_with_underscores
+def test_ls_path_tar_unicode_parent_prefix_is_literal(listing):
     rows = listing.warehouse.select_node_fields_by_parent_path_tar(
-        listing.dataset_rows, "dir_1", ["path"]
+        listing.dataset_rows, "dir2/spécial/dir_%1", ["path"]
     )
-    assert sorted(r[0] for r in rows) == ["dir_1/a.csv", "dir_1/b.csv"]
+    assert sorted(r[0] for r in rows) == [
+        "dir2/spécial/dir_%1/a.csv",
+        "dir2/spécial/dir_%1/b.csv",
+    ]
 
 
 def test_list_file(listing):

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -63,6 +63,37 @@ def listing(test_session):
         yield listing_obj
 
 
+UNDERSCORE_TREE = {
+    "dir_1": {None: ["a.csv", "b.csv"]},
+    "dirX1": {None: ["c.csv"]},
+    "dirX2": {None: ["d.csv"]},
+}
+
+
+@pytest.fixture
+def listing_with_underscores(test_session):
+    fake_uri = path_to_fsspec_uri("/underscores")
+    catalog = test_session.catalog
+    dataset_name, _, _, _ = get_listing(fake_uri, test_session)
+    (
+        dc.read_values(file=list(_tree_to_entries(UNDERSCORE_TREE)))
+        .settings(
+            namespace=catalog.metastore.system_namespace_name,
+            project=catalog.metastore.listing_project_name,
+        )
+        .save(dataset_name, listing=True)
+    )
+
+    with Listing(
+        catalog.metastore.clone(),
+        catalog.warehouse.clone(),
+        Client.get_client(fake_uri, catalog.cache, **catalog.client_config),
+        dataset_name=dataset_name,
+        column="file",
+    ) as listing_obj:
+        yield listing_obj
+
+
 def test_get_listing_returns_exact_math_on_update(test_session):
     # Context: https://github.com/datachain-ai/datachain/pull/726
     # On update it should be returning the exact match (not a "bigger" one)
@@ -175,6 +206,27 @@ def test_list_dir(listing):
     dir1 = listing.resolve_path("dir1/")
     names = listing.ls_path(dir1, ["path"])
     assert {n[0] for n in names} == {"dir1/d2", "dir1/dataset.csv"}
+
+
+def test_resolve_path_underscore_is_not_a_wildcard(listing_with_underscores):
+    # https://github.com/datachain-ai/datachain/issues/1891
+    node = listing_with_underscores.resolve_path("dir_1")
+    assert node.dir_type == DirType.DIR
+
+    # "dir_2" must not resolve via "dirX2" (`_` treated as a LIKE wildcard)
+    with pytest.raises(FileNotFoundError):
+        listing_with_underscores.resolve_path("dir_2")
+
+
+def test_ls_path_tar_parent_with_underscore(listing_with_underscores):
+    # https://github.com/datachain-ai/datachain/issues/1891
+    # the LIKE-based prefix match dropped all rows on SQLite (escaped
+    # pattern without an ESCAPE clause) and must not match "dirX1" either
+    listing = listing_with_underscores
+    rows = listing.warehouse.select_node_fields_by_parent_path_tar(
+        listing.dataset_rows, "dir_1", ["path"]
+    )
+    assert sorted(r[0] for r in rows) == ["dir_1/a.csv", "dir_1/b.csv"]
 
 
 def test_list_file(listing):


### PR DESCRIPTION
Two path-filter bugs found while investigating #1891. These are the queries the issue points at — but `read_storage()` doesn't go through them, so they aren't the cause of the reported symptom (that's #1892).

Both are the same mistake: matching a **literal** path prefix with `LIKE`, where `_` and `%` are wildcards.

## Bug 1 — `get_node_by_path()` over-matches, so bad paths look empty instead of missing

`startswith()` without `autoescape` turns `_` and `%` in a user-supplied path into wildcards, so a directory that doesn't exist resolves successfully against a similarly-named one:

```
<dir>/dir_1/a.csv
<dir>/dir_1/b.csv
<dir>/dirX2/d.csv
```

```console
$ datachain ls <dir>/          # populates the listing
dirX2/
dir_1/

$ datachain ls <dir>/dir_2/    # dir_2 does not exist
$ echo $?
0
```

`dir_2/` silently resolves via `dirX2/` (the `_` matches `X`), so you get an empty listing and a success exit code instead of an error. After the fix:

```console
$ datachain ls <dir>/dir_2/
Error: Unable to resolve path dir_2/
```

This needs an existing listing to reuse — on a fresh path the filesystem scan raises first.

## Bug 2 — `select_node_fields_by_parent_path_tar()` under-matches, dropping every row

Here the pattern is escaped but no `ESCAPE` clause is ever emitted:

```python
dr.c("path").like(f"{sql_escape_like(dirpath)}%")   # -> LIKE 'dir\_1/%'
```

SQLite has no default escape character, so the backslash is matched literally and nothing matches at all:

```sql
sqlite> SELECT count(*) FROM t WHERE path LIKE 'dir\_1/%';               -- 0
sqlite> SELECT count(*) FROM t WHERE path LIKE 'dir\_1/%' ESCAPE '\';    -- 1
```

Postgres and ClickHouse happened to be safe — backslash is their default escape.

I'm not claiming a user-level repro for this one. It's only reached for location-backed (tar member) nodes, and I couldn't get the public API to route there — `DirType.TAR_ARCHIVE` is no longer assigned anywhere, so the branch survives only via `node.location`. Treat it as a latent bug fixed for consistency with bug 1 rather than something users are hitting today.

## The fix

Compare a `substr()` prefix instead of using `LIKE` in both places, so the operand is matched literally.

### Why not `startswith(..., autoescape=True)`?

That is what `metastore.py` uses in three places, so it was the obvious candidate — but it does not work on the ClickHouse version we run. `autoescape` makes SQLAlchemy emit an `ESCAPE` clause, and ClickHouse only gained support for that in **26.6.1.123** ([#99599](https://github.com/ClickHouse/ClickHouse/issues/99599) / [#99774](https://github.com/ClickHouse/ClickHouse/pull/99774), merged 2026-05-25). Before that it is a parse error, confirmed on 26.5.1.1 via `chdb`:

```
Code: 62. DB::Exception: Syntax error: failed at position 74 (ESCAPE): ESCAPE '/'.
Expected one of: OR, AND, ...
```

Confirmed against the deployed cluster, which reports **26.2.1.525** — the probe below is a `SYNTAX_ERROR` there:

```sql
SELECT 'dir_1/a.csv' LIKE 'dir#_1/%' ESCAPE '#';
-- Code: 62. DB::Exception: Syntax error: failed at position 49 ('#') ... (SYNTAX_ERROR)
```

Local dev and CI are pinned to `clickhouse/clickhouse-server:25.8` (`docker-compose.yaml`, `.github/workflows/build_test_release.yml`), so every environment we run against is below 26.6. `autoescape` would compile fine, pass the whole SQLite suite, and then fail at runtime on the warehouse.

Note the current pin ordering is the safe one — dev/CI (25.8) is *older* than the deployed cluster (26.2), so tests exercise the lowest version. Bumping only dev/CI would invert that and let version-dependent SQL pass CI while failing in production.

The metastore is unaffected either way: a metastore is only ever `SQLiteMetastore` or `PostgreSQLMetastore`, it runs on its own engine, and no ClickHouse metastore exists, so metastore SQL never reaches a ClickHouse connection.

Matching the literal prefix `dir_1/` against a row `dir_1/a.csv`, measured rather than assumed (SQLite in-process, Postgres 14.18 local, ClickHouse 26.5.1.1 via `chdb`):

| form | SQLite | Postgres | ClickHouse |
| --- | --- | --- | --- |
| `LIKE 'dir_1/%'` (unescaped) | matches, but also `dirX1/` | same | same |
| `LIKE 'dir\_1/%'` (backslash, no clause) | **0 rows** — backslash is literal | correct | correct |
| `LIKE 'dir/_1//%' ESCAPE '/'` (what `autoescape` emits) | correct | correct | **syntax error** < 26.6 |
| `substr(p, 1, length(prefix)) = prefix` | correct | correct | correct |

SQLite needs the `ESCAPE` clause; ClickHouse before 26.6 cannot parse it. `substr()` is the only form correct on all three without dialect-specific branching or a ClickHouse version floor. If every deployment ever reaches 26.6+, `startswith(..., autoescape=True)` becomes viable and would be the simpler, more consistent choice. Note the newest LTS (26.3) is still below that line, so this needs the stable channel, not just a routine LTS bump.

If it ever needs to become `LIKE` — e.g. if `path` gets indexed, since `LIKE 'prefix%'` is indexable and `substr(...) = ...` is not (SQLite plans `SEARCH ... USING INDEX` vs `SCAN`) — the way to do it is a per-dialect hook, following the existing `AbstractWarehouse.instr()` precedent (`instr` on SQLite, `position` on ClickHouse). Today it makes no difference: dataset tables carry no index on `path` in SQLite, and ClickHouse orders them by `sys__id`.

### Prefix length

The length comes from SQL `length()` rather than Python `len()` so the two sides agree on what a "character" is. They don't always: `substr`/`length` count bytes on ClickHouse but characters on SQLite, so a Python-side `len()` would slice 13 bytes off a 14-byte prefix like `dir2/spécial/` and never match. SQLite alone can't catch that — both are character-based there — so it's a latent ClickHouse-only failure.

### Heads-up: `sql_escape_like` now has no caller in this repo

Dropping the `.like()` in `select_node_fields_by_parent_path_tar` removes the last in-repo use of `datachain.utils.sql_escape_like`; only its definition and unit test remain here. **It is still imported by `datachain_saas`** (`clickhouse.py`, where `compile_glob` rewrites the `GLOB` operator into `LIKE` for ClickHouse), so please don't garbage-collect it as unused — it is an internal util with an out-of-repo consumer.

Worth noting what it actually guarantees: it backslash-escapes `\`, `%` and `_` but emits no `ESCAPE` clause, so its output is only correct on a backend where backslash is the default escape — ClickHouse and Postgres, not SQLite. That mismatch is exactly the bug being fixed here, and it is also why the Studio usage is fine: that path is ClickHouse-only.

## Tests

`test_resolve_unicode_path_prefix_is_literal` and `test_ls_path_tar_unicode_parent_prefix_is_literal`, over a tree containing `dir2/spécial/dir_%1/` and `dir2/spécial/dirXX2/` so `_`, `%` and non-ASCII are all covered in one fixture. Both fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





