### PR TITLE
fix: match literal node path prefixes with LIKE ... ESCAPE (#1891)

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -35,7 +35,7 @@ from datachain.query.batch import RowsOutput
 from datachain.query.schema import ColumnMeta
 from datachain.sql.functions import path as pathfunc
 from datachain.sql.types import SQLType
-from datachain.utils import safe_closing, sql_escape_like
+from datachain.utils import LIKE_ESCAPE_CHAR, safe_closing, sql_escape_like
 
 if TYPE_CHECKING:
     from sqlalchemy.sql._typing import (
@@ -562,6 +562,20 @@ class AbstractWarehouse(ABC, Serializable):
         source string column
         """
 
+    def prefix_match(self, col: sa.ColumnElement, prefix: str) -> sa.ColumnElement:
+        """
+        Return SQLAlchemy Boolean matching rows whose `col` starts with `prefix`,
+        with `prefix` taken literally.
+
+        `%` and `_` are LIKE wildcards, so the prefix is escaped and the escape
+        character declared alongside it -- the standard spelling, and the one
+        SQLite needs, since it has no default escape character of its own.
+
+        Backends whose LIKE cannot take an ESCAPE clause should override this and
+        rely on their own default escape character instead.
+        """
+        return col.startswith(sql_escape_like(prefix), escape=LIKE_ESCAPE_CHAR)
+
     @abstractmethod
     def get_table(self, name: str) -> sa.Table:
         """
@@ -792,7 +806,7 @@ class AbstractWarehouse(ABC, Serializable):
             dr.select()
             .where(
                 dr.c("is_latest") == true(),
-                dr.c("path").startswith(path),
+                self.prefix_match(dr.c("path"), path),
             )
             .exists()
         )
@@ -861,7 +875,7 @@ class AbstractWarehouse(ABC, Serializable):
         q = (
             sa.select(*(field_to_expr(f) for f in fields))
             .where(
-                dr.c("path").like(f"{sql_escape_like(dirpath)}%"),
+                self.prefix_match(dr.c("path"), dirpath),
                 ~self.instr(pathfunc.name(dr.c("path")), "/"),
                 dr.c("is_latest") == true(),
             )

--- a/src/datachain/utils.py
+++ b/src/datachain/utils.py
@@ -308,7 +308,14 @@ def datachain_paths_join(source_path: str, file_paths: Iterable[str]) -> Iterabl
     return (f"{source_stripped}/{path.lstrip('/')}" for path in file_paths)
 
 
-def sql_escape_like(search: str, escape: str = "\\") -> str:
+# Escape character `sql_escape_like()` inserts before `%` and `_`. A LIKE built
+# from its output has to declare the same character to SQL (SQLAlchemy's
+# `escape=`), or SQLite treats the backslashes literally and matches nothing.
+# `AbstractWarehouse.prefix_match()` does both steps together.
+LIKE_ESCAPE_CHAR = "\\"
+
+
+def sql_escape_like(search: str, escape: str = LIKE_ESCAPE_CHAR) -> str:
     return (
         search.replace(escape, escape * 2)
         .replace("%", f"{escape}%")

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -81,6 +81,33 @@ def test_ls_not_found(cloud_test_catalog):
         ls([f"{src}/cats/bogus*"], catalog=cloud_test_catalog.catalog)
 
 
+WILDCARD_TREE = {
+    "dir_1": {"a.csv": "a", "b.csv": "b"},
+    # decoy: `_` is a LIKE wildcard, so an unescaped `dir_2/` prefix matches this
+    "dirX2": {"c.csv": "c"},
+}
+
+
+@pytest.mark.parametrize("tree", [WILDCARD_TREE], indirect=True)
+def test_ls_dir_with_underscore_lists_only_its_own_files(cloud_test_catalog, capsys):
+    src = cloud_test_catalog.src_uri
+    catalog = cloud_test_catalog.catalog
+    dc.read_storage(src, session=cloud_test_catalog.session).exec()
+
+    ls([f"{src}/dir_1/"], catalog=catalog)
+    assert same_lines(capsys.readouterr().out, "a.csv\nb.csv\n")
+
+
+@pytest.mark.parametrize("tree", [WILDCARD_TREE], indirect=True)
+def test_ls_missing_dir_raises_instead_of_matching_sibling(cloud_test_catalog):
+    src = cloud_test_catalog.src_uri
+    catalog = cloud_test_catalog.catalog
+    dc.read_storage(src, session=cloud_test_catalog.session).exec()
+
+    with pytest.raises(FileNotFoundError):
+        ls([f"{src}/dir_2/"], catalog=catalog)
+
+
 # TODO return file test when https://github.com/datachain-ai/datachain/issues/318
 # is done
 @pytest.mark.parametrize("cloud_type", ["s3", "gs", "azure"], indirect=True)

--- a/tests/unit/test_listing.py
+++ b/tests/unit/test_listing.py
@@ -25,7 +25,13 @@ TREE = {
         "d2": {None: ["file1.csv", "file2.csv"]},
         None: ["dataset.csv"],
     },
-    "dir2": {None: ["diagram.png"]},
+    "dir2": {
+        "spécial": {
+            "dir_%1": {None: ["a.csv", "b.csv"]},
+            "dirXX2": {None: ["d.csv"]},
+        },
+        None: ["diagram.png"],
+    },
     None: ["users.csv"],
 }
 
@@ -209,6 +215,16 @@ def test_list_dir(listing):
     dir1 = listing.resolve_path("dir1/")
     names = listing.ls_path(dir1, ["path"])
     assert {n[0] for n in names} == {"dir1/d2", "dir1/dataset.csv"}
+
+
+def test_resolve_path_with_wildcard_chars_is_literal(listing):
+    node = listing.resolve_path("dir2/spécial/dir_%1")
+    assert node.dir_type == DirType.DIR
+
+    # must not resolve via the dirXX2/ sibling, which `dir_%2` matches as a
+    # LIKE pattern
+    with pytest.raises(FileNotFoundError):
+        listing.resolve_path("dir2/spécial/dir_%2")
 
 
 def test_list_file(listing):

--- a/tests/unit/test_warehouse.py
+++ b/tests/unit/test_warehouse.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 import pytest
 import sqlalchemy as sa
 
+import datachain as dc
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteWarehouse
+from datachain.lib.file import File
 
 
 def test_serialize(sqlite_db):
@@ -177,3 +179,49 @@ def test_dataset_rows_select_from_ids_requires_sys_id(
                 is_batched=is_batched,
             )
         )
+
+
+WILDCARD_PATHS = [
+    "dir_%1/a.csv",
+    "dir_%1/b.csv",
+    "dir_%1/nested/c.csv",
+    # decoy: unescaped, `dir_%1/` is the pattern `dir?<any>1/`, which matches this
+    "dirXX1/d.csv",
+]
+
+
+@pytest.fixture
+def wildcard_rows(test_session, warehouse):
+    saved = dc.read_values(
+        file=[File(path=p) for p in WILDCARD_PATHS], session=test_session
+    ).save("wildcard_paths")
+    dataset = saved.dataset
+    assert dataset is not None
+    yield warehouse.dataset_rows(dataset, dataset.latest_version, column="file")
+    dc.delete_dataset(dataset.name, force=True, session=test_session)
+
+
+def test_prefix_match_treats_wildcards_literally(warehouse, wildcard_rows):
+    query = wildcard_rows.select(wildcard_rows.c("path")).where(
+        warehouse.prefix_match(wildcard_rows.c("path"), "dir_%1/")
+    )
+
+    assert sorted(r[0] for r in warehouse.db.execute(query)) == [
+        "dir_%1/a.csv",
+        "dir_%1/b.csv",
+        "dir_%1/nested/c.csv",
+    ]
+
+
+def test_select_node_fields_by_parent_path_tar_wildcards_are_literal(
+    warehouse, wildcard_rows
+):
+    rows = warehouse.select_node_fields_by_parent_path_tar(
+        wildcard_rows, "dir_%1", ["path"]
+    )
+
+    assert sorted(r[0] for r in rows) == [
+        "dir_%1/a.csv",
+        "dir_%1/b.csv",
+        "dir_%1/nested/c.csv",
+    ]


### PR DESCRIPTION
Closes #1891 — this carries the `LIKE`/`ESCAPE` fix the issue names. The reported symptom itself turned out to be glob anchoring (#1892); #1893 was a third bug found alongside.

## The bugs

Two queries matched a *literal* path prefix with `LIKE`, where `_` and `%` are wildcards.

`get_node_by_path()` used `startswith()` with no escaping, so a directory that doesn't exist resolved via a similarly-shaped sibling — given `dir_1/` and `dirX2/`, listing the nonexistent `dir_2/` matched `dirX2/` and printed nothing with exit code 0 instead of reporting the missing path:

```console
$ datachain ls <dir>/dir_2/    # does not exist
$ echo $?
0
```

`select_node_fields_by_parent_path_tar()` escaped the pattern via `sql_escape_like()` but emitted no `ESCAPE` clause. SQLite has no default escape character, so `dir\_1/%` matched nothing and the query returned 0 rows. (Only reachable for location-backed tar nodes; `DirType.TAR_ARCHIVE` is no longer assigned anywhere, so there's no user-level repro for this half.)

## The fix

Escaping the operand and declaring the escape character are only correct together — `escape=` alone declares without escaping, and its default of `None` emits no clause, which is what the second bug got wrong. `AbstractWarehouse.prefix_match()` does both, so the mistake isn't expressible, and `LIKE_ESCAPE_CHAR` is defined once beside `sql_escape_like()` so pattern and clause can't drift.

It's an overridable warehouse method — the same seam as the existing abstract `instr()` — because the correct spelling is dialect-dependent. SQLite needs the clause; ClickHouse can't parse it before 26.6, and the cloud is on 26.2, so it overrides the clause away in datachain-ai/studio#13128. That branch shares this one's name, so the `studio` job checks it out automatically and the pairing is verified in this PR's CI.

| form | SQLite | Postgres | ClickHouse |
| --- | --- | --- | --- |
| `LIKE 'dir_1/%'` (unescaped) | matches, but also `dirX1/` | same | same |
| `LIKE 'dir\_1/%'` (no clause) | **0 rows** | correct | correct |
| `LIKE 'dir\_1/%' ESCAPE '\'` | correct | correct | **syntax error < 26.6** |

## Tests

Behaviour rather than the SQL it compiles to, since the spelling is what legitimately differs per backend. All run against SQLite locally and ClickHouse in the `studio` job.

| test | asserts |
| --- | --- |
| `test_prefix_match_treats_wildcards_literally` | only rows under `dir_%1/`, not the `dirXX1/` decoy that an unescaped pattern would match |
| `test_select_node_fields_by_parent_path_tar_wildcards_are_literal` | same, through the production query |
| `test_resolve_path_with_wildcard_chars_is_literal` | `dir_%1` resolves, `dir_%2` raises |
| `test_ls_missing_dir_raises_instead_of_matching_sibling` | `ls <dir>/dir_2/` raises rather than resolving via `dirX2/` |
| `test_ls_dir_with_underscore_lists_only_its_own_files` | happy path; passes either way |

Each decoy was checked to match the unescaped pattern and not the escaped one, so the tests fail if the escaping is removed.

Supersedes #1894, which fixed the same bugs with a `substr()` comparison.

